### PR TITLE
Optional host secret not fully supported.

### DIFF
--- a/pkg/apis/forklift/v1alpha1/host.go
+++ b/pkg/apis/forklift/v1alpha1/host.go
@@ -36,7 +36,7 @@ type HostSpec struct {
 	// Certificate SHA-1 fingerprint, called thumbprint by VMware.
 	Thumbprint string `json:"thumbprint,omitempty"`
 	// Credentials.
-	Secret core.ObjectReference `json:"secret,omitempty"`
+	Secret *core.ObjectReference `json:"secret,omitempty"`
 }
 
 //

--- a/pkg/apis/forklift/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/forklift/v1alpha1/zz_generated.deepcopy.go
@@ -22,6 +22,7 @@ package v1alpha1
 import (
 	mapped "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1/mapped"
 	plan "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1/plan"
+	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -30,7 +31,7 @@ func (in *Host) DeepCopyInto(out *Host) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
-	out.Spec = in.Spec
+	in.Spec.DeepCopyInto(&out.Spec)
 	in.Status.DeepCopyInto(&out.Status)
 	in.Referenced.DeepCopyInto(&out.Referenced)
 	return
@@ -91,7 +92,11 @@ func (in *HostList) DeepCopyObject() runtime.Object {
 func (in *HostSpec) DeepCopyInto(out *HostSpec) {
 	*out = *in
 	out.Provider = in.Provider
-	out.Secret = in.Secret
+	if in.Secret != nil {
+		in, out := &in.Secret, &out.Secret
+		*out = new(v1.ObjectReference)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/controller/host/validation.go
+++ b/pkg/controller/host/validation.go
@@ -174,18 +174,16 @@ func (r *Reconciler) validateIp(host *api.Host) error {
 //   2. The secret exists.
 //   3. the content of the secret is valid.
 func (r *Reconciler) validateSecret(host *api.Host) error {
-	// NotSet
+	ref := host.Spec.Secret
+	if !libref.RefSet(ref) {
+		return nil
+	}
 	newCnd := libcnd.Condition{
 		Type:     SecretNotValid,
 		Status:   True,
-		Reason:   NotSet,
+		Reason:   NotFound,
 		Category: Critical,
 		Message:  "The `secret` is not valid.",
-	}
-	ref := host.Spec.Secret
-	if !libref.RefSet(&ref) {
-		host.Status.SetCondition(newCnd)
-		return nil
 	}
 	// NotFound
 	secret := &core.Secret{}


### PR DESCRIPTION
The secret referenced in the `Host` CR is optional.  The CRD specified this but not completely supported in the controller.  Needed to relax the host validation and handle appropriately when building the VMIO secret.