### PR TITLE
Support metrics settings.

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -28,6 +28,10 @@ import (
 )
 
 //
+// Application settings.
+var Settings = &settings.Settings
+
+//
 // Function provided by controller packages to add
 // them self to the manager.
 type AddFunction func(manager.Manager) error
@@ -51,10 +55,6 @@ var InventoryControllers = []AddFunction{
 //
 // Add controllers to the manager based on role.
 func AddToManager(m manager.Manager) error {
-	err := settings.Settings.Load()
-	if err != nil {
-		return err
-	}
 	load := func(functions []AddFunction) error {
 		for _, f := range functions {
 			if err := f(m); err != nil {
@@ -63,14 +63,14 @@ func AddToManager(m manager.Manager) error {
 		}
 		return nil
 	}
-	if settings.Settings.Role.Has(settings.InventoryRole) {
+	if Settings.Role.Has(settings.InventoryRole) {
 		err := load(InventoryControllers)
 		if err != nil {
 			return err
 		}
 
 	}
-	if settings.Settings.Role.Has(settings.MainRole) {
+	if Settings.Role.Has(settings.MainRole) {
 		err := load(MainControllers)
 		if err != nil {
 			return err

--- a/pkg/settings/metrics.go
+++ b/pkg/settings/metrics.go
@@ -1,0 +1,44 @@
+package settings
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+)
+
+//
+// Environment variables.
+const (
+	MetricsPort = "METRICS_PORT"
+)
+
+//
+// Metrics settings
+type Metrics struct {
+	// Metrics port. 0 = disabled.
+	Port int
+}
+
+//
+// Load settings.
+func (r *Metrics) Load() error {
+	// Port
+	if s, found := os.LookupEnv(MetricsPort); found {
+		r.Port, _ = strconv.Atoi(s)
+	} else {
+		r.Port = 8080
+	}
+
+	return nil
+}
+
+//
+// Metrics address.
+// Port = 0 will disable metrics.
+func (r *Metrics) Address() string {
+	if r.Port > 0 {
+		return fmt.Sprintf(":%d", r.Port)
+	} else {
+		return "0"
+	}
+}

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -15,6 +15,8 @@ var Settings = ControllerSettings{}
 type ControllerSettings struct {
 	// Roles.
 	Role
+	// Metrics settings.
+	Metrics
 	// Inventory settings.
 	Inventory
 	// Migration settings.
@@ -25,6 +27,10 @@ type ControllerSettings struct {
 // Load settings.
 func (r *ControllerSettings) Load() error {
 	err := r.Role.Load()
+	if err != nil {
+		return liberr.Wrap(err)
+	}
+	err = r.Metrics.Load()
 	if err != nil {
 		return liberr.Wrap(err)
 	}


### PR DESCRIPTION
Add support for Prometheus metrics endpoint settings.

Set environment variable `METRICS_PORT` in the deployment.  Eg: 8888.

```
{"level":"info","ts":1608233315.162371,"logger":"controller-runtime.metrics","msg":"metrics server is starting to listen","addr":":8888"}
```