### PR TITLE
Add a new composite VM resource to the provider API

### DIFF
--- a/pkg/controller/provider/web/vsphere/doc.go
+++ b/pkg/controller/provider/web/vsphere/doc.go
@@ -72,5 +72,10 @@ func Handlers(container *container.Container) []libweb.RequestHandler {
 				base.Handler{Container: container},
 			},
 		},
+		&WorkloadHandler{
+			Handler: Handler{
+				base.Handler{Container: container},
+			},
+		},
 	}
 }

--- a/pkg/controller/provider/web/vsphere/workload.go
+++ b/pkg/controller/provider/web/vsphere/workload.go
@@ -1,0 +1,144 @@
+package vsphere
+
+import (
+	"errors"
+	"github.com/gin-gonic/gin"
+	libmodel "github.com/konveyor/controller/pkg/inventory/model"
+	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1"
+	model "github.com/konveyor/forklift-controller/pkg/controller/provider/model/vsphere"
+	"github.com/konveyor/forklift-controller/pkg/controller/provider/web/base"
+	"net/http"
+)
+
+//
+// Routes.
+const (
+	WorkloadCollection = "workloads"
+	WorkloadsRoot      = ProviderRoot + "/" + WorkloadCollection
+	WorkloadRoot       = WorkloadsRoot + "/:" + VMParam
+)
+
+//
+// Virtual Machine handler.
+type WorkloadHandler struct {
+	Handler
+}
+
+//
+// Add routes to the `gin` router.
+func (h *WorkloadHandler) AddRoutes(e *gin.Engine) {
+	e.GET(WorkloadRoot, h.Get)
+}
+
+//
+// List resources in a REST collection.
+func (h WorkloadHandler) List(ctx *gin.Context) {
+}
+
+//
+// Get a specific REST resource.
+func (h WorkloadHandler) Get(ctx *gin.Context) {
+	status := h.Prepare(ctx)
+	if status != http.StatusOK {
+		ctx.Status(status)
+		return
+	}
+	m := &model.VM{
+		Base: model.Base{
+			ID: ctx.Param(VMParam),
+		},
+	}
+	db := h.Reconciler.DB()
+	err := db.Get(m)
+	if errors.Is(err, model.NotFound) {
+		ctx.Status(http.StatusNotFound)
+		return
+	}
+	if err != nil {
+		Log.Trace(err)
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+	tr := Tree{
+		Provider: h.Provider,
+		DB:       db,
+		Detail: map[string]bool{
+			model.DatacenterKind: true,
+			model.ClusterKind:    true,
+			model.HostKind:       true,
+			model.VmKind:         true,
+		},
+	}
+	navigator := func(m libmodel.Model) (ref model.Ref) {
+		switch m.(type) {
+		case *model.Folder:
+			ref = m.(*model.Folder).Parent
+		case *model.Host:
+			ref = m.(*model.Host).Parent
+		case *model.Cluster:
+			ref = m.(*model.Cluster).Parent
+		case *model.VM:
+			ref = m.(*model.VM).Host
+		}
+
+		return
+	}
+	root, err := tr.Ancestry(m, navigator)
+	if err != nil {
+		Log.Trace(err)
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+	content := Workload{}
+	content.SelfLink = h.Link(h.Provider, m)
+	content.With(root)
+
+	ctx.JSON(http.StatusOK, content)
+}
+
+//
+// Build self link (URI).
+func (h WorkloadHandler) Link(p *api.Provider, m *model.VM) string {
+	return h.Handler.Link(
+		WorkloadRoot,
+		base.Params{
+			base.NsParam:       p.Namespace,
+			base.ProviderParam: p.Name,
+			VMParam:            m.ID,
+		})
+}
+
+//
+// Workload
+type Workload struct {
+	SelfLink string `json:"selfLink"`
+	*VM
+	Host struct {
+		*Host
+		Cluster struct {
+			*Cluster
+			Datacenter *Datacenter `json:"datacenter"`
+		} `json:"cluster"`
+	} `json:"host"`
+}
+
+func (r *Workload) With(root *TreeNode) {
+	node := root
+	for {
+		switch node.Kind {
+		case model.DatacenterKind:
+			r.Host.Cluster.Datacenter = node.Object.(*Datacenter)
+		case model.ClusterKind:
+			r.Host.Cluster.Cluster = node.Object.(*Cluster)
+		case model.HostKind:
+			r.Host.Host = node.Object.(*Host)
+		case model.VmKind:
+			r.VM = node.Object.(*VM)
+		}
+		if len(node.Children) > 0 {
+			node = node.Children[0]
+		} else {
+			break
+		}
+	}
+}


### PR DESCRIPTION
Add a _new_ composite resource (endpoint) to the provider inventory/API.  Borrowing the term from _vSphere_, the new resource is called a _"workload"_ and contains all fields as a `VM` but with the `host` field redefined to be the de-referenced `Host` resource.  The (de-referenced) `Host` resource has all of the same properties as a regular `Host` but with an additional `cluster` property.  The `Cluster` has all the same fields a a regular `Cluster` but with an additional `datacenter` field which contains the `Datacenter`.

This composite resource is generally useful.  However, an immediate use case is: for the policy-agent to evaluate rules against the VM and its host and cluster.

To support this, the _tree_ functionality in the model and web layers was expanded to support:
- Build a tree from the leaf up (ancestry).
- Make tree navigation more configurable.  As a result, the hard coded navigation was replaced with _caller_ supplied `Navigator` objects which guides the tree builder as it traverses up/down the tree.
- Removed unused _flattening_ functionality from the `Tree` as it has not proven to be valuable.