### PR TITLE
Provider API fixes.

### DIFF
--- a/pkg/controller/provider/web/vsphere/cluster.go
+++ b/pkg/controller/provider/web/vsphere/cluster.go
@@ -118,7 +118,7 @@ type Cluster struct {
 	Networks    []model.Ref `json:"networks"`
 	Datastores  []model.Ref `json:"datastores"`
 	DasEnabled  bool        `json:"dasEnabled"`
-	DasVms      []model.Ref `json:"DasVms"`
+	DasVms      []model.Ref `json:"dasVms"`
 	DrsEnabled  bool        `json:"drsEnabled"`
 	DrsBehavior string      `json:"drsBehavior"`
 	DrsVms      []model.Ref `json:"drsVms"`

--- a/pkg/controller/provider/web/vsphere/datacenter.go
+++ b/pkg/controller/provider/web/vsphere/datacenter.go
@@ -115,12 +115,20 @@ func (h DatacenterHandler) Link(p *api.Provider, m *model.Datacenter) string {
 // REST Resource.
 type Datacenter struct {
 	Resource
+	Datastores model.Ref `json:"datastores"`
+	Networks   model.Ref `json:"networks"`
+	Clusters   model.Ref `json:"clusters"`
+	VMs        model.Ref `json:"vms"`
 }
 
 //
 // Build the resource using the model.
 func (r *Datacenter) With(m *model.Datacenter) {
 	r.Resource.With(&m.Base)
+	r.Datastores = m.Datastores
+	r.Networks = m.Networks
+	r.Clusters = m.Clusters
+	r.VMs = m.Vms
 }
 
 //

--- a/pkg/controller/provider/web/vsphere/tree.go
+++ b/pkg/controller/provider/web/vsphere/tree.go
@@ -151,6 +151,8 @@ func (h TreeHandler) HostTree(ctx *gin.Context) {
 				refs = m.(*model.Folder).Children
 			case *model.Cluster:
 				refs = m.(*model.Cluster).Hosts
+			case *model.Host:
+				refs = m.(*model.Host).Vms
 			}
 
 			return


### PR DESCRIPTION
Provider API fixes:
- Add datastore, network, cluster, vm folders to Datacenter REST resource.
- Fixed `dasVms` json tag.
- Fixed host tree missing VM leaf nodes.