### PR TITLE
Fix Finder.ByRef() to include detail param.

### DIFF
--- a/pkg/controller/provider/web/base/handler.go
+++ b/pkg/controller/provider/web/base/handler.go
@@ -21,6 +21,7 @@ const (
 	NsParam            = libweb.NsParam
 	ProviderParam      = "provider"
 	DetailParam        = "detail"
+	NameParam          = "name"
 )
 
 //

--- a/pkg/controller/provider/web/vsphere/base.go
+++ b/pkg/controller/provider/web/vsphere/base.go
@@ -10,7 +10,8 @@ import (
 //
 // Fields.
 const (
-	NameParam = "name"
+	DetailParam = base.DetailParam
+	NameParam   = base.NameParam
 )
 
 //

--- a/pkg/controller/provider/web/vsphere/client.go
+++ b/pkg/controller/provider/web/vsphere/client.go
@@ -126,7 +126,11 @@ func (r *Finder) ByRef(resource interface{}, ref base.Ref) (err error) {
 			err = r.List(
 				&list,
 				base.Param{
-					Key:   "name",
+					Key:   DetailParam,
+					Value: "1",
+				},
+				base.Param{
+					Key:   NameParam,
 					Value: name,
 				})
 			if err != nil {
@@ -154,7 +158,11 @@ func (r *Finder) ByRef(resource interface{}, ref base.Ref) (err error) {
 			err = r.List(
 				&list,
 				base.Param{
-					Key:   "name",
+					Key:   DetailParam,
+					Value: "1",
+				},
+				base.Param{
+					Key:   NameParam,
 					Value: name,
 				})
 			if err != nil {
@@ -182,7 +190,11 @@ func (r *Finder) ByRef(resource interface{}, ref base.Ref) (err error) {
 			err = r.List(
 				&list,
 				base.Param{
-					Key:   "name",
+					Key:   DetailParam,
+					Value: "1",
+				},
+				base.Param{
+					Key:   NameParam,
 					Value: name,
 				})
 			if err != nil {
@@ -210,7 +222,11 @@ func (r *Finder) ByRef(resource interface{}, ref base.Ref) (err error) {
 			err = r.List(
 				&list,
 				base.Param{
-					Key:   "name",
+					Key:   DetailParam,
+					Value: "1",
+				},
+				base.Param{
+					Key:   NameParam,
 					Value: name,
 				})
 			if err != nil {


### PR DESCRIPTION
The Finder.ByRef() needs to pass the `detail=1` param when the ref specifies the `name` instead of the ID because it uses the web.Client.List() which by default will not include details.  Find() is intended to behave like `Get()` and include details by default.