### PR TITLE
Add VM.devices instead of individual xxxSupported fields.

### DIFF
--- a/pkg/controller/provider/model/vsphere/model.go
+++ b/pkg/controller/provider/model/vsphere/model.go
@@ -330,9 +330,7 @@ type VM struct {
 	IpAddress             string `sql:""`
 	NumaNodeAffinity      string `sql:""`
 	StorageUsed           int64  `sql:""`
-	SriovSupported        bool   `sql:""`
-	PassthroughSupported  bool   `sql:""`
-	UsbSupported          bool   `sql:""`
+	Devices               string `sql:""`
 	Disks                 string `sql:""`
 	Networks              string `sql:""`
 	Host                  string `sql:""`
@@ -358,6 +356,21 @@ func (m *VM) EncodeDisks(d []Disk) {
 func (m *VM) DecodeDisks() []Disk {
 	list := []Disk{}
 	json.Unmarshal([]byte(m.Disks), &list)
+	return list
+}
+
+//
+// Encode devices.
+func (m *VM) EncodeDevices(d []Device) {
+	j, _ := json.Marshal(d)
+	m.Devices = string(j)
+}
+
+//
+// Decode devices.
+func (m *VM) DecodeDevices() []Device {
+	list := []Device{}
+	json.Unmarshal([]byte(m.Devices), &list)
 	return list
 }
 
@@ -397,6 +410,12 @@ type Disk struct {
 	Capacity  int64  `json:"capacity"`
 	Shared    bool   `json:"shared"`
 	RDM       bool   `json:"rdm"`
+}
+
+//
+// Virtual Device.
+type Device struct {
+	Kind string `json:"kind"`
 }
 
 //

--- a/pkg/controller/provider/web/vsphere/vm.go
+++ b/pkg/controller/provider/web/vsphere/vm.go
@@ -112,29 +112,27 @@ func (h VMHandler) Link(p *api.Provider, m *model.VM) string {
 // REST Resource.
 type VM struct {
 	Resource
-	UUID                  string        `json:"uuid"`
-	Firmware              string        `json:"firmware"`
-	CpuAffinity           model.List    `json:"cpuAffinity"`
-	CpuHotAddEnabled      bool          `json:"cpuHostAddEnabled"`
-	CpuHotRemoveEnabled   bool          `json:"cpuHostRemoveEnabled"`
-	MemoryHotAddEnabled   bool          `json:"memoryHotAddEnabled"`
-	FaultToleranceEnabled bool          `json:"faultToleranceEnabled"`
-	CpuCount              int32         `json:"cpuCount"`
-	CoresPerSocket        int32         `json:"coresPerSocket"`
-	MemoryMB              int32         `json:"memoryMB"`
-	GuestName             string        `json:"guestName"`
-	BalloonedMemory       int32         `json:"balloonedMemory"`
-	IpAddress             string        `json:"ipAddress"`
-	StorageUsed           int64         `json:"storageUsed"`
-	NumaNodeAffinity      model.List    `json:"numaNodeAffinity"`
-	SriovSupported        bool          `json:"sriovSupported"`
-	PassthroughSupported  bool          `json:"passthroughSupported"`
-	UsbSupported          bool          `json:"usbSupported"`
-	Networks              model.RefList `json:"networks"`
-	Disks                 []model.Disk  `json:"disks"`
-	Host                  model.Ref     `json:"host"`
-	RevisionAnalyzed      int64         `json:"revisionAnalyzed"`
-	Concerns              model.List    `json:"concerns"`
+	UUID                  string         `json:"uuid"`
+	Firmware              string         `json:"firmware"`
+	CpuAffinity           model.List     `json:"cpuAffinity"`
+	CpuHotAddEnabled      bool           `json:"cpuHostAddEnabled"`
+	CpuHotRemoveEnabled   bool           `json:"cpuHostRemoveEnabled"`
+	MemoryHotAddEnabled   bool           `json:"memoryHotAddEnabled"`
+	FaultToleranceEnabled bool           `json:"faultToleranceEnabled"`
+	CpuCount              int32          `json:"cpuCount"`
+	CoresPerSocket        int32          `json:"coresPerSocket"`
+	MemoryMB              int32          `json:"memoryMB"`
+	GuestName             string         `json:"guestName"`
+	BalloonedMemory       int32          `json:"balloonedMemory"`
+	IpAddress             string         `json:"ipAddress"`
+	StorageUsed           int64          `json:"storageUsed"`
+	NumaNodeAffinity      model.List     `json:"numaNodeAffinity"`
+	Devices               []model.Device `json:"devices"`
+	Networks              model.RefList  `json:"networks"`
+	Disks                 []model.Disk   `json:"disks"`
+	Host                  model.Ref      `json:"host"`
+	RevisionAnalyzed      int64          `json:"revisionAnalyzed"`
+	Concerns              model.List     `json:"concerns"`
 }
 
 //
@@ -155,9 +153,7 @@ func (r *VM) With(m *model.VM) {
 	r.IpAddress = m.IpAddress
 	r.StorageUsed = m.StorageUsed
 	r.FaultToleranceEnabled = m.FaultToleranceEnabled
-	r.SriovSupported = m.SriovSupported
-	r.PassthroughSupported = m.PassthroughSupported
-	r.UsbSupported = m.UsbSupported
+	r.Devices = m.DecodeDevices()
 	r.NumaNodeAffinity = *(&model.List{}).With(m.NumaNodeAffinity)
 	r.Networks = *model.RefListPtr().With(m.Networks)
 	r.Disks = m.DecodeDisks()


### PR DESCRIPTION
Add VM.devices (list) instead of individual xxxSupported fields.
Taking the opportunity provided by switching to OPA to model the devices information more naturally.  This will also provide more flexibility moving foward.