### PR TITLE
Use StringData to update secret in ensureSecret

### DIFF
--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -250,7 +250,7 @@ func (r *KubeVirt) ensureSecret(vmRef ref.Ref) (secret *core.Secret, err error) 
 	}
 	if len(list.Items) > 0 {
 		secret = &list.Items[0]
-		secret.Data = newSecret.Data
+		secret.StringData = newSecret.StringData
 		err = r.Destination.Client.Update(context.TODO(), secret)
 		if err != nil {
 			err = liberr.Wrap(err)


### PR DESCRIPTION
Because `builder.Secret` creates a Secret with `StringData` instead of `Data`, `ensureSecret` needs to use the new secret's `StringData` to update the existing secret.