### PR TITLE
Define METRICS_PORT to fix make run.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,8 @@ manager: generate fmt vet
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run: generate fmt vet
-	go run ./cmd/manager/main.go
+	export METRICS_PORT=8888;\
+		go run ./cmd/manager/main.go
 
 # Install CRDs into a cluster
 install: manifests


### PR DESCRIPTION
Fix port collision between the provider API and metrics.