### PR TITLE
Mark active step complete when VM is canceled

### DIFF
--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -243,6 +243,11 @@ func (r *Migration) Cancel() (err error) {
 				return
 			}
 			vm.MarkCompleted()
+			for _, step := range vm.Pipeline {
+				if step.MarkedStarted() {
+					step.MarkCompleted()
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
This marks the current pipeline step complete when the VM is canceled. Required for https://github.com/konveyor/forklift-ui/pull/400