### PR TITLE
Don't set a default cutover

### DIFF
--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -313,11 +313,8 @@ func (r *KubeVirt) vmImport(
 		object.Spec.Warm = true
 		if r.Migration.Spec.Cutover != nil {
 			object.Spec.FinalizeDate = r.Migration.Spec.Cutover
-		} else if r.Plan.Spec.Cutover != nil {
-			object.Spec.FinalizeDate = r.Plan.Spec.Cutover
 		} else {
-			now := meta.Now()
-			object.Spec.FinalizeDate = &now
+			object.Spec.FinalizeDate = r.Plan.Spec.Cutover
 		}
 	}
 


### PR DESCRIPTION
The UI doesn't schedule a cutover right away, so we need to be able to start a plan with no cutover date.