### PR TITLE
Introduce vSphere migration throttling

### DIFF
--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -105,11 +105,11 @@ func (r Migration) Run() (reQ time.Duration, err error) {
 		}
 	}
 
-	vm, err := r.scheduler.Next()
+	vm, hasNext, err := r.scheduler.Next()
 	if err != nil {
 		return
 	}
-	if vm != nil {
+	if hasNext {
 		err = r.step(vm)
 		if err != nil {
 			return
@@ -124,6 +124,9 @@ func (r Migration) Run() (reQ time.Duration, err error) {
 	return
 }
 
+//
+// Steps a VM through the migration itinerary
+// and updates its status.
 func (r Migration) step(vm *plan.VMStatus) (err error) {
 	// check whether the VM has been canceled by the user
 	if r.Context.Migration.Spec.Canceled(vm.Ref) {

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -276,7 +276,6 @@ func (r *Migration) init() (err error) {
 	}
 	r.scheduler, err = scheduler.New(r.Context)
 	if err != nil {
-		err = liberr.Wrap(err)
 		return
 	}
 

--- a/pkg/controller/plan/scheduler/doc.go
+++ b/pkg/controller/plan/scheduler/doc.go
@@ -9,8 +9,11 @@ import (
 	"github.com/konveyor/forklift-controller/pkg/settings"
 )
 
+// Scheduler API
+// Determines which of the plan's VMs can have their migrations started.
 type Scheduler interface {
-	Next() (*plan.VMStatus, bool, error)
+	// Return the next VM that can be migrated.
+	Next() (vm *plan.VMStatus, hasNext bool, err error)
 }
 
 //

--- a/pkg/controller/plan/scheduler/doc.go
+++ b/pkg/controller/plan/scheduler/doc.go
@@ -1,0 +1,30 @@
+package scheduler
+
+import (
+	liberr "github.com/konveyor/controller/pkg/error"
+	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1"
+	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1/plan"
+	plancontext "github.com/konveyor/forklift-controller/pkg/controller/plan/context"
+	"github.com/konveyor/forklift-controller/pkg/controller/plan/scheduler/vsphere"
+	"github.com/konveyor/forklift-controller/pkg/settings"
+)
+
+type Scheduler interface {
+	Next() (*plan.VMStatus, error)
+}
+
+//
+// Scheduler factory.
+func New(ctx *plancontext.Context) (scheduler Scheduler, err error) {
+	switch ctx.Source.Provider.Type() {
+	case api.VSphere:
+		scheduler = &vsphere.Scheduler{
+			Context:     ctx,
+			MaxInFlight: settings.Settings.MaxInFlight,
+		}
+	default:
+		liberr.New("provider not supported.")
+	}
+
+	return
+}

--- a/pkg/controller/plan/scheduler/doc.go
+++ b/pkg/controller/plan/scheduler/doc.go
@@ -10,7 +10,7 @@ import (
 )
 
 type Scheduler interface {
-	Next() (*plan.VMStatus, error)
+	Next() (*plan.VMStatus, bool, error)
 }
 
 //

--- a/pkg/controller/plan/scheduler/vsphere/scheduler.go
+++ b/pkg/controller/plan/scheduler/vsphere/scheduler.go
@@ -2,22 +2,41 @@ package vsphere
 
 import (
 	"context"
+	"sync"
+
 	liberr "github.com/konveyor/controller/pkg/error"
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1"
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1/plan"
 	plancontext "github.com/konveyor/forklift-controller/pkg/controller/plan/context"
-	"github.com/konveyor/forklift-controller/pkg/controller/provider/web/vsphere"
+	model "github.com/konveyor/forklift-controller/pkg/controller/provider/model/vsphere"
 )
+
+//
+// Package level mutex to ensure that
+// multiple concurrent reconciles don't
+// attempt to schedule VMs into the same
+// slots.
+var mutex sync.Mutex
 
 //
 // Scheduler for migrations from ESX hosts.
 type Scheduler struct {
 	*plancontext.Context
+	// Maximum number of disks per host that can be
+	// migrated at once.
 	MaxInFlight int
-	inflight    map[string]int
-	pending     map[string][]*pendingVM
+	// Mapping of hosts by ID to the number of disks
+	// on each host that are currently being migrated.
+	inFlight map[string]int
+	// Mapping of hosts by ID to lists of VMs
+	// that are waiting to be migrated.
+	pending map[string][]*pendingVM
 }
 
+//
+// Convenience struct to package a
+// VMStatus with a cost that is calculated
+// from the inventory VM object.
 type pendingVM struct {
 	status *plan.VMStatus
 	cost   int
@@ -25,7 +44,9 @@ type pendingVM struct {
 
 //
 // Return the next VM to migrate.
-func (r *Scheduler) Next() (vm *plan.VMStatus, err error) {
+func (r *Scheduler) Next() (vm *plan.VMStatus, hasNext bool, err error) {
+	mutex.Lock()
+	defer mutex.Unlock()
 	err = r.buildSchedule()
 	if err != nil {
 		return
@@ -33,42 +54,53 @@ func (r *Scheduler) Next() (vm *plan.VMStatus, err error) {
 	for _, vms := range r.schedulable() {
 		if len(vms) > 0 {
 			vm = vms[0].status
+			hasNext = true
 		}
 	}
 	return
 }
 
 //
-// Determine how much host capcity is occupied
+// Determine how much host capacity is occupied
 // by running migrations across all plans for
 // the same provider, and determine which
 // VMs are still waiting to be started.
-func (r *Scheduler) buildSchedule() error {
-	r.inflight = make(map[string]int)
-	r.pending = make(map[string][]*pendingVM)
+func (r *Scheduler) buildSchedule() (err error) {
+	err = r.buildInFlight()
+	if err != nil {
+		return
+	}
+
+	err = r.buildPending()
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+//
+// Build the map of the number of disks that
+// are currently in flight for each host.
+func (r *Scheduler) buildInFlight() (err error) {
+	r.inFlight = make(map[string]int)
 
 	// Since we modify the plan VMStatuses in memory,
 	// we need to use the plan from the context rather
 	// than from the list of plans that are retrieved below.
 	for _, vmStatus := range r.Plan.Status.Migration.VMs {
-		obj, err := r.Source.Inventory.VM(&vmStatus.Ref)
+		vm := &model.VM{}
+		err = r.Source.Inventory.Find(vm, vmStatus.Ref)
 		if err != nil {
-			return err
+			return
 		}
-		vm := obj.(*vsphere.VM)
 		if vmStatus.Running() {
-			r.inflight[vm.Host.ID] += len(vm.Disks)
-		} else if !vmStatus.MarkedCompleted() {
-			pending := &pendingVM{
-				status: vmStatus,
-				cost:   len(vm.Disks),
-			}
-			r.pending[vm.Host.ID] = append(r.pending[vm.Host.ID], pending)
+			r.inFlight[vm.Host.ID] += len(vm.Disks)
 		}
 	}
 
 	planList := &api.PlanList{}
-	err := r.List(context.TODO(), planList)
+	err = r.List(context.TODO(), planList)
 	if err != nil {
 		return liberr.Wrap(err)
 	}
@@ -83,35 +115,58 @@ func (r *Scheduler) buildSchedule() error {
 		}
 
 		for _, vmStatus := range p.Status.Migration.VMs {
-			obj, err := r.Source.Inventory.VM(&vmStatus.Ref)
+			vm := &model.VM{}
+			err = r.Source.Inventory.Find(vm, vmStatus.Ref)
 			if err != nil {
 				return err
 			}
-			vm := obj.(*vsphere.VM)
 			if vmStatus.Running() {
-				r.inflight[vm.Host.ID] += len(vm.Disks)
+				r.inFlight[vm.Host.ID] += len(vm.Disks)
 			}
 		}
 	}
 
-	return nil
+	return
+}
+
+//
+// Build the map of pending VMs belonging to each host.
+func (r *Scheduler) buildPending() (err error) {
+	r.pending = make(map[string][]*pendingVM)
+
+	for _, vmStatus := range r.Plan.Status.Migration.VMs {
+		vm := &model.VM{}
+		err = r.Source.Inventory.Find(vm, vmStatus.Ref)
+		if err != nil {
+			return
+		}
+
+		if !vmStatus.MarkedStarted() && !vmStatus.MarkedCompleted() {
+			pending := &pendingVM{
+				status: vmStatus,
+				cost:   len(vm.Disks),
+			}
+			r.pending[vm.Host.ID] = append(r.pending[vm.Host.ID], pending)
+		}
+	}
+	return
 }
 
 //
 // Return a map of all the VMs that could be scheduled
 // based on the available host capacities.
-func (r *Scheduler) schedulable() map[string][]*pendingVM {
-	schedulable := make(map[string][]*pendingVM)
+func (r *Scheduler) schedulable() (schedulable map[string][]*pendingVM) {
+	schedulable = make(map[string][]*pendingVM)
 	for host, vms := range r.pending {
-		if r.inflight[host] >= r.MaxInFlight {
+		if r.inFlight[host] >= r.MaxInFlight {
 			continue
 		}
 		for i := range vms {
-			if vms[i].cost+r.inflight[host] <= r.MaxInFlight {
+			if vms[i].cost+r.inFlight[host] <= r.MaxInFlight {
 				schedulable[host] = append(schedulable[host], vms[i])
 			}
 		}
 	}
 
-	return schedulable
+	return
 }

--- a/pkg/controller/plan/scheduler/vsphere/scheduler.go
+++ b/pkg/controller/plan/scheduler/vsphere/scheduler.go
@@ -1,0 +1,117 @@
+package vsphere
+
+import (
+	"context"
+	liberr "github.com/konveyor/controller/pkg/error"
+	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1"
+	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1/plan"
+	plancontext "github.com/konveyor/forklift-controller/pkg/controller/plan/context"
+	"github.com/konveyor/forklift-controller/pkg/controller/provider/web/vsphere"
+)
+
+//
+// Scheduler for migrations from ESX hosts.
+type Scheduler struct {
+	*plancontext.Context
+	MaxInFlight int
+	inflight    map[string]int
+	pending     map[string][]*pendingVM
+}
+
+type pendingVM struct {
+	status *plan.VMStatus
+	cost   int
+}
+
+//
+// Return the next VM to migrate.
+func (r *Scheduler) Next() (vm *plan.VMStatus, err error) {
+	err = r.buildSchedule()
+	if err != nil {
+		return
+	}
+	for _, vms := range r.schedulable() {
+		if len(vms) > 0 {
+			vm = vms[0].status
+		}
+	}
+	return
+}
+
+//
+// Determine how much host capcity is occupied
+// by running migrations across all plans for
+// the same provider, and determine which
+// VMs are still waiting to be started.
+func (r *Scheduler) buildSchedule() error {
+	r.inflight = make(map[string]int)
+	r.pending = make(map[string][]*pendingVM)
+
+	// Since we modify the plan VMStatuses in memory,
+	// we need to use the plan from the context rather
+	// than from the list of plans that are retrieved below.
+	for _, vmStatus := range r.Plan.Status.Migration.VMs {
+		obj, err := r.Source.Inventory.VM(&vmStatus.Ref)
+		if err != nil {
+			return err
+		}
+		vm := obj.(*vsphere.VM)
+		if vmStatus.Running() {
+			r.inflight[vm.Host.ID] += len(vm.Disks)
+		} else if !vmStatus.MarkedCompleted() {
+			pending := &pendingVM{
+				status: vmStatus,
+				cost:   len(vm.Disks),
+			}
+			r.pending[vm.Host.ID] = append(r.pending[vm.Host.ID], pending)
+		}
+	}
+
+	planList := &api.PlanList{}
+	err := r.List(context.TODO(), planList)
+	if err != nil {
+		return liberr.Wrap(err)
+	}
+	for _, p := range planList.Items {
+		// skip this plan, it's already done.
+		if p.Name == r.Plan.Name && p.Namespace == r.Plan.Namespace {
+			continue
+		}
+		// ignore plans that aren't using the same source provider
+		if p.Spec.Provider.Source != r.Plan.Spec.Provider.Source {
+			continue
+		}
+
+		for _, vmStatus := range p.Status.Migration.VMs {
+			obj, err := r.Source.Inventory.VM(&vmStatus.Ref)
+			if err != nil {
+				return err
+			}
+			vm := obj.(*vsphere.VM)
+			if vmStatus.Running() {
+				r.inflight[vm.Host.ID] += len(vm.Disks)
+			}
+		}
+	}
+
+	return nil
+}
+
+//
+// Return a map of all the VMs that could be scheduled
+// based on the available host capacities.
+func (r *Scheduler) schedulable() map[string][]*pendingVM {
+	schedulable := make(map[string][]*pendingVM)
+	for host, vms := range r.pending {
+		if r.inflight[host] >= r.MaxInFlight {
+			continue
+		}
+		for i := range vms {
+			if vms[i].cost+r.inflight[host] <= r.MaxInFlight {
+				schedulable[host] = append(schedulable[host], vms[i])
+			}
+		}
+	}
+
+	return schedulable
+}

--- a/pkg/controller/plan/scheduler/vsphere/scheduler_test.go
+++ b/pkg/controller/plan/scheduler/vsphere/scheduler_test.go
@@ -13,7 +13,7 @@ func TestScheduler(t *testing.T) {
 	hostC := "hostC"
 
 	scheduler := Scheduler{MaxInFlight: 10}
-	scheduler.inflight = map[string]int{
+	scheduler.inFlight = map[string]int{
 		hostA: 6,
 		hostB: 10,
 		hostC: 0,

--- a/pkg/controller/plan/scheduler/vsphere/scheduler_test.go
+++ b/pkg/controller/plan/scheduler/vsphere/scheduler_test.go
@@ -1,0 +1,100 @@
+package vsphere
+
+import (
+	"github.com/onsi/gomega"
+	"testing"
+)
+
+func TestScheduler(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	hostA := "hostA"
+	hostB := "hostB"
+	hostC := "hostC"
+
+	scheduler := Scheduler{MaxInFlight: 10}
+	scheduler.inflight = map[string]int{
+		hostA: 6,
+		hostB: 10,
+		hostC: 0,
+	}
+	scheduler.pending = map[string][]*pendingVM{
+		// Only VMs that fit the available capacity
+		// can be scheduled. Host A already has 6 slots occupied,
+		// so only the VM with cost 4 can be scheduled.
+		hostA: {
+			{
+				cost: 6,
+			},
+			{
+				cost: 5,
+			},
+			{
+				cost: 4,
+			},
+			{
+				cost: 7,
+			},
+		},
+
+		// host B has reached capacity, so we
+		// can't schedule any migrations from it.
+		hostB: {
+			{
+				cost: 10,
+			},
+			{
+				cost: 0,
+			},
+			{
+				cost: 1,
+			},
+		},
+
+		// host C is unoccupied, so any of its
+		// vms with a cost of 10 or less could
+		// be started
+		hostC: {
+			{
+				cost: 11,
+			},
+			{
+				cost: 1,
+			},
+			{
+				cost: 2,
+			},
+			{
+				cost: 3,
+			},
+			{
+				cost: 10,
+			},
+		},
+	}
+
+	// no VMs from host B could be scheduled, so we shouldn't see
+	// an entry for host B in the schedule map.
+	expectedSchedule := map[string][]*pendingVM{
+		hostA: {
+			{
+				cost: 4,
+			},
+		},
+		hostC: {
+			{
+				cost: 1,
+			},
+			{
+				cost: 2,
+			},
+			{
+				cost: 3,
+			},
+			{
+				cost: 10,
+			},
+		},
+	}
+	g.Expect(scheduler.schedulable()).To(gomega.Equal(expectedSchedule))
+}


### PR DESCRIPTION
This introduces a stateless scheduling mechanism for vSphere, which restricts the number of VM migrations that can be started across all plans using the same source. 

* Each host can have a number of disks in flight equal to `MAX_VM_INFLIGHT`. VMs can be scheduled if there are enough slots free on the host to accommodate the number of disks attached to the VM. 
* Each Plan can start at most a single VM on each reconcile, in order to allow other Plans an opportunity to schedule a VM.
* `migration.Run` has been refactored to first find all the Plan's started VM migrations and step through their pipelines. Then it acquires the next VM that can be scheduled if any, and steps through its pipeline.