### PR TITLE
Reconciler improvements.

### DIFF
--- a/pkg/controller/map/storage/controller.go
+++ b/pkg/controller/map/storage/controller.go
@@ -40,7 +40,7 @@ const (
 	// Controller name.
 	Name = "storage-map"
 	// Fast re-queue delay.
-	FastReQ = time.Millisecond * 100
+	FastReQ = time.Millisecond * 500
 	// Slow re-queue delay.
 	SlowReQ = time.Second * 3
 )
@@ -105,27 +105,36 @@ type Reconciler struct {
 
 //
 // Reconcile a Map CR.
-func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+func (r *Reconciler) Reconcile(request reconcile.Request) (result reconcile.Result, err error) {
 	fastReQ := reconcile.Result{RequeueAfter: FastReQ}
 	slowReQ := reconcile.Result{RequeueAfter: SlowReQ}
 	noReQ := reconcile.Result{}
-	var err error
+	result = noReQ
 
 	// Reset the logger.
 	log.Reset()
 	log.SetValues("map", request.Name)
 	log.Info("Reconcile")
 
+	defer func() {
+		if err != nil {
+			log.Trace(err)
+			err = nil
+		}
+	}()
+
 	// Fetch the CR.
 	mp := &api.StorageMap{}
 	err = r.Get(context.TODO(), request.NamespacedName, mp)
 	if err != nil {
 		if k8serr.IsNotFound(err) {
-			return noReQ, nil
+			err = nil
 		}
-		log.Trace(err)
-		return noReQ, err
+		return
 	}
+	defer func() {
+		log.Info("Conditions.", "all", mp.Status.Conditions)
+	}()
 
 	// Begin staging conditions.
 	mp.Status.BeginStagingConditions()
@@ -134,10 +143,12 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	err = r.validate(mp)
 	if err != nil {
 		if errors.As(err, &web.ProviderNotReadyError{}) {
-			return slowReQ, nil
+			result = slowReQ
+			err = nil
+		} else {
+			result = fastReQ
 		}
-		log.Trace(err)
-		return fastReQ, nil
+		return
 	}
 
 	// Ready condition.
@@ -158,9 +169,10 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	err = r.Status().Update(context.TODO(), mp)
 	if err != nil {
 		log.Trace(err)
-		return fastReQ, nil
+		result = fastReQ
+		return
 	}
 
 	// Done
-	return noReQ, nil
+	return
 }

--- a/pkg/controller/plan/controller.go
+++ b/pkg/controller/plan/controller.go
@@ -46,7 +46,7 @@ const (
 	// Controller name.
 	Name = "plan"
 	// Fast re-queue delay.
-	FastReQ = time.Millisecond * 100
+	FastReQ = time.Millisecond * 500
 	// Slow re-queue delay.
 	SlowReQ = time.Second * 3
 )
@@ -135,11 +135,11 @@ type Reconciler struct {
 
 //
 // Reconcile a Plan CR.
-func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+func (r *Reconciler) Reconcile(request reconcile.Request) (result reconcile.Result, err error) {
 	fastReQ := reconcile.Result{RequeueAfter: FastReQ}
 	slowReQ := reconcile.Result{RequeueAfter: SlowReQ}
 	noReQ := reconcile.Result{}
-	var err error
+	result = noReQ
 
 	// Reset the logger.
 	log.Reset()
@@ -149,6 +149,7 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	defer func() {
 		if err != nil {
 			log.Trace(err)
+			err = nil
 		}
 	}()
 
@@ -157,10 +158,9 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	err = r.Get(context.TODO(), request.NamespacedName, plan)
 	if err != nil {
 		if k8serr.IsNotFound(err) {
-			return noReQ, nil
+			err = nil
 		}
-		log.Trace(err)
-		return noReQ, err
+		return
 	}
 	defer func() {
 		log.Info("Conditions.", "all", plan.Status.Conditions)
@@ -173,10 +173,12 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	err = r.validate(plan)
 	if err != nil {
 		if errors.As(err, &web.ProviderNotReadyError{}) {
-			return slowReQ, nil
+			result = slowReQ
+			err = nil
+		} else {
+			result = fastReQ
 		}
-		log.Trace(err)
-		return fastReQ, nil
+		return
 	}
 
 	// Ready condition.
@@ -199,8 +201,8 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	plan.Status.ObservedGeneration = plan.Generation
 	err = r.Status().Update(context.TODO(), plan)
 	if err != nil {
-		log.Trace(err)
-		return fastReQ, nil
+		result = fastReQ
+		return
 	}
 
 	//
@@ -208,16 +210,18 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	// The plan is updated as needed to reflect status.
 	reQ, err := r.execute(plan)
 	if err != nil {
-		log.Trace(err)
-		return fastReQ, nil
+		result = fastReQ
+		return
 	}
 
 	// Done
 	if reQ > 0 {
-		return reconcile.Result{RequeueAfter: reQ}, nil
+		result = reconcile.Result{RequeueAfter: reQ}
 	} else {
-		return noReQ, nil
+		result = noReQ
 	}
+
+	return
 }
 
 //


### PR DESCRIPTION
General reconciler improvements and standardization.

We don't want to trace provider-not-ready errors.  This add a lot of unnecessary noise in the logs.