### PR TITLE
Fix Dockerfile after #126

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
 # Builder image
 FROM registry.access.redhat.com/ubi8/go-toolset:1.14.12 as builder
 ENV GOPATH=$APP_ROOT
-COPY pkg    $APP_ROOT/src/github.com/konveyor/forklift-controller/pkg
-COPY cmd    $APP_ROOT/src/github.com/konveyor/forklift-controller/cmd
-COPY vendor $APP_ROOT/src/github.com/konveyor/forklift-controller/vendor
-RUN GO111MODULE=off CGO_ENABLED=1 GOOS=linux go build -a -o manager github.com/konveyor/forklift-controller/cmd/manager
+RUN env
+COPY . .
+RUN CGO_ENABLED=1 go build -o manager github.com/konveyor/forklift-controller/cmd/manager
 
 
 # Runner image


### PR DESCRIPTION
With the transition to go modules, the Dockerfile needs to be updated to leverage it.