### PR TITLE
Support volume/access modes.

### DIFF
--- a/config/crds/forklift_v1alpha1_plan.yaml
+++ b/config/crds/forklift_v1alpha1_plan.yaml
@@ -43,8 +43,21 @@ spec:
                       destination:
                         description: Destination storage.
                         properties:
+                          accessMode:
+                            description: Access mode.
+                            enum:
+                            - ReadWriteOnce
+                            - ReadWriteMany
+                            - ReadOnlyMany
+                            type: string
                           storageClass:
                             description: A storage class.
+                            type: string
+                          volumeMode:
+                            description: Volume mode.
+                            enum:
+                            - Filesystem
+                            - Block
                             type: string
                         required:
                         - storageClass

--- a/config/crds/forklift_v1alpha1_provisioner.yaml
+++ b/config/crds/forklift_v1alpha1_provisioner.yaml
@@ -50,6 +50,10 @@ spec:
                           type: array
                         name:
                           description: Name.
+                          enum:
+                          - ReadWriteOnce
+                          - ReadWriteMany
+                          - ReadOnlyMany
                           type: string
                         priority:
                           description: Priority
@@ -67,6 +71,9 @@ spec:
                     type: array
                   name:
                     description: Name.
+                    enum:
+                    - Filesystem
+                    - Block
                     type: string
                   priority:
                     description: Priority

--- a/config/crds/forklift_v1alpha1_storagemap.yaml
+++ b/config/crds/forklift_v1alpha1_storagemap.yaml
@@ -37,8 +37,21 @@ spec:
                   destination:
                     description: Destination storage.
                     properties:
+                      accessMode:
+                        description: Access mode.
+                        enum:
+                        - ReadWriteOnce
+                        - ReadWriteMany
+                        - ReadOnlyMany
+                        type: string
                       storageClass:
                         description: A storage class.
+                        type: string
+                      volumeMode:
+                        description: Volume mode.
+                        enum:
+                        - Filesystem
+                        - Block
                         type: string
                     required:
                     - storageClass

--- a/config/samples/provisioner.yaml
+++ b/config/samples/provisioner.yaml
@@ -2,44 +2,22 @@
 kind: Provisioner
 apiVersion: forklift.konveyor.io/v1alpha1
 metadata:
-  name: test
+  name: cinder
   namespace: openshift-migration
 spec:
-  name: kubernetes.io/rbd
-  features:
-    - SmartCloning
-    - Snapshots
+  name: kubernetes.io/cinder
   volumeModes:
   - name: Block
     priority: 0
-    features:
-    - SmartCloning
-    - Snapshots
     accessModes:
     - name: ReadWriteOnce
       priority: 0
-      features:
-      - featureA
-      - featureB
     - name: ReadWriteMany
       priority: 1
-      features:
-      - featureA
-      - featureB
   - name: Filesystem
     priority: 1
-    features:
-    - SmartCloning
-    - Snapshots
     accessModes:
     - name: ReadWriteOnce
       priority: 0
-      features:
-      - featureA
-      - featureB
     - name: ReadWriteMany
       priority: 1
-      features:
-      - featureA
-      - featureB
-

--- a/pkg/apis/forklift/v1alpha1/mapped/storage.go
+++ b/pkg/apis/forklift/v1alpha1/mapped/storage.go
@@ -1,6 +1,9 @@
 package mapped
 
-import "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1/ref"
+import (
+	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1/ref"
+	core "k8s.io/api/core/v1"
+)
 
 //
 // Mapped storage.
