### PR TITLE
Fix mapping CRs reference watch on provider.

### DIFF
--- a/pkg/apis/forklift/v1alpha1/mapping.go
+++ b/pkg/apis/forklift/v1alpha1/mapping.go
@@ -71,7 +71,7 @@ type DestinationStorage struct {
 // Network map spec.
 type NetworkMapSpec struct {
 	// Provider
-	Provider provider.Pair `json:"provider" ref:"Provider"`
+	Provider provider.Pair `json:"provider"`
 	// Map.
 	Map []NetworkPair `json:"map"`
 }
@@ -80,7 +80,7 @@ type NetworkMapSpec struct {
 // Storage map spec.
 type StorageMapSpec struct {
 	// Provider
-	Provider provider.Pair `json:"provider" ref:"Provider"`
+	Provider provider.Pair `json:"provider"`
 	// Map.
 	Map []StoragePair `json:"map"`
 }


### PR DESCRIPTION
Having the `ref:` tag on the provider.Pair shadows the fields on provider.Pair.
The ref _mapper_ will not drill into a _struct_ field with the tag.