### PR TITLE
Plan controller Host watch removed.

### DIFF
--- a/pkg/controller/plan/controller.go
+++ b/pkg/controller/plan/controller.go
@@ -99,16 +99,6 @@ func Add(mgr manager.Manager) error {
 	}
 	err = cnt.Watch(
 		&source.Kind{
-			Type: &api.Host{},
-		},
-		&handler.EnqueueRequestForObject{},
-		&HostPredicate{})
-	if err != nil {
-		log.Trace(err)
-		return err
-	}
-	err = cnt.Watch(
-		&source.Kind{
 			Type: &api.Migration{},
 		},
 		&handler.EnqueueRequestsFromMapFunc{

--- a/pkg/controller/plan/predicate.go
+++ b/pkg/controller/plan/predicate.go
@@ -85,32 +85,6 @@ func (r ProviderPredicate) Generic(e event.GenericEvent) bool {
 	return false
 }
 
-type HostPredicate struct {
-	predicate.Funcs
-}
-
-func (r HostPredicate) Create(e event.CreateEvent) bool {
-	return false
-}
-
-func (r HostPredicate) Update(e event.UpdateEvent) bool {
-	p, cast := e.ObjectNew.(*api.Host)
-	if cast {
-		reconciled := p.Status.ObservedGeneration == p.Generation
-		return reconciled
-	}
-
-	return false
-}
-
-func (r HostPredicate) Delete(e event.DeleteEvent) bool {
-	return true
-}
-
-func (r HostPredicate) Generic(e event.GenericEvent) bool {
-	return false
-}
-
 type MigrationPredicate struct {
 	predicate.Funcs
 }


### PR DESCRIPTION
The plan controller was watching the `Host` CR because it validated that ALL `Host` in the same namespace as the plan had the ready condition.  There are two problems with this:
- The implementation is flawed.  I needed to have a custom event handler that would re-map the Host event into an event for each `Plan` by querying them.  Without this, the Host namespace and name in the Host event was passed to the Plan reconciler.
- Blocking all plans when a (potentially unrelated) host is not READY adds little value and subject to all kinds of race conditions.  Also, seems wrong to block unrelated plan.

A symptom of this is the plan reconciler getting events for plan (namespace/name) that does not exist.