### PR TITLE
Wrap error (only) at the edge.

### DIFF
--- a/pkg/controller/map/network/validation.go
+++ b/pkg/controller/map/network/validation.go
@@ -2,7 +2,6 @@ package network
 
 import (
 	libcnd "github.com/konveyor/controller/pkg/condition"
-	liberr "github.com/konveyor/controller/pkg/error"
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1"
 	"github.com/konveyor/forklift-controller/pkg/controller/validation"
 )
@@ -37,7 +36,7 @@ func (r *Reconciler) validate(mp *api.NetworkMap) error {
 	provider := validation.ProviderPair{Client: r}
 	conditions, err := provider.Validate(mp.Spec.Provider)
 	if err != nil {
-		return liberr.Wrap(err)
+		return err
 	}
 	mp.Status.UpdateConditions(conditions)
 	if mp.Status.HasCondition(validation.SourceProviderNotReady) {
@@ -46,7 +45,7 @@ func (r *Reconciler) validate(mp *api.NetworkMap) error {
 	network := validation.NetworkPair{Client: r, Provider: provider.Referenced}
 	conditions, err = network.Validate(mp.Spec.Map)
 	if err != nil {
-		return liberr.Wrap(err)
+		return err
 	}
 	mp.Status.UpdateConditions(conditions)
 

--- a/pkg/controller/map/storage/validation.go
+++ b/pkg/controller/map/storage/validation.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	libcnd "github.com/konveyor/controller/pkg/condition"
-	liberr "github.com/konveyor/controller/pkg/error"
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1"
 	"github.com/konveyor/forklift-controller/pkg/controller/validation"
 )
@@ -37,7 +36,7 @@ func (r *Reconciler) validate(mp *api.StorageMap) error {
 	provider := validation.ProviderPair{Client: r}
 	conditions, err := provider.Validate(mp.Spec.Provider)
 	if err != nil {
-		return liberr.Wrap(err)
+		return err
 	}
 	mp.Status.UpdateConditions(conditions)
 	if mp.Status.HasCondition(validation.SourceProviderNotReady) {
@@ -46,7 +45,7 @@ func (r *Reconciler) validate(mp *api.StorageMap) error {
 	storage := validation.StoragePair{Client: r, Provider: provider.Referenced}
 	conditions, err = storage.Validate(mp.Spec.Map)
 	if err != nil {
-		return liberr.Wrap(err)
+		return err
 	}
 	mp.Status.UpdateConditions(conditions)
 

--- a/pkg/controller/plan/builder/vsphere/builder.go
+++ b/pkg/controller/plan/builder/vsphere/builder.go
@@ -40,7 +40,6 @@ func (r *Builder) Secret(vmRef ref.Ref, in, object *core.Secret) (err error) {
 	url := r.Source.Provider.Spec.URL
 	hostID, err := r.hostID(vmRef)
 	if err != nil {
-		err = liberr.Wrap(err)
 		return
 	}
 	if hostDef, found := r.hosts[hostID]; found {
@@ -52,12 +51,12 @@ func (r *Builder) Secret(vmRef ref.Ref, in, object *core.Secret) (err error) {
 		url = hostURL.String()
 		hostSecret, nErr := r.hostSecret(hostDef)
 		if nErr != nil {
-			err = liberr.Wrap(nErr)
+			err = nErr
 			return
 		}
 		h, nErr := r.host(hostID)
 		if nErr != nil {
-			err = liberr.Wrap(nErr)
+			err = nErr
 			return
 		}
 		hostSecret.Data["thumbprint"] = []byte(h.Thumbprint)
@@ -71,7 +70,7 @@ func (r *Builder) Secret(vmRef ref.Ref, in, object *core.Secret) (err error) {
 			"thumbprint": string(in.Data["thumbprint"]),
 		})
 	if mErr != nil {
-		err = liberr.Wrap(mErr)
+		err = mErr
 		return
 	}
 	object.StringData = map[string]string{
@@ -105,7 +104,6 @@ func (r *Builder) Import(vmRef ref.Ref, mp *plan.Map, object *vmio.VirtualMachin
 	}
 	object.Source.Vmware.Mappings, err = r.mapping(mp, vm)
 	if err != nil {
-		err = liberr.Wrap(err)
 		return
 	}
 
@@ -186,7 +184,7 @@ func (r *Builder) loadHosts() (err error) {
 			if errors.As(pErr, &web.NotFoundError{}) {
 				continue
 			} else {
-				err = liberr.Wrap(pErr)
+				err = pErr
 				return
 			}
 		}
@@ -255,9 +253,6 @@ func (r *Builder) hostSecret(host *api.Host) (secret *core.Secret, err error) {
 			Name:      ref.Name,
 		},
 		secret)
-	if err != nil {
-		err = liberr.Wrap(err)
-	}
 
 	return
 }
@@ -290,7 +285,7 @@ func (r *Builder) mapping(in *plan.Map, vm *model.VM) (out *vmio.VmwareMappings,
 		network := &model.Network{}
 		fErr := r.Source.Inventory.Find(network, ref)
 		if fErr != nil {
-			err = liberr.Wrap(fErr)
+			err = fErr
 			return
 		}
 		needed := false

--- a/pkg/controller/plan/builder/vsphere/host.go
+++ b/pkg/controller/plan/builder/vsphere/host.go
@@ -34,10 +34,6 @@ func (r *EsxHost) TestConnection() (err error) {
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
 	defer cancel()
 	err = r.connect(ctx)
-	if err != nil {
-		liberr.Wrap(err)
-	}
-
 	return
 }
 
@@ -49,7 +45,6 @@ func (r *EsxHost) networkID(network *model.Network) (id string, err error) {
 	defer cancel()
 	err = r.connect(ctx)
 	if err != nil {
-		err = liberr.Wrap(err)
 		return
 	}
 	defer func() {
@@ -57,7 +52,7 @@ func (r *EsxHost) networkID(network *model.Network) (id string, err error) {
 	}()
 	object, fErr := r.finder.Network(ctx, network.Name)
 	if fErr != nil {
-		err = liberr.Wrap(fErr)
+		err = fErr
 		return
 	}
 
@@ -74,7 +69,6 @@ func (r *EsxHost) DatastoreID(ds *model.Datastore) (id string, err error) {
 	defer cancel()
 	err = r.connect(ctx)
 	if err != nil {
-		err = liberr.Wrap(err)
 		return
 	}
 	defer func() {
@@ -82,7 +76,7 @@ func (r *EsxHost) DatastoreID(ds *model.Datastore) (id string, err error) {
 	}()
 	object, fErr := r.finder.Datastore(ctx, ds.Name)
 	if fErr != nil {
-		err = liberr.Wrap(fErr)
+		err = fErr
 		return
 	}
 

--- a/pkg/controller/plan/controller.go
+++ b/pkg/controller/plan/controller.go
@@ -259,14 +259,12 @@ func (r *Reconciler) execute(plan *api.Plan) (reQ time.Duration, err error) {
 			},
 		})
 	if err != nil {
-		err = liberr.Wrap(err)
 		return
 	}
 	//
 	// Find and validate the current (active) migration.
 	migration, err = r.activeMigration(plan)
 	if err != nil {
-		err = liberr.Wrap(err)
 		return
 	}
 	if migration != nil {
@@ -296,7 +294,6 @@ func (r *Reconciler) execute(plan *api.Plan) (reQ time.Duration, err error) {
 	runner := Migration{Context: ctx}
 	err = runner.Cancel()
 	if err != nil {
-		err = liberr.Wrap(err)
 		return
 	}
 
@@ -305,7 +302,6 @@ func (r *Reconciler) execute(plan *api.Plan) (reQ time.Duration, err error) {
 	pending := []*api.Migration{}
 	pending, err = r.pendingMigrations(plan)
 	if err != nil {
-		err = liberr.Wrap(err)
 		return
 	}
 	//
@@ -331,7 +327,6 @@ func (r *Reconciler) execute(plan *api.Plan) (reQ time.Duration, err error) {
 	runner = Migration{Context: ctx}
 	reQ, err = runner.Run()
 	if err != nil {
-		err = liberr.Wrap(err)
 		return
 	}
 	// Reflect the active snapshot status on the plan.

--- a/pkg/controller/provider/container/vsphere/reconciler.go
+++ b/pkg/controller/provider/container/vsphere/reconciler.go
@@ -295,9 +295,7 @@ func (r *Reconciler) Test() (err error) {
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 	err = r.connect(ctx)
-	if err != nil {
-		err = liberr.Wrap(err)
-	} else {
+	if err == nil {
 		r.client.Logout(ctx)
 	}
 
@@ -349,7 +347,7 @@ func (r *Reconciler) Shutdown() {
 func (r *Reconciler) getUpdates(ctx context.Context) error {
 	err := r.connect(ctx)
 	if err != nil {
-		return liberr.Wrap(err)
+		return err
 	}
 	defer r.client.Logout(ctx)
 	about := r.client.ServiceContent.About
@@ -359,7 +357,7 @@ func (r *Reconciler) getUpdates(ctx context.Context) error {
 			Product:    about.LicenseProductName,
 		})
 	if err != nil {
-		return liberr.Wrap(err)
+		return err
 	}
 	pc := property.DefaultCollector(r.client.Client)
 	pc, err = pc.Create(ctx)
@@ -411,12 +409,11 @@ next:
 		req.Version = updateSet.Version
 		tx, err = r.db.Begin()
 		if err != nil {
-			return liberr.Wrap(err)
+			return err
 		}
 		for _, fs := range updateSet.FilterSet {
 			err = r.apply(ctx, tx, fs.ObjectSet)
 			if err != nil {
-				err = liberr.Wrap(err)
 				Log.Trace(err)
 				break
 			}
@@ -449,7 +446,7 @@ func (r *Reconciler) watch() (list []*libmodel.Watch) {
 		&model.Cluster{},
 		&ClusterEventHandler{DB: r.db})
 	if err != nil {
-		Log.Trace(liberr.Wrap(err))
+		Log.Trace(err)
 	} else {
 		list = append(list, w)
 	}
@@ -458,7 +455,7 @@ func (r *Reconciler) watch() (list []*libmodel.Watch) {
 		&model.Host{},
 		&HostEventHandler{DB: r.db})
 	if err != nil {
-		Log.Trace(liberr.Wrap(err))
+		Log.Trace(err)
 	} else {
 		list = append(list, w)
 	}

--- a/pkg/controller/provider/container/vsphere/watch.go
+++ b/pkg/controller/provider/container/vsphere/watch.go
@@ -119,7 +119,7 @@ func (r *VMEventHandler) Updated(event libmodel.Event) {
 //
 // Report errors.
 func (r *VMEventHandler) Error(err error) {
-	Log.Trace(liberr.Wrap(err))
+	Log.Trace(err)
 }
 
 //
@@ -178,7 +178,7 @@ func (r *VMEventHandler) search() {
 	Log.Info("Search for VMs that need to be validated.")
 	version, err := r.policyAgent.Version()
 	if err != nil {
-		Log.Trace(liberr.Wrap(err))
+		Log.Trace(err)
 		return
 	}
 	list := []model.VM{}

--- a/pkg/controller/provider/controller.go
+++ b/pkg/controller/provider/controller.go
@@ -303,22 +303,22 @@ func (r *Reconciler) updateContainer(provider *api.Provider) (err error) {
 	db := r.getDB(provider)
 	secret, err := r.getSecret(provider)
 	if err != nil {
-		return liberr.Wrap(err)
+		return err
 	}
 	err = db.Open(true)
 	if err != nil {
-		return liberr.Wrap(err)
+		return err
 	}
 	pModel := &ocpmodel.Provider{}
 	pModel.With(provider)
 	err = db.Insert(pModel)
 	if err != nil {
-		return liberr.Wrap(err)
+		return err
 	}
 	new := container.Build(db, provider, secret)
 	current, found, err := r.container.Replace(new)
 	if err != nil {
-		return liberr.Wrap(err)
+		return err
 	}
 	if found {
 		current.DB().Close(true)

--- a/pkg/controller/provider/model/vsphere/tree.go
+++ b/pkg/controller/provider/model/vsphere/tree.go
@@ -2,7 +2,6 @@ package vsphere
 
 import (
 	"fmt"
-	liberr "github.com/konveyor/controller/pkg/error"
 	libmodel "github.com/konveyor/controller/pkg/inventory/model"
 	libref "github.com/konveyor/controller/pkg/ref"
 )
@@ -82,11 +81,11 @@ func (r *Tree) Build(root Model, navigator BranchNavigator) (*TreeNode, error) {
 		for _, ref := range navigator(model) {
 			m, err := ref.Get(r.DB)
 			if err != nil {
-				return liberr.Wrap(err)
+				return err
 			}
 			err = walk(m, true)
 			if err != nil {
-				return liberr.Wrap(err)
+				return err
 			}
 		}
 
@@ -94,7 +93,7 @@ func (r *Tree) Build(root Model, navigator BranchNavigator) (*TreeNode, error) {
 	}
 	err := walk(root, false)
 	if err != nil {
-		return nil, liberr.Wrap(err)
+		return nil, err
 	}
 
 	return treeRoot, nil
@@ -115,7 +114,7 @@ func (r *Tree) Ancestry(leaf Model, navigator ParentNavigator) (*TreeNode, error
 		}
 		m, err := ref.Get(r.DB)
 		if err != nil {
-			return nil, liberr.Wrap(err)
+			return nil, err
 		}
 		root = &TreeNode{
 			Kind:  ref.Kind,

--- a/pkg/controller/provider/web/base/client.go
+++ b/pkg/controller/provider/web/base/client.go
@@ -194,7 +194,6 @@ func (c *RestClient) Get(resource interface{}, id string) (status int, err error
 	}
 	path, err := c.Resolver.Path(resource, id)
 	if err != nil {
-		err = liberr.Wrap(err)
 		return
 	}
 	status, err = c.get(path, resource)
@@ -223,7 +222,6 @@ func (c *RestClient) List(list interface{}, param ...Param) (status int, err err
 	}
 	path, err := c.Resolver.Path(resource, "/")
 	if err != nil {
-		err = liberr.Wrap(err)
 		return
 	}
 	if len(param) > 0 {
@@ -281,7 +279,6 @@ func (c *RestClient) get(path string, resource interface{}) (status int, err err
 	}
 	err = c.buildTransport()
 	if err != nil {
-		err = liberr.Wrap(err)
 		return
 	}
 	client := http.Client{Transport: c.transport}

--- a/pkg/controller/provider/web/ocp/provider.go
+++ b/pkg/controller/provider/web/ocp/provider.go
@@ -2,7 +2,6 @@ package ocp
 
 import (
 	"github.com/gin-gonic/gin"
-	liberr "github.com/konveyor/controller/pkg/error"
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1"
 	model "github.com/konveyor/forklift-controller/pkg/controller/provider/model/ocp"
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/web/base"
@@ -103,7 +102,7 @@ func (h *ProviderHandler) ListContent(ctx *gin.Context) (content []interface{}, 
 			r.With(m)
 			aErr := h.AddCount(&r)
 			if aErr != nil {
-				err = liberr.Wrap(aErr)
+				err = aErr
 				return
 			}
 			r.SelfLink = h.Link(m)

--- a/pkg/controller/provider/web/vsphere/datastore.go
+++ b/pkg/controller/provider/web/vsphere/datastore.go
@@ -3,7 +3,6 @@ package vsphere
 import (
 	"errors"
 	"github.com/gin-gonic/gin"
-	liberr "github.com/konveyor/controller/pkg/error"
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1"
 	model "github.com/konveyor/forklift-controller/pkg/controller/provider/model/vsphere"
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/web/base"
@@ -137,7 +136,7 @@ func (h DatastoreHandler) filter(ctx *gin.Context, list *[]model.Datastore) (err
 	for _, m := range *list {
 		path, pErr := m.Path(db)
 		if pErr != nil {
-			err = liberr.Wrap(pErr)
+			err = pErr
 			return
 		}
 		if h.PathMatchRoot(path, name) {

--- a/pkg/controller/provider/web/vsphere/host.go
+++ b/pkg/controller/provider/web/vsphere/host.go
@@ -3,7 +3,6 @@ package vsphere
 import (
 	"errors"
 	"github.com/gin-gonic/gin"
-	liberr "github.com/konveyor/controller/pkg/error"
 	libmodel "github.com/konveyor/controller/pkg/inventory/model"
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1"
 	model "github.com/konveyor/forklift-controller/pkg/controller/provider/model/vsphere"
@@ -152,7 +151,7 @@ func (h HostHandler) filter(ctx *gin.Context, list *[]model.Host) (err error) {
 	for _, m := range *list {
 		path, pErr := m.Path(db)
 		if pErr != nil {
-			err = liberr.Wrap(pErr)
+			err = pErr
 			return
 		}
 		if h.PathMatchRoot(path, name) {
@@ -258,7 +257,6 @@ func (r *AdapterBuilder) build(host *Host) (err error) {
 		if vNIC.DPortGroup != "" {
 			err = r.withDPG(host, &vNIC, &adapter)
 			if err != nil {
-				err = liberr.Wrap(err)
 				return
 			}
 			list = append(list, adapter)

--- a/pkg/controller/provider/web/vsphere/network.go
+++ b/pkg/controller/provider/web/vsphere/network.go
@@ -3,7 +3,6 @@ package vsphere
 import (
 	"errors"
 	"github.com/gin-gonic/gin"
-	liberr "github.com/konveyor/controller/pkg/error"
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1"
 	model "github.com/konveyor/forklift-controller/pkg/controller/provider/model/vsphere"
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/web/base"
@@ -137,7 +136,7 @@ func (h NetworkHandler) filter(ctx *gin.Context, list *[]model.Network) (err err
 	for _, m := range *list {
 		path, pErr := m.Path(db)
 		if pErr != nil {
-			err = liberr.Wrap(pErr)
+			err = pErr
 			return
 		}
 		if h.PathMatchRoot(path, name) {

--- a/pkg/controller/provider/web/vsphere/provider.go
+++ b/pkg/controller/provider/web/vsphere/provider.go
@@ -2,7 +2,6 @@ package vsphere
 
 import (
 	"github.com/gin-gonic/gin"
-	liberr "github.com/konveyor/controller/pkg/error"
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1"
 	model "github.com/konveyor/forklift-controller/pkg/controller/provider/model/ocp"
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/model/vsphere"
@@ -105,7 +104,7 @@ func (h *ProviderHandler) ListContent(ctx *gin.Context) (content []interface{}, 
 			r.With(m)
 			aErr := h.AddDerived(&r)
 			if aErr != nil {
-				err = liberr.Wrap(aErr)
+				err = aErr
 				return
 			}
 			r.SelfLink = h.Link(m)
@@ -130,7 +129,6 @@ func (h ProviderHandler) AddDerived(r *Provider) (err error) {
 	about := &vsphere.About{}
 	err = db.Get(about)
 	if err != nil {
-		err = liberr.Wrap(err)
 		return
 	}
 	r.APIVersion = about.APIVersion
@@ -138,42 +136,36 @@ func (h ProviderHandler) AddDerived(r *Provider) (err error) {
 	// Datacenter
 	n, err = db.Count(&vsphere.Datacenter{}, nil)
 	if err != nil {
-		err = liberr.Wrap(err)
 		return
 	}
 	r.DatacenterCount = n
 	// Cluster
 	n, err = db.Count(&vsphere.Cluster{}, nil)
 	if err != nil {
-		err = liberr.Wrap(err)
 		return
 	}
 	r.ClusterCount = n
 	// Host
 	n, err = db.Count(&vsphere.Host{}, nil)
 	if err != nil {
-		err = liberr.Wrap(err)
 		return
 	}
 	r.HostCount = n
 	// VM
 	n, err = db.Count(&vsphere.VM{}, nil)
 	if err != nil {
-		err = liberr.Wrap(err)
 		return
 	}
 	r.VMCount = n
 	// Network
 	n, err = db.Count(&vsphere.Network{}, nil)
 	if err != nil {
-		err = liberr.Wrap(err)
 		return
 	}
 	r.NetworkCount = n
 	// Datastore
 	n, err = db.Count(&vsphere.Datastore{}, nil)
 	if err != nil {
-		err = liberr.Wrap(err)
 		return
 	}
 	r.DatastoreCount = n

--- a/pkg/controller/provider/web/vsphere/tree.go
+++ b/pkg/controller/provider/web/vsphere/tree.go
@@ -2,7 +2,6 @@ package vsphere
 
 import (
 	"github.com/gin-gonic/gin"
-	liberr "github.com/konveyor/controller/pkg/error"
 	libmodel "github.com/konveyor/controller/pkg/inventory/model"
 	libref "github.com/konveyor/controller/pkg/ref"
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1"
@@ -219,7 +218,7 @@ func (r *Tree) Build(m model.Model, navigator model.BranchNavigator) (*TreeNode,
 	}
 	modelRoot, err := tree.Build(m, navigator)
 	if err != nil {
-		return nil, liberr.Wrap(err)
+		return nil, err
 	}
 	for _, child := range modelRoot.Children {
 		walk(child)
@@ -251,7 +250,7 @@ func (r *Tree) Ancestry(leaf model.Model, navigator model.ParentNavigator) (*Tre
 	}
 	modelRoot, err := tree.Ancestry(leaf, navigator)
 	if err != nil {
-		return nil, liberr.Wrap(err)
+		return nil, err
 	}
 	root = r.node(nil, modelRoot.Model)
 	node = root

--- a/pkg/controller/validation/network.go
+++ b/pkg/controller/validation/network.go
@@ -47,13 +47,11 @@ type NetworkPair struct {
 func (r *NetworkPair) Validate(list []mapped.NetworkPair) (result libcnd.Conditions, err error) {
 	conditions, err := r.validateSource(list)
 	if err != nil {
-		err = liberr.Wrap(err)
 		return
 	}
 	result.UpdateConditions(conditions)
 	conditions, err = r.validateDestination(list)
 	if err != nil {
-		err = liberr.Wrap(err)
 		return
 	}
 	result.UpdateConditions(conditions)
@@ -70,7 +68,6 @@ func (r *NetworkPair) validateSource(list []mapped.NetworkPair) (result libcnd.C
 	}
 	inventory, err := web.NewClient(provider)
 	if err != nil {
-		err = liberr.Wrap(err)
 		return
 	}
 	notValid := []string{}
@@ -97,7 +94,7 @@ func (r *NetworkPair) validateSource(list []mapped.NetworkPair) (result libcnd.C
 				ambiguous = append(ambiguous, ref.String())
 				continue
 			}
-			err = liberr.Wrap(pErr)
+			err = pErr
 			return
 		}
 	}
@@ -134,7 +131,6 @@ func (r *NetworkPair) validateDestination(list []mapped.NetworkPair) (result lib
 	}
 	inventory, err := web.NewClient(provider)
 	if err != nil {
-		err = liberr.Wrap(err)
 		return
 	}
 	notFound := []string{}
@@ -165,7 +161,7 @@ next:
 				if errors.As(pErr, &web.NotFoundError{}) {
 					notFound = append(notFound, entry.Source.ID)
 				} else {
-					err = liberr.Wrap(pErr)
+					err = pErr
 					return
 				}
 			}

--- a/pkg/controller/validation/provider.go
+++ b/pkg/controller/validation/provider.go
@@ -113,13 +113,11 @@ type ProviderPair struct {
 func (r *ProviderPair) Validate(pair provider.Pair) (result libcnd.Conditions, err error) {
 	conditions, err := r.validateSource(pair)
 	if err != nil {
-		err = liberr.Wrap(err)
 		return
 	}
 	result.UpdateConditions(conditions)
 	conditions, err = r.validateDestination(pair)
 	if err != nil {
-		err = liberr.Wrap(err)
 		return
 	}
 	result.UpdateConditions(conditions)
@@ -133,7 +131,6 @@ func (r *ProviderPair) validateSource(pair provider.Pair) (result libcnd.Conditi
 	validation := Provider{Client: r.Client}
 	conditions, err := validation.Validate(pair.Source)
 	if err != nil {
-		err = liberr.Wrap(err)
 		return
 	}
 	// Remap the condition to be source oriented.
@@ -173,7 +170,6 @@ func (r *ProviderPair) validateDestination(pair provider.Pair) (result libcnd.Co
 	validation := Provider{Client: r.Client}
 	conditions, err := validation.Validate(pair.Destination)
 	if err != nil {
-		err = liberr.Wrap(err)
 		return
 	}
 	// Remap the condition to be destination oriented.

--- a/pkg/controller/validation/storage.go
+++ b/pkg/controller/validation/storage.go
@@ -33,13 +33,11 @@ type StoragePair struct {
 func (r *StoragePair) Validate(list []mapped.StoragePair) (result libcnd.Conditions, err error) {
 	conditions, err := r.validateSource(list)
 	if err != nil {
-		err = liberr.Wrap(err)
 		return
 	}
 	result.UpdateConditions(conditions)
 	conditions, err = r.validateDestination(list)
 	if err != nil {
-		err = liberr.Wrap(err)
 		return
 	}
 	result.UpdateConditions(conditions)
@@ -56,7 +54,6 @@ func (r *StoragePair) validateSource(list []mapped.StoragePair) (result libcnd.C
 	}
 	inventory, err := web.NewClient(provider)
 	if err != nil {
-		err = liberr.Wrap(err)
 		return
 	}
 	notValid := []string{}
@@ -83,7 +80,7 @@ func (r *StoragePair) validateSource(list []mapped.StoragePair) (result libcnd.C
 				ambiguous = append(ambiguous, ref.String())
 				continue
 			}
-			err = liberr.Wrap(pErr)
+			err = pErr
 			return
 		}
 	}
@@ -120,7 +117,6 @@ func (r *StoragePair) validateDestination(list []mapped.StoragePair) (result lib
 	}
 	inventory, err := web.NewClient(provider)
 	if err != nil {
-		err = liberr.Wrap(err)
 		return
 	}
 	notValid := []string{}
@@ -144,7 +140,7 @@ func (r *StoragePair) validateDestination(list []mapped.StoragePair) (result lib
 			if errors.As(pErr, &web.NotFoundError{}) {
 				notValid = append(notValid, entry.Destination.StorageClass)
 			} else {
-				err = liberr.Wrap(pErr)
+				err = pErr
 				return
 			}
 		}

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -30,23 +30,23 @@ type ControllerSettings struct {
 func (r *ControllerSettings) Load() error {
 	err := r.Role.Load()
 	if err != nil {
-		return liberr.Wrap(err)
+		return err
 	}
 	err = r.Metrics.Load()
 	if err != nil {
-		return liberr.Wrap(err)
+		return err
 	}
 	err = r.Inventory.Load()
 	if err != nil {
-		return liberr.Wrap(err)
+		return err
 	}
 	err = r.Migration.Load()
 	if err != nil {
-		return liberr.Wrap(err)
+		return err
 	}
 	err = r.PolicyAgent.Load()
 	if err != nil {
-		return liberr.Wrap(err)
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
The original philosophy was the by wrapping errors at all levels would:
- Ensure errors got wrapped.
- Easier to code review because it's consistent.
After living with it for a while it seem apparent that neither are true.  Wrapping only where errors are returned by external packages is:
- reliable
- straight forward to code review
- reduces code noise. 