@@ -16,4 +19,10 @@ type StoragePair struct {
 type DestinationStorage struct {
 	// A storage class.
 	StorageClass string `json:"storageClass"`
+	// Volume mode.
+	// +kubebuilder:validation:Enum=Filesystem,Block
+	VolumeMode core.PersistentVolumeMode `json:"volumeMode,omitempty"`
+	// Access mode.
+	// +kubebuilder:validation:Enum=ReadWriteOnce,ReadWriteMany,ReadOnlyMany
+	AccessMode core.PersistentVolumeAccessMode `json:"accessMode,omitempty"`
 }

--- a/pkg/apis/forklift/v1alpha1/provisioner.go
+++ b/pkg/apis/forklift/v1alpha1/provisioner.go
@@ -18,14 +18,17 @@ package v1alpha1
 
 import (
 	libcnd "github.com/konveyor/controller/pkg/condition"
+	core "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sort"
 )
 
 //
 // Volume mode.
 type VolumeMode struct {
 	// Name.
-	Name string `json:"name"`
+	// +kubebuilder:validation:Enum=Filesystem,Block
+	Name core.PersistentVolumeMode `json:"name"`
 	// Priority
 	Priority int `json:"priority"`
 	// Feature list.
@@ -35,10 +38,37 @@ type VolumeMode struct {
 }
 
 //
+// Find accessMode by name.
+// Returns the `default` when not found.
+// The default is the mode with the lowest priority.
+func (r *VolumeMode) AccessMode(name core.PersistentVolumeAccessMode) (m *AccessMode) {
+	list := r.AccessModes
+	sort.Slice(
+		list,
+		func(i, j int) bool {
+			return list[i].Priority < list[j].Priority
+		})
+	for i := range list {
+		m = &list[i]
+		if m.Name == name {
+			return
+		}
+	}
+	if len(list) == 0 {
+		m = &AccessMode{Name: name}
+	} else {
+		m = &list[0]
+	}
+
+	return
+}
+
+//
 // Access mode.
 type AccessMode struct {
 	// Name.
-	Name string `json:"name"`
+	// +kubebuilder:validation:Enum=ReadWriteOnce,ReadWriteMany,ReadOnlyMany
+	Name core.PersistentVolumeAccessMode `json:"name"`
 	// Priority
 	Priority int `json:"priority"`
 	// Feature list.
@@ -76,6 +106,32 @@ type Provisioner struct {
 	// Referenced resources populated
 	// during validation.
 	Referenced `json:"-"`
+}
+
+//
+// Find volumeMode by name.
+// Returns the `default` when not found.
+// The default is the mode with the lowest priority.
+func (r *Provisioner) VolumeMode(name core.PersistentVolumeMode) (m *VolumeMode) {
+	list := r.Spec.VolumeModes
+	sort.Slice(
+		list,
+		func(i, j int) bool {
+			return list[i].Priority < list[j].Priority
+		})
+	for i := range list {
+		m = &list[i]
+		if m.Name == name {
+			return
+		}
+	}
+	if len(list) == 0 {
+		m = &VolumeMode{Name: name}
+	} else {
+		m = &list[0]
+	}
+
+	return
 }
 
 //

--- a/pkg/controller/plan/builder/doc.go
+++ b/pkg/controller/plan/builder/doc.go
@@ -6,10 +6,9 @@ import (
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1/plan"
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1/ref"
 	"github.com/konveyor/forklift-controller/pkg/controller/plan/builder/vsphere"
-	"github.com/konveyor/forklift-controller/pkg/controller/provider/web"
+	plancontext "github.com/konveyor/forklift-controller/pkg/controller/plan/context"
 	vmio "github.com/kubevirt/vm-import-operator/pkg/apis/v2v/v1beta1"
 	core "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 //
@@ -27,18 +26,11 @@ type Builder interface {
 
 //
 // Builder factory.
-func New(
-	client client.Client,
-	inventory web.Client,
-	provider *api.Provider) (builder Builder, err error) {
+func New(ctx *plancontext.Context) (builder Builder, err error) {
 	//
-	switch provider.Type() {
+	switch ctx.Source.Provider.Type() {
 	case api.VSphere:
-		b := &vsphere.Builder{
-			Client:    client,
-			Inventory: inventory,
-			Provider:  provider,
-		}
+		b := &vsphere.Builder{Context: ctx}
 		bErr := b.Load()
 		if bErr != nil {
 			err = liberr.Wrap(bErr)

--- a/pkg/controller/plan/context/doc.go
+++ b/pkg/controller/plan/context/doc.go
@@ -1,0 +1,4 @@
+package context
+
+//
+// Plan execution context.

--- a/pkg/controller/plan/controller.go
+++ b/pkg/controller/plan/controller.go
@@ -25,6 +25,7 @@ import (
 	libref "github.com/konveyor/controller/pkg/ref"
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1"
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1/snapshot"
+	plancontext "github.com/konveyor/forklift-controller/pkg/controller/plan/context"
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/web"
 	"github.com/konveyor/forklift-controller/pkg/settings"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
@@ -254,11 +255,12 @@ func (r *Reconciler) execute(plan *api.Plan) (reQ time.Duration, err error) {
 			return
 		}
 	}
-	runner := Migration{
-		Migration: migration,
-		Plan:      plan,
-		Client:    r,
+	ctx, err := plancontext.New(r, plan, migration)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
 	}
+	runner := Migration{Context: ctx}
 	reQ, err = runner.Run()
 	if err != nil {
 		err = liberr.Wrap(err)

--- a/pkg/controller/provider/model/ocp/model.go
+++ b/pkg/controller/provider/model/ocp/model.go
@@ -73,9 +73,8 @@ func (m *Base) ResourceVersion() uint64 {
 //
 // Decode the object field.
 // `r` must be pointer to the appropriate k8s object.
-func (m *Base) DecodeObject(r interface{}) interface{} {
-	json.Unmarshal([]byte(m.Object), r)
-	return r
+func (m *Base) DecodeObject(r interface{}) {
+	_ = json.Unmarshal([]byte(m.Object), r)
 }
 
 func (m *Base) Pk() string {

--- a/pkg/controller/provider/web/ocp/namespace.go
+++ b/pkg/controller/provider/web/ocp/namespace.go
@@ -112,14 +112,14 @@ func (h NamespaceHandler) Link(p *api.Provider, m *model.Namespace) string {
 // REST Resource.
 type Namespace struct {
 	Resource
-	Object interface{} `json:"object"`
+	Object core.Namespace `json:"object"`
 }
 
 //
 // Set fields with the specified object.
 func (r *Namespace) With(m *model.Namespace) {
 	r.Resource.With(&m.Base)
-	r.Object = m.DecodeObject(&core.Namespace{})
+	m.DecodeObject(&r.Object)
 }
 
 //

--- a/pkg/controller/provider/web/ocp/netattachdefinition.go
+++ b/pkg/controller/provider/web/ocp/netattachdefinition.go
@@ -149,14 +149,14 @@ func (h NetworkAttachmentDefinitionHandler) Link(p *api.Provider, m *model.Netwo
 // REST Resource.
 type NetworkAttachmentDefinition struct {
 	Resource
-	Object interface{} `json:"object"`
+	Object net.NetworkAttachmentDefinition `json:"object"`
 }
 
 //
 // Set fields with the specified object.
 func (r *NetworkAttachmentDefinition) With(m *model.NetworkAttachmentDefinition) {
 	r.Resource.With(&m.Base)
-	r.Object = m.DecodeObject(&net.NetworkAttachmentDefinition{})
+	m.DecodeObject(&r.Object)
 }
 
 //

--- a/pkg/controller/provider/web/ocp/provider.go
+++ b/pkg/controller/provider/web/ocp/provider.go
@@ -144,18 +144,18 @@ func (h ProviderHandler) Link(m *model.Provider) string {
 // REST Resource.
 type Provider struct {
 	Resource
-	Type           string      `json:"type"`
-	Object         interface{} `json:"object"`
-	VMCount        int64       `json:"vmCount"`
-	NetworkCount   int64       `json:"networkCount"`
-	NamespaceCount int64       `json:"namespaceCount"`
+	Type           string       `json:"type"`
+	Object         api.Provider `json:"object"`
+	VMCount        int64        `json:"vmCount"`
+	NetworkCount   int64        `json:"networkCount"`
+	NamespaceCount int64        `json:"namespaceCount"`
 }
 
 //
 // Set fields with the specified object.
 func (r *Provider) With(m *model.Provider) {
 	r.Resource.With(&m.Base)
-	r.Object = m.DecodeObject(&api.Provider{})
+	m.DecodeObject(&r.Object)
 	r.Type = m.Type
 }
 

--- a/pkg/controller/provider/web/ocp/storageclass.go
+++ b/pkg/controller/provider/web/ocp/storageclass.go
@@ -112,14 +112,14 @@ func (h StorageClassHandler) Link(p *api.Provider, m *model.StorageClass) string
 // REST Resource.
 type StorageClass struct {
 	Resource
-	Object interface{} `json:"object"`
+	Object storage.StorageClass `json:"object"`
 }
 
 //
 // Set fields with the specified object.
 func (r *StorageClass) With(m *model.StorageClass) {
 	r.Resource.With(&m.Base)
-	r.Object = m.DecodeObject(&storage.StorageClass{})
+	m.DecodeObject(&r.Object)
 }
 
 //

--- a/pkg/controller/provider/web/vsphere/provider.go
+++ b/pkg/controller/provider/web/vsphere/provider.go
@@ -196,23 +196,23 @@ func (h ProviderHandler) Link(m *model.Provider) string {
 // REST Resource.
 type Provider struct {
 	ocp.Resource
-	Type            string      `json:"type"`
-	Object          interface{} `json:"object"`
-	APIVersion      string      `json:"apiVersion"`
-	Product         string      `json:"product"`
-	DatacenterCount int64       `json:"datacenterCount"`
-	ClusterCount    int64       `json:"clusterCount"`
-	HostCount       int64       `json:"hostCount"`
-	VMCount         int64       `json:"vmCount"`
-	NetworkCount    int64       `json:"networkCount"`
-	DatastoreCount  int64       `json:"datastoreCount"`
+	Type            string       `json:"type"`
+	Object          api.Provider `json:"object"`
+	APIVersion      string       `json:"apiVersion"`
+	Product         string       `json:"product"`
+	DatacenterCount int64        `json:"datacenterCount"`
+	ClusterCount    int64        `json:"clusterCount"`
+	HostCount       int64        `json:"hostCount"`
+	VMCount         int64        `json:"vmCount"`
+	NetworkCount    int64        `json:"networkCount"`
+	DatastoreCount  int64        `json:"datastoreCount"`
 }
 
 //
 // Set fields with the specified object.
 func (r *Provider) With(m *model.Provider) {
 	r.Resource.With(&m.Base)
-	r.Object = m.DecodeObject(&api.Provider{})
+	m.DecodeObject(&r.Object)
 	r.Type = m.Type
 }
 

--- a/vendor/github.com/kubevirt/vm-import-operator/pkg/apis/v2v/v1beta1/resourcemapping_types.go
+++ b/vendor/github.com/kubevirt/vm-import-operator/pkg/apis/v2v/v1beta1/resourcemapping_types.go
@@ -93,6 +93,8 @@ type StorageResourceMappingItem struct {
 
 	// +optional
 	VolumeMode *corev1.PersistentVolumeMode `json:"volumeMode,omitempty"`
+	// +optional
+	AccessMode *corev1.PersistentVolumeAccessMode `json:"accessMode,omitempty"`
 }
 
 // ResourceMappingStatus defines the observed state of ResourceMapping

--- a/vendor/github.com/kubevirt/vm-import-operator/pkg/apis/v2v/v1beta1/virtualmachineimport_types.go
+++ b/vendor/github.com/kubevirt/vm-import-operator/pkg/apis/v2v/v1beta1/virtualmachineimport_types.go
@@ -191,6 +191,12 @@ const (
 
 	// ValidationReportedWarnings represents the existence of warnings related to resource mapping validation
 	ValidationReportedWarnings ValidConditionReason = "ValidationReportedWarnings"
+
+	// InvalidTargetVMName represents the target VM name being an invalid k8s name
+	InvalidTargetVMName ValidConditionReason = "InvalidTargetVMName"
+
+	// DuplicateTargetVMName
+	DuplicateTargetVMName ValidConditionReason = "DuplicateTargetVMName"
 )
 
 // MappingRulesVerifiedReason defines the reasons for the MappingRulesVerified condition of VM import

--- a/vendor/github.com/kubevirt/vm-import-operator/pkg/apis/v2v/v1beta1/vmimportconfig_types.go
+++ b/vendor/github.com/kubevirt/vm-import-operator/pkg/apis/v2v/v1beta1/vmimportconfig_types.go
@@ -17,9 +17,9 @@ limitations under the License.
 package v1beta1
 
 import (
-	sdkapi "github.com/kubevirt/controller-lifecycle-operator-sdk/pkg/sdk/api"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	sdkapi "kubevirt.io/controller-lifecycle-operator-sdk/pkg/sdk/api"
 )
 
 // VMImportConfigSpec defines the desired state of VMImportConfig

--- a/vendor/github.com/kubevirt/vm-import-operator/pkg/apis/v2v/v1beta1/zz_generated.deepcopy.go
+++ b/vendor/github.com/kubevirt/vm-import-operator/pkg/apis/v2v/v1beta1/zz_generated.deepcopy.go
@@ -272,6 +272,11 @@ func (in *StorageResourceMappingItem) DeepCopyInto(out *StorageResourceMappingIt
 		*out = new(v1.PersistentVolumeMode)
 		**out = **in
 	}
+	if in.AccessMode != nil {
+		in, out := &in.AccessMode, &out.AccessMode
+		*out = new(v1.PersistentVolumeAccessMode)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
Add support for passing _volumeMode_ and _accessMode_ to VMIO.
Both modes may be passed in the destination storage structures in the forklift plan and storageMap CRs.
When not passed, the `Provisioner` CR is used to provide defaults.

To provide this, the destination provider API client needed to be available to the vSphere `Builder` which, currently, it is not.  Rather than update the _Builder_ interface with the additional inventory client, it seemed like a better long term investment was to create a `Context` object that could be passed and/or used in other object aggregation.

The VMIO dependencies need to be updated.

Lastly, the OCP REST resources `Object` field needed to contain the concrete _type_ instead of _interface{}_ so when the other controllers used the REST client, the actual k8s object would be available.