### PR TITLE
Fix host connection test.

### DIFF
--- a/pkg/controller/plan/builder/vsphere/builder.go
+++ b/pkg/controller/plan/builder/vsphere/builder.go
@@ -445,9 +445,8 @@ func (r *Builder) esxHost(vm *model.VM) (esxHost *EsxHost, found bool, err error
 	}
 	secret.Data["thumbprint"] = []byte(hostModel.Thumbprint)
 	esxHost = &EsxHost{
-		Inventory: r.Source.Inventory,
-		Secret:    secret,
-		URL:       url,
+		Secret: secret,
+		URL:    url,
 	}
 
 	return

--- a/pkg/controller/plan/builder/vsphere/host.go
+++ b/pkg/controller/plan/builder/vsphere/host.go
@@ -3,7 +3,6 @@ package vsphere
 import (
 	"context"
 	liberr "github.com/konveyor/controller/pkg/error"
-	"github.com/konveyor/forklift-controller/pkg/controller/provider/web"
 	model "github.com/konveyor/forklift-controller/pkg/controller/provider/web/vsphere"
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/find"
@@ -22,8 +21,6 @@ type EsxHost struct {
 	URL string
 	// Host secret.
 	Secret *core.Secret
-	// Inventory client.
-	Inventory web.Client
 	// Host client.
 	client *govmomi.Client
 	// Finder


### PR DESCRIPTION
The connection test was still using the `thumbprint` in the secret instead of the thumbprint for the host in the inventory.