### PR TITLE
Improved migration error handling; Typed errors using errors.As().

### DIFF
--- a/pkg/controller/host/controller.go
+++ b/pkg/controller/host/controller.go
@@ -133,7 +133,7 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	// Validations.
 	err = r.validate(host)
 	if err != nil {
-		if errors.Is(err, web.ProviderNotReadyErr) {
+		if errors.As(err, &web.ProviderNotReadyError{}) {
 			return slowReQ, nil
 		}
 		log.Trace(err)

--- a/pkg/controller/host/validation.go
+++ b/pkg/controller/host/validation.go
@@ -130,7 +130,7 @@ func (r *Reconciler) validateRef(host *api.Host) error {
 	}
 	_, err = inventory.Host(&ref)
 	if err != nil {
-		if errors.Is(err, web.NotFoundErr) {
+		if errors.As(err, &web.NotFoundError{}) {
 			host.Status.SetCondition(
 				libcnd.Condition{
 					Type:     HostNotValid,
@@ -141,7 +141,7 @@ func (r *Reconciler) validateRef(host *api.Host) error {
 				})
 			return nil
 		}
-		if errors.Is(err, web.RefNotUniqueErr) {
+		if errors.As(err, &web.RefNotUniqueError{}) {
 			host.Status.SetCondition(
 				libcnd.Condition{
 					Type:     HostNotValid,

--- a/pkg/controller/map/network/controller.go
+++ b/pkg/controller/map/network/controller.go
@@ -133,7 +133,7 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	// Validations.
 	err = r.validate(mp)
 	if err != nil {
-		if errors.Is(err, web.ProviderNotReadyErr) {
+		if errors.As(err, &web.ProviderNotReadyError{}) {
 			return slowReQ, nil
 		}
 		log.Trace(err)

--- a/pkg/controller/map/storage/controller.go
+++ b/pkg/controller/map/storage/controller.go
@@ -133,7 +133,7 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	// Validations.
 	err = r.validate(mp)
 	if err != nil {
-		if errors.Is(err, web.ProviderNotReadyErr) {
+		if errors.As(err, &web.ProviderNotReadyError{}) {
 			return slowReQ, nil
 		}
 		log.Trace(err)

--- a/pkg/controller/plan/builder/vsphere/builder.go
+++ b/pkg/controller/plan/builder/vsphere/builder.go
@@ -166,7 +166,7 @@ func (r *Builder) Load() (err error) {
 		m := &model.Host{}
 		pErr := r.Inventory.Find(m, ref)
 		if pErr != nil {
-			if errors.Is(pErr, web.NotFoundErr) {
+			if errors.As(pErr, &web.NotFoundError{}) {
 				continue
 			} else {
 				err = liberr.Wrap(pErr)

--- a/pkg/controller/plan/controller.go
+++ b/pkg/controller/plan/controller.go
@@ -159,7 +159,7 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	// Validations.
 	err = r.validate(plan)
 	if err != nil {
-		if errors.Is(err, web.ProviderNotReadyErr) {
+		if errors.As(err, &web.ProviderNotReadyError{}) {
 			return slowReQ, nil
 		}
 		log.Trace(err)

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -13,7 +13,7 @@ import (
 	cdi "github.com/kubevirt/containerized-data-importer/pkg/apis/core/v1beta1"
 	vmio "github.com/kubevirt/vm-import-operator/pkg/apis/v2v/v1beta1"
 	core "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -151,7 +151,7 @@ func (r *KubeVirt) EnsureNamespace() (err error) {
 	}
 	err = r.Client.Create(context.TODO(), ns)
 	if err != nil {
-		if errors.IsAlreadyExists(err) {
+		if k8serr.IsAlreadyExists(err) {
 			err = nil
 		}
 	}
@@ -395,7 +395,7 @@ func (r *KubeVirt) ensureObject(object runtime.Object) (err error) {
 	}()
 	for {
 		err = r.Client.Create(context.TODO(), object)
-		if errors.IsAlreadyExists(err) && retry > 0 {
+		if k8serr.IsAlreadyExists(err) && retry > 0 {
 			retry--
 			err = r.deleteObject(object)
 			if err != nil {
@@ -413,7 +413,7 @@ func (r *KubeVirt) ensureObject(object runtime.Object) (err error) {
 // Delete a resource.
 func (r *KubeVirt) deleteObject(object runtime.Object) (err error) {
 	err = r.Client.Delete(context.TODO(), object)
-	if !errors.IsNotFound(err) {
+	if !k8serr.IsNotFound(err) {
 		err = liberr.Wrap(err)
 	} else {
 		err = nil

--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -139,11 +139,11 @@ func (r *Reconciler) validateVM(provider *api.Provider, plan *api.Plan) error {
 		}
 		_, pErr := inventory.VM(&ref)
 		if pErr != nil {
-			if errors.Is(pErr, web.NotFoundErr) {
+			if errors.As(pErr, &web.NotFoundError{}) {
 				notValid.Items = append(notValid.Items, ref.String())
 				continue
 			}
-			if errors.Is(pErr, web.RefNotUniqueErr) {
+			if errors.As(pErr, &web.RefNotUniqueError{}) {
 				ambiguous.Items = append(ambiguous.Items, ref.String())
 				continue
 			}

--- a/pkg/controller/provider/web/base/client.go
+++ b/pkg/controller/provider/web/base/client.go
@@ -4,7 +4,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
-	"errors"
 	"fmt"
 	liberr "github.com/konveyor/controller/pkg/error"
 	libmodel "github.com/konveyor/controller/pkg/inventory/model"
@@ -21,12 +20,34 @@ import (
 var Settings = &settings.Settings
 
 //
-// Errors
-var (
-	ResourceNotResolvedErr = errors.New("resource (kind) not resolved")
-	RefNotUniqueErr        = errors.New("ref matched multiple resources")
-	NotFoundErr            = errors.New("not found")
-)
+// Resource kind cannot be resolved.
+type ResourceNotResolvedError struct {
+	Object interface{}
+}
+
+func (r ResourceNotResolvedError) Error() string {
+	return fmt.Sprintf("Resource %#v cannot be resolved.", r.Object)
+}
+
+//
+// Reference matches multiple resources.
+type RefNotUniqueError struct {
+	Ref
+}
+
+func (r RefNotUniqueError) Error() string {
+	return fmt.Sprintf("Reference %#v matched multiple resources.", r.Ref)
+}
+
+//
+// Resource not found.
+type NotFoundError struct {
+	Ref
+}
+
+func (r NotFoundError) Error() string {
+	return fmt.Sprintf("Resource %#v not found.", r.Ref)
+}
 
 //
 // Reference.
@@ -162,7 +183,7 @@ type RestClient struct {
 // Get a resource.
 func (c *RestClient) Get(resource interface{}, id string) (status int, err error) {
 	if c.Resolver == nil {
-		err = liberr.Wrap(ResourceNotResolvedErr)
+		err = liberr.Wrap(ResourceNotResolvedError{resource})
 		return
 	}
 	lv := reflect.ValueOf(resource)

--- a/pkg/controller/provider/web/ocp/client.go
+++ b/pkg/controller/provider/web/ocp/client.go
@@ -10,6 +10,12 @@ import (
 )
 
 //
+// Errors.
+type ResourceNotResolvedError = base.ResourceNotResolvedError
+type RefNotUniqueError = base.RefNotUniqueError
+type NotFoundError = base.NotFoundError
+
+//
 // API path resolver.
 type Resolver struct {
 	*api.Provider
@@ -64,7 +70,10 @@ func (r *Resolver) Path(object interface{}, id string) (path string, err error) 
 				},
 			})
 	default:
-		err = liberr.Wrap(base.ResourceNotResolvedErr)
+		err = liberr.Wrap(
+			ResourceNotResolvedError{
+				Object: object,
+			})
 	}
 
 	return

--- a/pkg/controller/provider/web/vsphere/client.go
+++ b/pkg/controller/provider/web/vsphere/client.go
@@ -12,10 +12,9 @@ import (
 
 //
 // Errors.
-var (
-	RefNotUniqueErr = base.RefNotUniqueErr
-	NotFoundErr     = base.NotFoundErr
-)
+type ResourceNotResolvedError = base.ResourceNotResolvedError
+type RefNotUniqueError = base.RefNotUniqueError
+type NotFoundError = base.NotFoundError
 
 //
 // API path resolver.
@@ -84,7 +83,10 @@ func (r *Resolver) Path(resource interface{}, id string) (path string, err error
 				Base: model.Base{ID: id},
 			})
 	default:
-		err = liberr.Wrap(base.ResourceNotResolvedErr)
+		err = liberr.Wrap(
+			base.ResourceNotResolvedError{
+				Object: resource,
+			})
 	}
 
 	return
@@ -131,11 +133,11 @@ func (r *Finder) ByRef(resource interface{}, ref base.Ref) (err error) {
 				break
 			}
 			if len(list) == 0 {
-				err = liberr.Wrap(NotFoundErr)
+				err = liberr.Wrap(NotFoundError{Ref: ref})
 				break
 			}
 			if len(list) > 1 {
-				err = liberr.Wrap(RefNotUniqueErr)
+				err = liberr.Wrap(RefNotUniqueError{Ref: ref})
 				break
 			}
 			*resource.(*Network) = list[0]
@@ -159,11 +161,11 @@ func (r *Finder) ByRef(resource interface{}, ref base.Ref) (err error) {
 				break
 			}
 			if len(list) == 0 {
-				err = liberr.Wrap(NotFoundErr)
+				err = liberr.Wrap(NotFoundError{Ref: ref})
 				break
 			}
 			if len(list) > 1 {
-				err = liberr.Wrap(RefNotUniqueErr)
+				err = liberr.Wrap(RefNotUniqueError{Ref: ref})
 				break
 			}
 			*resource.(*Datastore) = list[0]
@@ -187,11 +189,11 @@ func (r *Finder) ByRef(resource interface{}, ref base.Ref) (err error) {
 				break
 			}
 			if len(list) == 0 {
-				err = liberr.Wrap(NotFoundErr)
+				err = liberr.Wrap(NotFoundError{Ref: ref})
 				break
 			}
 			if len(list) > 1 {
-				err = liberr.Wrap(RefNotUniqueErr)
+				err = liberr.Wrap(RefNotUniqueError{Ref: ref})
 				break
 			}
 			*resource.(*Host) = list[0]
@@ -215,17 +217,20 @@ func (r *Finder) ByRef(resource interface{}, ref base.Ref) (err error) {
 				break
 			}
 			if len(list) == 0 {
-				err = liberr.Wrap(NotFoundErr)
+				err = liberr.Wrap(NotFoundError{Ref: ref})
 				break
 			}
 			if len(list) > 1 {
-				err = liberr.Wrap(RefNotUniqueErr)
+				err = liberr.Wrap(RefNotUniqueError{Ref: ref})
 				break
 			}
 			*resource.(*VM) = list[0]
 		}
 	default:
-		err = liberr.Wrap(base.ResourceNotResolvedErr)
+		err = liberr.Wrap(
+			ResourceNotResolvedError{
+				Object: resource,
+			})
 	}
 
 	return

--- a/pkg/controller/validation/network.go
+++ b/pkg/controller/validation/network.go
@@ -91,11 +91,11 @@ func (r *NetworkPair) validateSource(list []mapped.NetworkPair) (result libcnd.C
 		}
 		_, pErr := inventory.Network(&ref)
 		if pErr != nil {
-			if errors.Is(pErr, web.NotFoundErr) {
+			if errors.As(pErr, &web.NotFoundError{}) {
 				notValid = append(notValid, entry.Source.String())
 				continue
 			}
-			if errors.Is(pErr, web.RefNotUniqueErr) {
+			if errors.As(pErr, &web.RefNotUniqueError{}) {
 				ambiguous = append(ambiguous, entry.Source.String())
 				continue
 			}
@@ -148,7 +148,10 @@ func (r *NetworkPair) validateDestination(list []mapped.NetworkPair) (result lib
 	case api.VSphere:
 		return
 	default:
-		err = liberr.Wrap(web.ProviderNotSupportedErr)
+		err = liberr.Wrap(
+			web.ProviderNotSupportedError{
+				Provider: provider,
+			})
 		return
 	}
 next:
@@ -162,7 +165,7 @@ next:
 				entry.Destination.Name)
 			pErr := inventory.Get(resource, id)
 			if pErr != nil {
-				if errors.Is(pErr, web.NotFoundErr) {
+				if errors.As(pErr, &web.NotFoundError{}) {
 					notFound = append(notFound, entry.Source.ID)
 				} else {
 					err = liberr.Wrap(pErr)

--- a/pkg/controller/validation/storage.go
+++ b/pkg/controller/validation/storage.go
@@ -75,11 +75,11 @@ func (r *StoragePair) validateSource(list []mapped.StoragePair) (result libcnd.C
 		}
 		_, pErr := inventory.Storage(&ref)
 		if pErr != nil {
-			if errors.Is(pErr, web.NotFoundErr) {
+			if errors.As(pErr, &web.NotFoundError{}) {
 				notValid = append(notValid, entry.Source.String())
 				continue
 			}
-			if errors.Is(pErr, web.RefNotUniqueErr) {
+			if errors.As(pErr, &web.RefNotUniqueError{}) {
 				ambiguous = append(ambiguous, entry.Source.String())
 				continue
 			}
@@ -131,14 +131,17 @@ func (r *StoragePair) validateDestination(list []mapped.StoragePair) (result lib
 	case api.VSphere:
 		return
 	default:
-		err = liberr.Wrap(web.ProviderNotSupportedErr)
+		err = liberr.Wrap(
+			web.ProviderNotSupportedError{
+				Provider: provider,
+			})
 		return
 	}
 	for _, entry := range list {
 		name := entry.Destination.StorageClass
 		pErr := inventory.Get(resource, name)
 		if pErr != nil {
-			if errors.Is(pErr, web.NotFoundErr) {
+			if errors.As(pErr, &web.NotFoundError{}) {
 				notValid = append(notValid, entry.Destination.StorageClass)
 			} else {
 				err = liberr.Wrap(pErr)


### PR DESCRIPTION
Currently all errors from building and creating the VMIO CR are bubbled up to main Reconcile(), traced and the reconcile re-queued.  Instead, errors associated with building/creating the CR should be captured as an `Error` on the VM pipeline structure itself.  As a result, the individual import would be failed.

To accomplish this, we really needed to include more contextual information in the errors being bubbled up.  To do this, we also needed raise/check errors based on error type using errors.As() instead of errors.Is() which does a direct comparison.  This is because to include the contextual information, we need to create a _new_ instance of the error.