### PR TITLE
Provider inventory: Support query by name.

### DIFF
--- a/pkg/controller/provider/web/base/client.go
+++ b/pkg/controller/provider/web/base/client.go
@@ -33,6 +33,13 @@ type Resolver interface {
 }
 
 //
+// Web parameter.
+type Param struct {
+	Key   string
+	Value string
+}
+
+//
 // REST API client.
 type Client struct {
 	Resolver
@@ -71,7 +78,7 @@ func (c *Client) Get(resource interface{}, id string) (status int, err error) {
 
 //
 // List resources in a collection.
-func (c *Client) List(list interface{}) (status int, err error) {
+func (c *Client) List(list interface{}, param ...Param) (status int, err error) {
 	var resource interface{}
 	lt := reflect.TypeOf(list)
 	lv := reflect.ValueOf(list)
@@ -92,6 +99,13 @@ func (c *Client) List(list interface{}) (status int, err error) {
 	if err != nil {
 		err = liberr.Wrap(err)
 		return
+	}
+	if len(param) > 0 {
+		q := liburl.Values{}
+		for _, p := range param {
+			q.Add(p.Key, p.Value)
+		}
+		path += "?" + q.Encode()
 	}
 	status, err = c.get(path, resource)
 

--- a/pkg/controller/provider/web/ocp/base.go
+++ b/pkg/controller/provider/web/ocp/base.go
@@ -1,0 +1,9 @@
+package ocp
+
+import "github.com/konveyor/forklift-controller/pkg/controller/provider/web/base"
+
+//
+// Base handler.
+type Handler struct {
+	base.Handler
+}

--- a/pkg/controller/provider/web/ocp/doc.go
+++ b/pkg/controller/provider/web/ocp/doc.go
@@ -14,8 +14,6 @@ const (
 	Root = base.ProvidersRoot + "/" + api.OpenShift
 )
 
-type Handler = base.Handler
-
 //
 // Shared logger.
 var Log *logging.Logger
@@ -35,18 +33,18 @@ func Handlers(container *container.Container) []libweb.RequestHandler {
 			},
 		},
 		&NamespaceHandler{
-			Handler: base.Handler{
-				Container: container,
+			Handler: Handler{
+				base.Handler{Container: container},
 			},
 		},
 		&StorageClassHandler{
-			Handler: base.Handler{
-				Container: container,
+			Handler: Handler{
+				base.Handler{Container: container},
 			},
 		},
 		&NetworkAttachmentDefinitionHandler{
-			Handler: base.Handler{
-				Container: container,
+			Handler: Handler{
+				base.Handler{Container: container},
 			},
 		},
 	}

--- a/pkg/controller/provider/web/ocp/provider.go
+++ b/pkg/controller/provider/web/ocp/provider.go
@@ -20,7 +20,7 @@ const (
 //
 // Provider handler.
 type ProviderHandler struct {
-	Handler
+	base.Handler
 }
 
 //

--- a/pkg/controller/provider/web/vsphere/base.go
+++ b/pkg/controller/provider/web/vsphere/base.go
@@ -1,0 +1,31 @@
+package vsphere
+
+import (
+	"github.com/gin-gonic/gin"
+	libmodel "github.com/konveyor/controller/pkg/inventory/model"
+	"github.com/konveyor/forklift-controller/pkg/controller/provider/web/base"
+)
+
+//
+// Fields.
+const (
+	NameParam = "name"
+)
+
+//
+// Base handler.
+type Handler struct {
+	base.Handler
+}
+
+//
+// Build list predicate.
+func (h Handler) Predicate(ctx *gin.Context) (p libmodel.Predicate) {
+	q := ctx.Request.URL.Query()
+	value := q.Get(NameParam)
+	if len(value) > 0 {
+		p = libmodel.Eq(NameParam, value)
+	}
+
+	return
+}

--- a/pkg/controller/provider/web/vsphere/cluster.go
+++ b/pkg/controller/provider/web/vsphere/cluster.go
@@ -22,7 +22,7 @@ const (
 //
 // Cluster handler.
 type ClusterHandler struct {
-	base.Handler
+	Handler
 	// Selected cluster.
 	cluster *model.Cluster
 }
@@ -33,37 +33,6 @@ func (h *ClusterHandler) AddRoutes(e *gin.Engine) {
 	e.GET(ClustersRoot, h.List)
 	e.GET(ClustersRoot+"/", h.List)
 	e.GET(ClusterRoot, h.Get)
-}
-
-//
-// Prepare to handle the request.
-func (h *ClusterHandler) Prepare(ctx *gin.Context) int {
-	status := h.Handler.Prepare(ctx)
-	if status != http.StatusOK {
-		ctx.Status(status)
-		return status
-	}
-	id := ctx.Param(ClusterParam)
-	if id != "" {
-		m := &model.Cluster{
-			Base: model.Base{
-				ID: id,
-			},
-		}
-		db := h.Reconciler.DB()
-		err := db.Get(m)
-		if errors.Is(err, model.NotFound) {
-			return http.StatusNotFound
-		}
-		if err != nil {
-			Log.Trace(err)
-			return http.StatusInternalServerError
-		}
-
-		h.cluster = m
-	}
-
-	return http.StatusOK
 }
 
 //
@@ -79,7 +48,8 @@ func (h ClusterHandler) List(ctx *gin.Context) {
 	err := db.List(
 		&list,
 		libmodel.ListOptions{
-			Page: &h.Page,
+			Predicate: h.Predicate(ctx),
+			Page:      &h.Page,
 		})
 	if err != nil {
 		Log.Trace(err)
@@ -105,9 +75,31 @@ func (h ClusterHandler) Get(ctx *gin.Context) {
 		ctx.Status(status)
 		return
 	}
+	m := &model.Cluster{
+		Base: model.Base{
+			ID: ctx.Param(ClusterParam),
+		},
+	}
+	db := h.Reconciler.DB()
+	err := db.Get(m)
+	if errors.Is(err, model.NotFound) {
+		ctx.Status(http.StatusNotFound)
+		return
+	}
+	if err != nil {
+		Log.Trace(err)
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
 	r := &Cluster{}
-	r.With(h.cluster)
-	r.SelfLink = h.Link(h.Provider, h.cluster)
+	r.With(m)
+	r.Path, err = m.Path(db)
+	if err != nil {
+		Log.Trace(err)
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+	r.SelfLink = h.Link(h.Provider, m)
 	content := r.Content(true)
 
 	ctx.JSON(http.StatusOK, content)

--- a/pkg/controller/provider/web/vsphere/datacenter.go
+++ b/pkg/controller/provider/web/vsphere/datacenter.go
@@ -22,7 +22,7 @@ const (
 //
 // Datacenter handler.
 type DatacenterHandler struct {
-	base.Handler
+	Handler
 	// Selected Datacenter.
 	datacenter *model.Datacenter
 }
@@ -33,37 +33,6 @@ func (h *DatacenterHandler) AddRoutes(e *gin.Engine) {
 	e.GET(DatacentersRoot, h.List)
 	e.GET(DatacentersRoot+"/", h.List)
 	e.GET(DatacenterRoot, h.Get)
-}
-
-//
-// Prepare to handle the request.
-func (h *DatacenterHandler) Prepare(ctx *gin.Context) int {
-	status := h.Handler.Prepare(ctx)
-	if status != http.StatusOK {
-		ctx.Status(status)
-		return status
-	}
-	id := ctx.Param(DatacenterParam)
-	if id != "" {
-		m := &model.Datacenter{
-			Base: model.Base{
-				ID: id,
-			},
-		}
-		db := h.Reconciler.DB()
-		err := db.Get(m)
-		if errors.Is(err, model.NotFound) {
-			return http.StatusNotFound
-		}
-		if err != nil {
-			Log.Trace(err)
-			return http.StatusInternalServerError
-		}
-
-		h.datacenter = m
-	}
-
-	return http.StatusOK
 }
 
 //
@@ -79,7 +48,8 @@ func (h DatacenterHandler) List(ctx *gin.Context) {
 	err := db.List(
 		&list,
 		libmodel.ListOptions{
-			Page: &h.Page,
+			Predicate: h.Predicate(ctx),
+			Page:      &h.Page,
 		})
 	if err != nil {
 		Log.Trace(err)
@@ -105,9 +75,31 @@ func (h DatacenterHandler) Get(ctx *gin.Context) {
 		ctx.Status(status)
 		return
 	}
+	m := &model.Datacenter{
+		Base: model.Base{
+			ID: ctx.Param(DatacenterParam),
+		},
+	}
+	db := h.Reconciler.DB()
+	err := db.Get(m)
+	if errors.Is(err, model.NotFound) {
+		ctx.Status(http.StatusNotFound)
+		return
+	}
+	if err != nil {
+		Log.Trace(err)
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
 	r := &Datacenter{}
-	r.With(h.datacenter)
-	r.SelfLink = h.Link(h.Provider, h.datacenter)
+	r.With(m)
+	r.Path, err = m.Path(db)
+	if err != nil {
+		Log.Trace(err)
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+	r.SelfLink = h.Link(h.Provider, m)
 	content := r.Content(true)
 
 	ctx.JSON(http.StatusOK, content)

--- a/pkg/controller/provider/web/vsphere/datastore.go
+++ b/pkg/controller/provider/web/vsphere/datastore.go
@@ -22,7 +22,7 @@ const (
 //
 // Datastore handler.
 type DatastoreHandler struct {
-	base.Handler
+	Handler
 }
 
 //
@@ -46,7 +46,8 @@ func (h DatastoreHandler) List(ctx *gin.Context) {
 	err := db.List(
 		&list,
 		libmodel.ListOptions{
-			Page: &h.Page,
+			Predicate: h.Predicate(ctx),
+			Page:      &h.Page,
 		})
 	if err != nil {
 		Log.Trace(err)
@@ -90,6 +91,12 @@ func (h DatastoreHandler) Get(ctx *gin.Context) {
 	}
 	r := &Datastore{}
 	r.With(m)
+	r.Path, err = m.Path(db)
+	if err != nil {
+		Log.Trace(err)
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
 	r.SelfLink = h.Link(h.Provider, m)
 	content := r.Content(true)
 

--- a/pkg/controller/provider/web/vsphere/doc.go
+++ b/pkg/controller/provider/web/vsphere/doc.go
@@ -14,8 +14,6 @@ const (
 	Root = base.ProvidersRoot + "/" + api.VSphere
 )
 
-type Handler = base.Handler
-
 //
 // Shared logger.
 var Log *logging.Logger
@@ -35,43 +33,43 @@ func Handlers(container *container.Container) []libweb.RequestHandler {
 			},
 		},
 		&TreeHandler{
-			Handler: base.Handler{
-				Container: container,
+			Handler: Handler{
+				base.Handler{Container: container},
 			},
 		},
 		&FolderHandler{
-			Handler: base.Handler{
-				Container: container,
+			Handler: Handler{
+				base.Handler{Container: container},
 			},
 		},
 		&DatacenterHandler{
-			Handler: base.Handler{
-				Container: container,
+			Handler: Handler{
+				base.Handler{Container: container},
 			},
 		},
 		&ClusterHandler{
-			Handler: base.Handler{
-				Container: container,
+			Handler: Handler{
+				base.Handler{Container: container},
 			},
 		},
 		&HostHandler{
-			Handler: base.Handler{
-				Container: container,
+			Handler: Handler{
+				base.Handler{Container: container},
 			},
 		},
 		&NetworkHandler{
-			Handler: base.Handler{
-				Container: container,
+			Handler: Handler{
+				base.Handler{Container: container},
 			},
 		},
 		&DatastoreHandler{
-			Handler: base.Handler{
-				Container: container,
+			Handler: Handler{
+				base.Handler{Container: container},
 			},
 		},
 		&VMHandler{
-			Handler: base.Handler{
-				Container: container,
+			Handler: Handler{
+				base.Handler{Container: container},
 			},
 		},
 	}

--- a/pkg/controller/provider/web/vsphere/host.go
+++ b/pkg/controller/provider/web/vsphere/host.go
@@ -24,7 +24,7 @@ const (
 //
 // Host handler.
 type HostHandler struct {
-	base.Handler
+	Handler
 }
 
 //
@@ -48,7 +48,8 @@ func (h HostHandler) List(ctx *gin.Context) {
 	err := db.List(
 		&list,
 		libmodel.ListOptions{
-			Page: &h.Page,
+			Predicate: h.Predicate(ctx),
+			Page:      &h.Page,
 		})
 	if err != nil {
 		Log.Trace(err)
@@ -99,6 +100,12 @@ func (h HostHandler) Get(ctx *gin.Context) {
 	}
 	r := &Host{}
 	r.With(m)
+	r.Path, err = m.Path(db)
+	if err != nil {
+		Log.Trace(err)
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
 	err = h.buildAdapters(r)
 	if err != nil {
 		Log.Trace(err)

--- a/pkg/controller/provider/web/vsphere/provider.go
+++ b/pkg/controller/provider/web/vsphere/provider.go
@@ -22,7 +22,7 @@ const (
 //
 // Provider handler.
 type ProviderHandler struct {
-	Handler
+	base.Handler
 }
 
 //

--- a/pkg/controller/provider/web/vsphere/resource.go
+++ b/pkg/controller/provider/web/vsphere/resource.go
@@ -11,6 +11,8 @@ type Resource struct {
 	ID string `json:"id"`
 	// Parent.
 	Parent *model.Ref `json:"parent"`
+	// Path
+	Path string `json:"path,omitempty"`
 	// Revision
 	Revision int64 `json:"revision"`
 	// Object name.

--- a/pkg/controller/provider/web/vsphere/tree.go
+++ b/pkg/controller/provider/web/vsphere/tree.go
@@ -7,7 +7,6 @@ import (
 	"github.com/konveyor/controller/pkg/ref"
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1"
 	model "github.com/konveyor/forklift-controller/pkg/controller/provider/model/vsphere"
-	"github.com/konveyor/forklift-controller/pkg/controller/provider/web/base"
 	"net/http"
 )
 
@@ -22,7 +21,7 @@ const (
 //
 // Tree handler.
 type TreeHandler struct {
-	base.Handler
+	Handler
 	// Datacenters list.
 	datacenters []model.Datacenter
 }

--- a/pkg/controller/provider/web/vsphere/vm.go
+++ b/pkg/controller/provider/web/vsphere/vm.go
@@ -22,7 +22,7 @@ const (
 //
 // Virtual Machine handler.
 type VMHandler struct {
-	base.Handler
+	Handler
 }
 
 //
@@ -46,7 +46,8 @@ func (h VMHandler) List(ctx *gin.Context) {
 	err := db.List(
 		&list,
 		libmodel.ListOptions{
-			Page: &h.Page,
+			Predicate: h.Predicate(ctx),
+			Page:      &h.Page,
 		})
 	if err != nil {
 		Log.Trace(err)
@@ -90,6 +91,12 @@ func (h VMHandler) Get(ctx *gin.Context) {
 	}
 	r := &VM{}
 	r.With(m)
+	r.Path, err = m.Path(db)
+	if err != nil {
+		Log.Trace(err)
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
 	r.SelfLink = h.Link(h.Provider, m)
 	content := r.Content(true)
 

--- a/vendor/github.com/konveyor/controller/pkg/inventory/model/predicate.go
+++ b/vendor/github.com/konveyor/controller/pkg/inventory/model/predicate.go
@@ -124,8 +124,9 @@ type SimplePredicate struct {
 //
 // Find referenced field.
 func (p *SimplePredicate) match(fields []*Field) (*Field, bool) {
+	name := strings.ToLower(p.Field)
 	for _, f := range fields {
-		if f.Name == p.Field {
+		if name == strings.ToLower(f.Name) {
 			return f, true
 		}
 	}


### PR DESCRIPTION
Begin adding support for extended query parameters starting with `name`.

Eg: `https://inventory/namespaces/openshift-migration/providers/vsphere/test/networks?name=VM_Storage`