### PR TITLE
Fix storage and network map validation segfault

### DIFF
--- a/pkg/controller/map/network/validation.go
+++ b/pkg/controller/map/network/validation.go
@@ -59,7 +59,7 @@ func (r *Reconciler) validate(mp *api.NetworkMap) error {
 		return err
 	}
 	mp.Status.UpdateConditions(conditions)
-	if mp.Status.HasCondition(validation.SourceProviderNotReady) {
+	if mp.Status.HasAnyCondition(validation.SourceProviderNotReady, validation.SourceProviderNotValid) {
 		return nil
 	}
 	mp.Referenced.Provider.Source = pv.Referenced.Source

--- a/pkg/controller/map/storage/validation.go
+++ b/pkg/controller/map/storage/validation.go
@@ -51,7 +51,7 @@ func (r *Reconciler) validate(mp *api.StorageMap) error {
 		return err
 	}
 	mp.Status.UpdateConditions(conditions)
-	if mp.Status.HasCondition(validation.SourceProviderNotReady) {
+	if mp.Status.HasAnyCondition(validation.SourceProviderNotReady, validation.SourceProviderNotValid) {
 		return nil
 	}
 	mp.Referenced.Provider.Source = pv.Referenced.Source


### PR DESCRIPTION
If a Map's source provider was invalid for a reason other than not being ready, it would attempt to validate the source network or storage and fail because the referenced provider would be nil. This fixes the condition checks to include `SourceProviderNotValid`, which short circuits the validation and prevents the segfault.