### PR TITLE
Add VM snapshot property.

### DIFF
--- a/pkg/controller/provider/container/vsphere/model.go
+++ b/pkg/controller/provider/container/vsphere/model.go
@@ -504,6 +504,13 @@ func (v *VmAdapter) Apply(u types.ObjectUpdate) {
 				if s, cast := p.Val.(types.VirtualMachinePowerState); cast {
 					v.model.PowerState = string(s)
 				}
+			case fSnapshot:
+				if snapshot, cast := p.Val.(types.VirtualMachineSnapshotInfo); cast {
+					ref := snapshot.CurrentSnapshot
+					if ref != nil {
+						v.model.Snapshot = v.Ref(*ref)
+					}
+				}
 			case fCpuAffinity:
 				if a, cast := p.Val.(types.VirtualMachineAffinityInfo); cast {
 					v.model.CpuAffinity = a.AffinitySet

--- a/pkg/controller/provider/container/vsphere/reconciler.go
+++ b/pkg/controller/provider/container/vsphere/reconciler.go
@@ -107,6 +107,7 @@ const (
 	fStorageUsed         = "summary.storage.committed"
 	fRuntimeHost         = "runtime.host"
 	fPowerState          = "runtime.powerState"
+	fSnapshot            = "snapshot"
 )
 
 //
@@ -683,6 +684,7 @@ func (r *Reconciler) propertySpec() []types.PropertySpec {
 				fNetwork,
 				fRuntimeHost,
 				fPowerState,
+				fSnapshot,
 			},
 		},
 	}

--- a/pkg/controller/provider/model/vsphere/model.go
+++ b/pkg/controller/provider/model/vsphere/model.go
@@ -354,6 +354,7 @@ type VM struct {
 	IpAddress             string    `sql:""`
 	NumaNodeAffinity      []string  `sql:""`
 	StorageUsed           int64     `sql:""`
+	Snapshot              Ref       `sql:""`
 	Devices               []Device  `sql:""`
 	Disks                 []Disk    `sql:""`
 	Networks              []Ref     `sql:""`

--- a/pkg/controller/provider/web/vsphere/vm.go
+++ b/pkg/controller/provider/web/vsphere/vm.go
@@ -159,6 +159,7 @@ type VM struct {
 	UUID                  string          `json:"uuid"`
 	Firmware              string          `json:"firmware"`
 	PowerState            string          `json:"powerState"`
+	Snapshot              model.Ref       `json:"snapshot"`
 	CpuAffinity           []int32         `json:"cpuAffinity"`
 	CpuHotAddEnabled      bool            `json:"cpuHotAddEnabled"`
 	CpuHotRemoveEnabled   bool            `json:"cpuHotRemoveEnabled"`
@@ -188,6 +189,7 @@ func (r *VM) With(m *model.VM) {
 	r.UUID = m.UUID
 	r.Firmware = m.Firmware
 	r.PowerState = m.PowerState
+	r.Snapshot = m.Snapshot
 	r.CpuAffinity = m.CpuAffinity
 	r.CpuHotAddEnabled = m.CpuHotAddEnabled
 	r.CpuHotRemoveEnabled = m.CpuHotRemoveEnabled


### PR DESCRIPTION
Add VM snapshot property.
```
"snapshot": {
    "kind": "VirtualMachineSnapshot",
    "id": "snapshot-3134"
},
```

Blank when the VM has not current snapshot.
```
"snapshot": {
    "kind": "",
    "id": ""
},
```