### PR TITLE
Provide workload instead of VM in the hook configMap.

### DIFF
--- a/pkg/controller/plan/hook.go
+++ b/pkg/controller/plan/hook.go
@@ -279,11 +279,11 @@ func (r *HookRunner) configMap() (mp *core.ConfigMap, err error) {
 // Workload
 func (r *HookRunner) workload() (workload string, err error) {
 	inventory := r.Source.Inventory
-	vm, err := inventory.VM(&r.vm.Ref)
+	object, err := inventory.Workload(&r.vm.Ref)
 	if err != nil {
 		return
 	}
-	b, err := yaml.Marshal(vm)
+	b, err := yaml.Marshal(object)
 	if err != nil {
 		err = liberr.Wrap(err)
 		return

--- a/pkg/controller/provider/web/base/client.go
+++ b/pkg/controller/provider/web/base/client.go
@@ -79,6 +79,13 @@ type Finder interface {
 	//   NotFoundErr
 	//   RefNotUniqueErr
 	VM(ref *Ref) (interface{}, error)
+	// Find a workload by ref.
+	// Returns the matching resource and:
+	//   ProviderNotSupportedErr
+	//   ProviderNotReadyErr
+	//   NotFoundErr
+	//   RefNotUniqueErr
+	Workload(ref *Ref) (interface{}, error)
 	// Find a Network by ref.
 	// Returns the matching resource and:
 	//   ProviderNotSupportedErr
@@ -135,12 +142,20 @@ type Client interface {
 	//   NotFoundErr
 	//   RefNotUniqueErr
 	VM(ref *Ref) (interface{}, error)
+	// Find a Workload by ref.
+	// Returns the matching resource and:
+	//   ProviderNotSupportedErr
+	//   ProviderNotReadyErr
+	//   NotFoundErr
+	//   RefNotUniqueErr
+	Workload(ref *Ref) (interface{}, error)
 	// Find a Network by ref.
 	// Returns the matching resource and:
 	//   ProviderNotSupportedErr
 	//   ProviderNotReadyErr
 	//   NotFoundErr
 	//   RefNotUniqueErr
+
 	Network(ref *Ref) (interface{}, error)
 	// Find storage by ref.
 	// Returns the matching resource and:

--- a/pkg/controller/provider/web/client.go
+++ b/pkg/controller/provider/web/client.go
@@ -177,6 +177,17 @@ func (r *ProviderClient) VM(ref *base.Ref) (object interface{}, err error) {
 }
 
 //
+// Find a workload by ref.
+// Returns the matching resource and:
+//   ProviderNotSupportedErr
+//   ProviderNotReadyErr
+//   NotFoundErr
+//   RefNotUniqueErr
+func (r *ProviderClient) Workload(ref *base.Ref) (object interface{}, err error) {
+	return r.Finder().Workload(ref)
+}
+
+//
 // Find a network by ref.
 // Returns the matching resource and:
 //   ProviderNotSupportedErr

--- a/pkg/controller/provider/web/ocp/client.go
+++ b/pkg/controller/provider/web/ocp/client.go
@@ -134,6 +134,20 @@ func (r *Finder) VM(ref *base.Ref) (object interface{}, err error) {
 }
 
 //
+// Find workload by ref.
+// Returns the matching resource and:
+//   ProviderNotSupportedErr
+//   ProviderNotReadyErr
+//   NotFoundErr
+//   RefNotUniqueErr
+func (r *Finder) Workload(ref *base.Ref) (object interface{}, err error) {
+	err = liberr.Wrap(&NotFoundError{
+		Ref: *ref,
+	})
+	return
+}
+
+//
 // Find a Network by ref.
 //Returns the matching resource and:
 //   ProviderNotSupportedErr


### PR DESCRIPTION
Provide workload instead of VM in the hook configMap.

Needed to add the `Workload` to the client objects.  The _workload_ is considered a provider non-specific (common) resource.