### PR TITLE
VMIO CR generated names.

### DIFF
--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -144,27 +144,7 @@ func (r Migration) Run() (reQ time.Duration, err error) {
 				vm.Phase = Completed
 			}
 		case CreateImport:
-			err = r.kubevirt.EnsureSecret(vm.Ref)
-			if err != nil {
-				if !errors.As(err, &web.ProviderNotReadyError{}) {
-					vm.AddError(err.Error())
-					err = nil
-					break
-				} else {
-					return
-				}
-			}
 			err = r.kubevirt.EnsureImport(vm)
-			if err != nil {
-				if !errors.As(err, &web.ProviderNotReadyError{}) {
-					vm.AddError(err.Error())
-					err = nil
-					break
-				} else {
-					return
-				}
-			}
-			err = r.kubevirt.SetSecretOwner(vm)
 			if err != nil {
 				if !errors.As(err, &web.ProviderNotReadyError{}) {
 					vm.AddError(err.Error())


### PR DESCRIPTION
Convert `KubeVirt` to use generated names.  This includes finding resources by label.
This also includes consolidating the _ensureXX()_ to build the VM Import CR and associated secret.