### PR TITLE
Integration with PA-based validation service.

### DIFF
--- a/pkg/controller/provider/container/vsphere/reconciler.go
+++ b/pkg/controller/provider/container/vsphere/reconciler.go
@@ -445,14 +445,27 @@ next:
 // Add model watches.
 func (r *Reconciler) watch() (list []*libmodel.Watch) {
 	// Cluster
-	w, err := r.db.Watch(&model.Cluster{}, &WatchCluster{r.db})
+	w, err := r.db.Watch(
+		&model.Cluster{},
+		&ClusterEventHandler{DB: r.db})
+	if err != nil {
+		Log.Trace(liberr.Wrap(err))
+	} else {
+		list = append(list, w)
+	}
+	// Host
+	w, err = r.db.Watch(
+		&model.Host{},
+		&HostEventHandler{DB: r.db})
 	if err != nil {
 		Log.Trace(liberr.Wrap(err))
 	} else {
 		list = append(list, w)
 	}
 	// VM
-	w, err = r.db.Watch(&model.VM{}, &WatchVM{r.db})
+	w, err = r.db.Watch(
+		&model.VM{},
+		&VMEventHandler{Provider: r.provider, DB: r.db})
 	if err != nil {
 		Log.Trace(liberr.Wrap(err))
 	} else {

--- a/pkg/controller/provider/container/vsphere/watch.go
+++ b/pkg/controller/provider/container/vsphere/watch.go
@@ -1,82 +1,258 @@
+//
+// The approach for providing VM policy-based integration has the
+// following design constraints:
+//   - Validation must never block updating the data model.
+//   - Real-time validation is best effort.
+//   - A scheduled search for VMs that needs to be validated
+//     ensures that all VMs eventually get validated.
+// Real-time validation is triggered by VM create/update model events.
+// If the validation service is unavailable or fails, the condition
+// is only logged with the intent that the next scheduled search will
+// validate the latest version of VM.
+// The scheduled search is a goroutine that periodically queries the
+// DB for VMs with: revision != revisionValidated.  Each matched VM
+// is validated.  To reduce overlap between the scheduled validation
+// and event-driven validation, Each model event is "reported" (though
+// a channel) to the search (loop). Reported are omitted from the search result.
+// Both Cluster and Host model events result in all of the VMs in their respective
+// containment trees will be updated with: revisionValidated = 0 which triggers
+// (re)validation.
+//
 package vsphere
 
 import (
+	"errors"
 	liberr "github.com/konveyor/controller/pkg/error"
 	libmodel "github.com/konveyor/controller/pkg/inventory/model"
+	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1"
+	refapi "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1/ref"
 	model "github.com/konveyor/forklift-controller/pkg/controller/provider/model/vsphere"
+	"github.com/konveyor/forklift-controller/pkg/controller/validation/policy"
+	"github.com/konveyor/forklift-controller/pkg/settings"
+	"time"
 )
 
 //
-// VM Watch.
-// Watch for VM changes and analyze as needed.
-type WatchVM struct {
-	libmodel.DB
+// Application settings.
+var Settings = &settings.Settings
+
+//
+// Reported model event.
+type ReportedEvent struct {
+	// VM id.
+	id string
+	// VM revision.
+	revision int64
+}
+
+//
+// Watch for VM changes and validate as needed.
+type VMEventHandler struct {
+	libmodel.StubEventHandler
+	// Provider.
+	Provider *api.Provider
+	// DB.
+	DB libmodel.DB
+	// Policy agent.
+	policyAgent *policy.Scheduler
+	// Reported VM events.
+	input chan ReportedEvent
+	// Reported VM IDs.
+	reported map[string]int64
+	// Last search.
+	lastSearch time.Time
+}
+
+//
+// Search interval.
+func (r *VMEventHandler) searchInterval() time.Duration {
+	seconds := Settings.PolicyAgent.SearchInterval
+	if seconds < 10 {
+		seconds = 10
+	}
+
+	return time.Second * time.Duration(seconds)
+}
+
+//
+// Reset.
+func (r *VMEventHandler) reset() {
+	r.reported = map[string]int64{}
+	r.lastSearch = time.Now()
+}
+
+//
+// Watch ended.
+func (r *VMEventHandler) Started() {
+	r.input = make(chan ReportedEvent)
+	r.policyAgent = policy.New(r.Provider)
+	if !Settings.PolicyAgent.Enabled() {
+		Log.Info("Policy agent not enabled.")
+		return
+	}
+	r.policyAgent.Start()
+	go r.run()
 }
 
 //
 // VM Created.
-// Analyzed as needed.
-func (r WatchVM) Created(event libmodel.Event) {
-	vm, cast := event.Model.(*model.VM)
-	if !cast {
-		return
+func (r *VMEventHandler) Created(event libmodel.Event) {
+	if vm, cast := event.Model.(*model.VM); cast {
+		if !vm.Validated() {
+			r.report(vm)
+			r.validate(vm)
+		}
 	}
-	if vm.Analyzed() {
-		return
-	}
-
-	r.analyze(vm)
 }
 
 //
 // VM Updated.
-// Analyzed as needed.
-func (r WatchVM) Updated(event libmodel.Event) {
-	vm, cast := event.Updated.(*model.VM)
-	if !cast {
-		return
+func (r *VMEventHandler) Updated(event libmodel.Event) {
+	if vm, cast := event.Updated.(*model.VM); cast {
+		if !vm.Validated() {
+			r.report(vm)
+			r.validate(vm)
+		}
 	}
-	if vm.Analyzed() {
-		return
-	}
-
-	r.analyze(vm)
-}
-
-// VM Deleted.
-func (r WatchVM) Deleted(event libmodel.Event) {
 }
 
 //
 // Report errors.
-func (r WatchVM) Error(err error) {
+func (r *VMEventHandler) Error(err error) {
 	Log.Trace(liberr.Wrap(err))
 }
 
 //
 // Watch ended.
-func (r WatchVM) End() {
+func (r *VMEventHandler) End() {
+	r.policyAgent.Shutdown()
+	close(r.input)
+}
+
+//
+// Report model event.
+func (r *VMEventHandler) report(vm *model.VM) {
+	if !r.policyAgent.Enabled() {
+		return
+	}
+	defer func() {
+		_ = recover()
+	}()
+	r.input <- ReportedEvent{
+		revision: vm.Revision,
+		id:       vm.ID,
+	}
+}
+
+//
+// Run.
+// Periodically search for VMs that need to be validated.
+func (r *VMEventHandler) run() {
+	interval := r.searchInterval()
+	if !r.policyAgent.Enabled() {
+		return
+	}
+	r.reset()
+	for {
+		select {
+		case <-time.After(interval):
+		case reportedEvent, open := <-r.input:
+			if open {
+				r.reported[reportedEvent.id] = reportedEvent.revision
+			} else {
+				return
+			}
+		}
+		if time.Since(r.lastSearch) > interval {
+			r.search()
+			r.reset()
+		}
+	}
+}
+
+//
+// Search for VMs to be validated.
+// VMs that have been reported through the model event
+// watch are ignored.
+func (r *VMEventHandler) search() {
+	Log.Info("Search for VMs that need to be validated.")
+	version, err := r.policyAgent.Version()
+	if err != nil {
+		Log.Trace(liberr.Wrap(err))
+		return
+	}
+	list := []model.VM{}
+	err = r.DB.List(
+		&list,
+		libmodel.ListOptions{
+			Predicate: libmodel.Or(
+				libmodel.Neq("Revision", libmodel.Field{Name: "RevisionValidated"}),
+				libmodel.Neq("PolicyVersion", version)),
+		})
+	if err != nil {
+		Log.Trace(liberr.Wrap(err))
+		return
+	}
+	for _, vm := range list {
+		if revision, found := r.reported[vm.ID]; found {
+			if vm.Revision == revision {
+				continue
+			}
+		}
+		r.validate(&vm)
+	}
 }
 
 //
 // Analyze the VM.
-func (r WatchVM) analyze(vm *model.VM) {
+func (r *VMEventHandler) validate(vm *model.VM) {
+	var err error
+	if !Settings.PolicyAgent.Enabled() {
+		return
+	}
+	task := &policy.Task{
+		ResultHandler: r.validated,
+		Revision:      vm.Revision,
+		Ref: refapi.Ref{
+			ID: vm.ID,
+		},
+	}
+	err = r.policyAgent.Submit(task)
+	if err != nil {
+		if errors.As(err, &policy.BacklogExceededError{}) {
+			Log.Info(err.Error())
+		} else {
+			Log.Trace(liberr.Wrap(err))
+		}
+	}
+}
+
+//
+// VM validated.
+func (r *VMEventHandler) validated(task *policy.Task) {
+	if task.Error != nil {
+		Log.Info(task.Error.Error())
+		return
+	}
 	tx, err := r.DB.Begin()
 	if err != nil {
 		Log.Trace(liberr.Wrap(err))
 		return
 	}
 	defer tx.End()
-	err = tx.Get(vm)
+	latest := &model.VM{Base: model.Base{ID: task.Ref.ID}}
+	err = r.DB.Get(latest)
 	if err != nil {
 		Log.Trace(liberr.Wrap(err))
 		return
 	}
-
-	// TODO: Open Policy Agent - HERE
-
-	vm.RevisionAnalyzed = vm.Revision
-	err = tx.Update(vm)
+	if task.Revision != latest.Revision {
+		return
+	}
+	latest.PolicyVersion = task.Version
+	latest.RevisionValidated = latest.Revision
+	latest.Concerns = task.Concerns
+	err = tx.Update(latest)
 	if err != nil {
 		Log.Trace(liberr.Wrap(err))
 		return
@@ -86,82 +262,108 @@ func (r WatchVM) analyze(vm *model.VM) {
 		Log.Trace(liberr.Wrap(err))
 		return
 	}
+	Log.Info(
+		"PolicyAgent: validated",
+		"vmID",
+		latest.ID,
+		"revision",
+		latest.Revision,
+		"duration",
+		task.Duration())
 }
 
 //
-// Cluster Watch.
-// Watch for cluster changes and analyze as needed.
-type WatchCluster struct {
-	libmodel.DB
-}
-
-//
-// Cluster created.
-// Analyze all related VMs.
-func (r WatchCluster) Created(event libmodel.Event) {
-	cluster, cast := event.Model.(*model.Cluster)
-	if cast {
-		r.analyze(cluster)
-	}
+// Watch for cluster changes and validate as needed.
+type ClusterEventHandler struct {
+	libmodel.StubEventHandler
+	// DB.
+	DB libmodel.DB
 }
 
 //
 // Cluster updated.
 // Analyze all related VMs.
-func (r WatchCluster) Updated(event libmodel.Event) {
+func (r *ClusterEventHandler) Updated(event libmodel.Event) {
 	cluster, cast := event.Model.(*model.Cluster)
 	if cast {
-		r.analyze(cluster)
+		r.validate(cluster)
 	}
 }
 
 //
-// Cluster deleted.
-func (r WatchCluster) Deleted(event libmodel.Event) {
-}
-
-//
 // Report errors.
-func (r WatchCluster) Error(err error) {
+func (r *ClusterEventHandler) Error(err error) {
 	Log.Trace(liberr.Wrap(err))
 }
 
 //
-// Watch ended.
-func (r WatchCluster) End() {
+// Analyze all of the VMs related to the cluster.
+func (r *ClusterEventHandler) validate(cluster *model.Cluster) {
+	if !Settings.PolicyAgent.Enabled() {
+		return
+	}
+	for _, ref := range cluster.Hosts {
+		host := &model.Host{}
+		host.WithRef(ref)
+		err := r.DB.Get(host)
+		if err != nil {
+			Log.Trace(liberr.Wrap(err))
+			return
+		}
+		hostHandler := HostEventHandler{DB: r.DB}
+		hostHandler.validate(host)
+	}
 }
 
 //
-// Analyze all of the VMs related to the cluster.
-func (r WatchCluster) analyze(cluster *model.Cluster) {
+// Watch for host changes and validate as needed.
+type HostEventHandler struct {
+	libmodel.StubEventHandler
+	// DB.
+	DB libmodel.DB
+}
+
+//
+// Host updated.
+// Analyze all related VMs.
+func (r *HostEventHandler) Updated(event libmodel.Event) {
+	host, cast := event.Model.(*model.Host)
+	if cast {
+		r.validate(host)
+	}
+}
+
+//
+// Report errors.
+func (r *HostEventHandler) Error(err error) {
+	Log.Trace(liberr.Wrap(err))
+}
+
+//
+// Analyze all of the VMs related to the host.
+func (r *HostEventHandler) validate(host *model.Host) {
+	if !Settings.PolicyAgent.Enabled() {
+		return
+	}
 	tx, err := r.DB.Begin()
 	if err != nil {
 		Log.Trace(liberr.Wrap(err))
 		return
 	}
 	defer tx.End()
-	for _, ref := range cluster.Hosts {
-		host := &model.Host{}
-		host.WithRef(ref)
-		err = tx.Get(host)
+	for _, ref := range host.Vms {
+		vm := &model.VM{}
+		vm.WithRef(ref)
+		err = tx.Get(vm)
 		if err != nil {
 			Log.Trace(liberr.Wrap(err))
 			return
 		}
-		for _, ref := range host.Vms {
-			vm := &model.VM{}
-			vm.WithRef(ref)
-			err = tx.Get(vm)
-			if err != nil {
-				Log.Trace(liberr.Wrap(err))
-				return
-			}
-			vm.RevisionAnalyzed = 0
-			err = tx.Update(vm)
-			if err != nil {
-				Log.Trace(liberr.Wrap(err))
-				return
-			}
+		vm.RevisionValidated = 0
+		err = tx.Update(vm)
+		if err != nil {
+			Log.Trace(liberr.Wrap(err))
+			return
 		}
 	}
 	err = tx.Commit()

--- a/pkg/controller/provider/controller.go
+++ b/pkg/controller/provider/controller.go
@@ -337,7 +337,6 @@ func (r *Reconciler) getDB(provider *api.Provider) (db libmodel.DB) {
 	path := filepath.Join(dir, file)
 	models := model.Models(provider)
 	db = libmodel.New(path, models...)
-	db.Journal().Enable()
 	return
 }
 

--- a/pkg/controller/provider/model/vsphere/model.go
+++ b/pkg/controller/provider/model/vsphere/model.go
@@ -27,11 +27,11 @@ type Base struct {
 	// Managed object ID.
 	ID string `sql:"pk"`
 	// Name
-	Name string `sql:"index(b)"`
+	Name string `sql:"d0,index(b)"`
 	// Parent
-	Parent Ref `sql:"index(a)"`
+	Parent Ref `sql:"d0,index(a)"`
 	// Revision
-	Revision int64 `sql:""`
+	Revision int64 `sql:"d0"`
 }
 
 //
@@ -337,6 +337,8 @@ type Datastore struct {
 
 type VM struct {
 	Base
+	RevisionValidated     int64     `sql:"d0"`
+	PolicyVersion         int       `sql:"d0"`
 	UUID                  string    `sql:""`
 	Firmware              string    `sql:""`
 	PowerState            string    `sql:""`
@@ -357,14 +359,13 @@ type VM struct {
 	Disks                 []Disk    `sql:""`
 	Networks              []Ref     `sql:""`
 	Host                  Ref       `sql:""`
-	RevisionAnalyzed      int64     `sql:""`
 	Concerns              []Concern `sql:""`
 }
 
 //
-// Determine if current revision has been analyzed.
-func (m *VM) Analyzed() bool {
-	return m.RevisionAnalyzed == m.Revision
+// Determine if current revision has been validated.
+func (m *VM) Validated() bool {
+	return m.RevisionValidated == m.Revision
 }
 
 //
@@ -386,6 +387,7 @@ type Device struct {
 //
 // VM concerns.
 type Concern struct {
-	Name     string `json:"name"`
-	Severity string `json:"severity"`
+	Label      string `json:"label"`
+	Category   string `json:"category"`
+	Assessment string `json:"assessment"`
 }

--- a/pkg/controller/provider/web/ocp/provider.go
+++ b/pkg/controller/provider/web/ocp/provider.go
@@ -119,41 +119,12 @@ func (h *ProviderHandler) ListContent(ctx *gin.Context) (content []interface{}, 
 //
 // Add counts.
 func (h ProviderHandler) AddCount(r *Provider) error {
-	var err error
-	var n int64
-
 	if !h.Detail {
 		return nil
 	}
-	db := h.Reconciler.DB()
 
-	// VM
-	n, err = db.Count(&model.VM{}, nil)
-	if err != nil {
-		return liberr.Wrap(err)
-	}
-	r.VMCount = n
-
-	// Network
-	n, err = db.Count(&model.NetworkAttachmentDefinition{}, nil)
-	if err != nil {
-		return liberr.Wrap(err)
-	}
-	r.NetworkCount = n + 1
-
-	// Namespace
-	n, err = db.Count(&model.Namespace{}, nil)
-	if err != nil {
-		return liberr.Wrap(err)
-	}
-	r.NamespaceCount = n
-
-	// StorageClass
-	n, err = db.Count(&model.StorageClass{}, nil)
-	if err != nil {
-		return liberr.Wrap(err)
-	}
-	r.StorageClassCount = n
+	//
+	// TODO:
 
 	return nil
 }
@@ -173,12 +144,11 @@ func (h ProviderHandler) Link(m *model.Provider) string {
 // REST Resource.
 type Provider struct {
 	Resource
-	Type              string       `json:"type"`
-	Object            api.Provider `json:"object"`
-	VMCount           int64        `json:"vmCount"`
-	NetworkCount      int64        `json:"networkCount"`
-	NamespaceCount    int64        `json:"namespaceCount"`
-	StorageClassCount int64        `json:"storageclassCount"`
+	Type           string       `json:"type"`
+	Object         api.Provider `json:"object"`
+	VMCount        int64        `json:"vmCount"`
+	NetworkCount   int64        `json:"networkCount"`
+	NamespaceCount int64        `json:"namespaceCount"`
 }
 
 //

--- a/pkg/controller/provider/web/vsphere/vm.go
+++ b/pkg/controller/provider/web/vsphere/vm.go
@@ -154,6 +154,8 @@ func (h VMHandler) filter(ctx *gin.Context, list *[]model.VM) (err error) {
 // REST Resource.
 type VM struct {
 	Resource
+	PolicyVersion         int             `json:"policyVersion"`
+	RevisionValidated     int64           `json:"revisionValidated"`
 	UUID                  string          `json:"uuid"`
 	Firmware              string          `json:"firmware"`
 	PowerState            string          `json:"powerState"`
@@ -174,7 +176,6 @@ type VM struct {
 	Networks              []model.Ref     `json:"networks"`
 	Disks                 []model.Disk    `json:"disks"`
 	Host                  model.Ref       `json:"host"`
-	RevisionAnalyzed      int64           `json:"revisionAnalyzed"`
 	Concerns              []model.Concern `json:"concerns"`
 }
 
@@ -182,6 +183,8 @@ type VM struct {
 // Build the resource using the model.
 func (r *VM) With(m *model.VM) {
 	r.Resource.With(&m.Base)
+	r.PolicyVersion = m.PolicyVersion
+	r.RevisionValidated = m.RevisionValidated
 	r.UUID = m.UUID
 	r.Firmware = m.Firmware
 	r.PowerState = m.PowerState
@@ -202,7 +205,6 @@ func (r *VM) With(m *model.VM) {
 	r.Networks = m.Networks
 	r.Disks = m.Disks
 	r.Host = m.Host
-	r.RevisionAnalyzed = m.RevisionAnalyzed
 	r.Concerns = m.Concerns
 }
 

--- a/pkg/controller/validation/policy/client.go
+++ b/pkg/controller/validation/policy/client.go
@@ -1,0 +1,421 @@
+package policy
+
+import (
+	"bytes"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	liberr "github.com/konveyor/controller/pkg/error"
+	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1"
+	refapi "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1/ref"
+	model "github.com/konveyor/forklift-controller/pkg/controller/provider/model/vsphere"
+	"github.com/konveyor/forklift-controller/pkg/settings"
+	"io/ioutil"
+	"net/http"
+	liburl "net/url"
+	"time"
+)
+
+//
+// Application settings.
+var Settings = &settings.Settings
+
+//
+// New policy agent.
+func New(provider *api.Provider) *Scheduler {
+	return &Scheduler{
+		Client: Client{
+			Provider: provider,
+		},
+	}
+}
+
+//
+// Error reported by the service.
+type ValidationError struct {
+	Errors []string
+}
+
+func (r *ValidationError) Error() string {
+	return fmt.Sprintf("%v", r.Errors)
+}
+
+//
+// Client.
+type Client struct {
+	// Provider.
+	Provider *api.Provider
+	// Transport.
+	transport *http.Transport
+}
+
+//
+// Enabled.
+func (r *Client) Enabled() bool {
+	return Settings.PolicyAgent.Enabled()
+}
+
+//
+// Policy version.
+func (r *Client) Version() (version int, err error) {
+	out := &struct {
+		Result struct {
+			Version int `json:"rules_version"`
+		} `json:"result"`
+	}{}
+	path := "/v1/data/io/konveyor/forklift/vmware/rules_version"
+	err = r.get(path, out)
+	if err != nil {
+		return
+	}
+
+	version = out.Result.Version
+
+	return
+}
+
+//
+// Validate the VM.
+func (r *Client) Validate(ref refapi.Ref) (version int, concerns []model.Concern, err error) {
+	if !r.Enabled() {
+		return
+	}
+	in := &struct {
+		Input struct {
+			Provider struct {
+				Namespace string `json:"namespace"`
+				Name      string `json:"name"`
+			} `json:"provider"`
+			ID string `json:"vm_moref"`
+		} `json:"input"`
+	}{}
+	in.Input.Provider.Namespace = r.Provider.Namespace
+	in.Input.Provider.Name = r.Provider.Name
+	in.Input.ID = ref.ID
+	out := &struct {
+		Result struct {
+			Version  int             `json:"rules_version"`
+			Concerns []model.Concern `json:"concerns"`
+			Errors   []string        `json:"errors"`
+		}
+	}{}
+	path := "/v1/data/io/konveyor/forklift/vmware/validate"
+	err = r.post(path, in, out)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	if len(out.Result.Errors) > 0 {
+		err = liberr.Wrap(
+			&ValidationError{
+				Errors: out.Result.Errors,
+			})
+		return
+	}
+
+	concerns = out.Result.Concerns
+	version = out.Result.Version
+
+	return
+}
+
+//
+// Get request.
+func (r *Client) get(path string, out interface{}) (err error) {
+	parsedURL, err := liburl.Parse(Settings.PolicyAgent.URL)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	parsedURL.Path = path
+	request := &http.Request{
+		Method: http.MethodGet,
+		URL:    parsedURL,
+	}
+	err = r.buildTransport()
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	client := http.Client{Transport: r.transport}
+	response, err := client.Do(request)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	status := response.StatusCode
+	content := []byte{}
+	if status == http.StatusOK {
+		defer response.Body.Close()
+		content, err = ioutil.ReadAll(response.Body)
+		if err != nil {
+			err = liberr.Wrap(err)
+			return
+		}
+		err = json.Unmarshal(content, out)
+		if err != nil {
+			err = liberr.Wrap(err)
+			return
+		}
+	} else {
+		err = liberr.New(http.StatusText(status))
+	}
+
+	return
+}
+
+//
+// Post request.
+func (r *Client) post(path string, in interface{}, out interface{}) (err error) {
+	parsedURL, err := liburl.Parse(Settings.PolicyAgent.URL)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	parsedURL.Path = path
+	body, _ := json.Marshal(in)
+	reader := bytes.NewReader(body)
+	request := &http.Request{
+		Method: http.MethodPost,
+		Body:   ioutil.NopCloser(reader),
+		URL:    parsedURL,
+	}
+	err = r.buildTransport()
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	client := http.Client{Transport: r.transport}
+	response, err := client.Do(request)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	status := response.StatusCode
+	content := []byte{}
+	if status == http.StatusOK {
+		defer response.Body.Close()
+		content, err = ioutil.ReadAll(response.Body)
+		if err != nil {
+			err = liberr.Wrap(err)
+			return
+		}
+		err = json.Unmarshal(content, out)
+		if err != nil {
+			err = liberr.Wrap(err)
+			return
+		}
+	} else {
+		err = liberr.New(http.StatusText(status))
+	}
+
+	return
+}
+
+//
+// Build and set the transport as needed.
+func (c *Client) buildTransport() (err error) {
+	if c.transport != nil {
+		return
+	}
+	pool := x509.NewCertPool()
+	ca, err := ioutil.ReadFile(Settings.PolicyAgent.CA)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	pool.AppendCertsFromPEM(ca)
+	c.transport = &http.Transport{
+		TLSClientConfig: &tls.Config{
+			RootCAs: pool,
+		},
+	}
+
+	return
+}
+
+//
+// Dispatcher backlog (queue limit) exceeded.
+type BacklogExceededError struct {
+}
+
+func (r BacklogExceededError) Error() string {
+	return "Dispatcher backlog exceeded."
+}
+
+//
+// Policy agent task.
+type Task struct {
+	// VM reference.
+	Ref refapi.Ref
+	// Revision number of the VM being validated.
+	Revision interface{}
+	// Result handler.
+	ResultHandler func(*Task)
+	// Reported policy version.
+	Version int
+	// Reported concerns.
+	Concerns []model.Concern
+	// Reported error.
+	Error error
+	// Worker ID.
+	worker int
+	// Started timestamp.
+	started time.Time
+	// Completed timestamp.
+	completed time.Time
+}
+
+//
+// Worker ID.
+func (r *Task) Worker() int {
+	return r.worker
+}
+
+//
+// Duration.
+func (r *Task) Duration() time.Duration {
+	return r.completed.Sub(r.started)
+}
+
+//
+// Notify result handler the task has completed.
+func (r *Task) notify() {
+	if r.ResultHandler != nil {
+		r.ResultHandler(r)
+	}
+}
+
+//
+// Task worker.
+type Worker struct {
+	id int
+	// Client.
+	client Client
+	// Input queue.
+	input chan *Task
+	// Output (result) queue.
+	output chan *Task
+}
+
+//
+// Main worker run.
+// Process input queue. Validation delegated to the
+// policy agent.
+func (r *Worker) run() {
+	defer func() {
+		_ = recover()
+	}()
+	go func() {
+		for task := range r.input {
+			task.worker = r.id
+			task.started = time.Now()
+			task.Version, task.Concerns, task.Error = r.client.Validate(task.Ref)
+			task.completed = time.Now()
+			r.output <- task
+		}
+	}()
+}
+
+//
+// Policy agent task scheduler.
+type Scheduler struct {
+	Client
+	// Worker input queue.
+	input chan *Task
+	// Worker output queue.
+	output chan *Task
+	// Dispatcher has been started.  See: Run().
+	started bool
+}
+
+//
+// Main.
+// Start workers and process output queue.
+func (r *Scheduler) Start() {
+	if r.started {
+		return
+	}
+	r.input = make(chan *Task, r.backlog())
+	r.output = make(chan *Task)
+	for id := 0; id < r.parallel(); id++ {
+		w := Worker{
+			id:     id,
+			client: r.Client,
+			input:  r.input,
+			output: r.output,
+		}
+		w.run()
+	}
+	go func() {
+		for task := range r.output {
+			task.notify()
+		}
+	}()
+
+	r.started = true
+}
+
+//
+// Shutdown the scheduler.
+// Terminate workers and stop processing result queue.
+func (r *Scheduler) Shutdown() {
+	if !r.started {
+		return
+	}
+	r.started = false
+	close(r.input)
+	close(r.output)
+}
+
+//
+// Policy version.
+func (r *Scheduler) Version() (version int, err error) {
+	return r.Client.Version()
+}
+
+//
+// Submit validation task.
+// Queue validation request.
+// May block (no longer than 10 seconds) when backlog exceeded.
+// Returns: BacklogExceededError.
+func (r *Scheduler) Submit(task *Task) (err error) {
+	if !r.started {
+		return liberr.New("scheduler not started.")
+	}
+	defer func() {
+		_ = recover()
+	}()
+	select {
+	case r.input <- task:
+		// queued.
+	case <-time.After(10 * time.Second):
+		err = liberr.Wrap(BacklogExceededError{})
+	}
+
+	return
+}
+
+//
+// Backlog limit.
+// Input queue depth.
+func (r *Scheduler) backlog() (limit int) {
+	limit = Settings.PolicyAgent.Limit.Backlog
+	if limit < 1 {
+		limit = 1
+	}
+
+	return
+}
+
+//
+// Number of workers.
+func (r *Scheduler) parallel() (limit int) {
+	limit = Settings.PolicyAgent.Limit.Worker
+	if limit < 1 {
+		limit = 1
+	}
+
+	return
+}

--- a/pkg/settings/inventory.go
+++ b/pkg/settings/inventory.go
@@ -24,9 +24,6 @@ const (
 	TLSCertificate = "API_TLS_CERTIFICATE"
 	TLSKey         = "API_TLS_KEY"
 	TLSCa          = "API_TLS_CA"
-	XavierURL      = "XAVIER_URL"
-	XavierUser     = "XAVIER_USER"
-	XavierPassword = "XAVIER_PASSWORD"
 )
 
 //

--- a/pkg/settings/policy.go
+++ b/pkg/settings/policy.go
@@ -1,0 +1,66 @@
+package settings
+
+import (
+	"os"
+)
+
+//
+// Environment variables.
+const (
+	PolicyAgentURL            = "POLICY_AGENT_URL"
+	PolicyAgentCA             = "POLICY_AGENT_CA"
+	PolicyAgentWorkerLimit    = "POLICY_AGENT_WORKER_LIMIT"
+	PolicyAgentBacklogLimit   = "POLICY_AGENT_BACKLOG_LIMIT"
+	PolicyAgentSearchInterval = "POLICY_AGENT_SEARCH_INTERVAL"
+)
+
+//
+// Policy agent settings.
+type PolicyAgent struct {
+	// URL.
+	URL string
+	// CA path
+	CA string
+	// Search interval (seconds).
+	SearchInterval int
+	// Limits.
+	Limit struct {
+		// Number of workers.
+		Worker int
+		// Backlog depth.
+		Backlog int
+	}
+}
+
+//
+// Load settings.
+func (r *PolicyAgent) Load() (err error) {
+	if s, found := os.LookupEnv(PolicyAgentURL); found {
+		r.URL = s
+	}
+	if s, found := os.LookupEnv(PolicyAgentCA); found {
+		r.CA = s
+	} else {
+		r.CA = ServiceCAFile
+	}
+	r.Limit.Worker, err = getEnvLimit(PolicyAgentWorkerLimit, 25)
+	if err != nil {
+		return err
+	}
+	r.Limit.Backlog, err = getEnvLimit(PolicyAgentBacklogLimit, 10000)
+	if err != nil {
+		return err
+	}
+	r.SearchInterval, err = getEnvLimit(PolicyAgentSearchInterval, 10)
+	if err != nil {
+		return err
+	}
+
+	return
+}
+
+//
+// Enabled.
+func (r *PolicyAgent) Enabled() bool {
+	return r.URL != ""
+}

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -21,6 +21,8 @@ type ControllerSettings struct {
 	Inventory
 	// Migration settings.
 	Migration
+	// Policy agent settings.
+	PolicyAgent
 }
 
 //
@@ -39,6 +41,10 @@ func (r *ControllerSettings) Load() error {
 		return liberr.Wrap(err)
 	}
 	err = r.Migration.Load()
+	if err != nil {
+		return liberr.Wrap(err)
+	}
+	err = r.PolicyAgent.Load()
 	if err != nil {
 		return liberr.Wrap(err)
 	}


### PR DESCRIPTION
Integration with OPA-based validation service.

The `Concerns` resource modified to match what is provided by the validation service.
Add fields to the VM:
- PolicyVersion
- RevisionValidated.

Updated DB model watches:
On cluster updated:  List hosts and mark VM associated with each host as needing to be re-validated.
On host updated:List VMs and mark them as needing to be re-validated.
On VM created/updated: validate VM of the `RevisionValidated` != `Revision`.

Periodically search for VMs with `RevisionValidated` != `Revision` || `PolicyVersion != <latest version>`.  
This is needed to handle cases:
- The validation service is not available when the DB model is created/deleted.
- The policy (rules) version running in the validation service change.
- Validation fails.

