### PR TITLE
Watch inventory.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	github.com/gin-gonic/gin v1.6.3
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.1.0
-	github.com/konveyor/controller v0.3.0
+	github.com/konveyor/controller v0.3.1
 	github.com/onsi/gomega v1.10.3
 	github.com/prometheus/client_golang v1.8.0 // indirect
 	github.com/vmware/govmomi v0.23.1

--- a/go.sum
+++ b/go.sum
@@ -703,6 +703,8 @@ github.com/konveyor/controller v0.2.9 h1:GYjQA6xs9wQcKqiAyexmyND2bC8U0sFEjRJIPRc
 github.com/konveyor/controller v0.2.9/go.mod h1:TYIj+tCq1ND66/GhXU4pS1ZePNfWZYlqxs57WdWVha8=
 github.com/konveyor/controller v0.3.0 h1:S5GQZcoxIfai+ETzlzcDvSmoEVy6nc1hp94TFyk/S6Y=
 github.com/konveyor/controller v0.3.0/go.mod h1:TYIj+tCq1ND66/GhXU4pS1ZePNfWZYlqxs57WdWVha8=
+github.com/konveyor/controller v0.3.1 h1:iO5DPlSC4gRzPpzcv757qNBQY+aYN0bfDC47cytbf5E=
+github.com/konveyor/controller v0.3.1/go.mod h1:TYIj+tCq1ND66/GhXU4pS1ZePNfWZYlqxs57WdWVha8=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=

--- a/pkg/controller/map/network/handler/doc.go
+++ b/pkg/controller/map/network/handler/doc.go
@@ -1,0 +1,45 @@
+package handler
+
+import (
+	liberr "github.com/konveyor/controller/pkg/error"
+	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1"
+	"github.com/konveyor/forklift-controller/pkg/controller/map/network/handler/ocp"
+	"github.com/konveyor/forklift-controller/pkg/controller/map/network/handler/vsphere"
+	"github.com/konveyor/forklift-controller/pkg/controller/watch/handler"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+type WatchManager = handler.WatchManager
+
+//
+// Inventory event handler.
+type Handler interface {
+	// Ensure watch started.
+	Watch(m *handler.WatchManager) error
+}
+
+//
+// Handler factory.
+func New(
+	client client.Client,
+	channel chan event.GenericEvent,
+	provider *api.Provider) (h Handler, err error) {
+	//
+	switch provider.Type() {
+	case api.OpenShift:
+		h, err = ocp.New(
+			client,
+			channel,
+			provider)
+	case api.VSphere:
+		h, err = vsphere.New(
+			client,
+			channel,
+			provider)
+	default:
+		err = liberr.New("provider not supported.")
+	}
+
+	return
+}

--- a/pkg/controller/map/network/handler/ocp/doc.go
+++ b/pkg/controller/map/network/handler/ocp/doc.go
@@ -1,0 +1,23 @@
+package ocp
+
+import (
+	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1"
+	"github.com/konveyor/forklift-controller/pkg/controller/watch/handler"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+//
+// Handler factory.
+func New(
+	client client.Client,
+	channel chan event.GenericEvent,
+	provider *api.Provider) (h *Handler, err error) {
+	//
+	b, err := handler.New(client, channel, provider)
+	if err != nil {
+		return
+	}
+	h = &Handler{Handler: b}
+	return
+}

--- a/pkg/controller/map/network/handler/ocp/handler.go
+++ b/pkg/controller/map/network/handler/ocp/handler.go
@@ -1,0 +1,79 @@
+package ocp
+
+import (
+	liberr "github.com/konveyor/controller/pkg/error"
+	libweb "github.com/konveyor/controller/pkg/inventory/web"
+	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1"
+	"github.com/konveyor/forklift-controller/pkg/controller/provider/web/ocp"
+	"github.com/konveyor/forklift-controller/pkg/controller/watch/handler"
+	"golang.org/x/net/context"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+//
+// Provider watch event handler.
+type Handler struct {
+	*handler.Handler
+}
+
+//
+// Ensure watch on networks.
+func (r *Handler) Watch(watch *handler.WatchManager) (err error) {
+	_, err = watch.Ensure(
+		r.Provider(),
+		&ocp.NetworkAttachmentDefinition{},
+		r)
+
+	return
+}
+
+//
+// Resource created.
+func (r *Handler) Created(e libweb.Event) {
+	if !r.HasParity() {
+		return
+	}
+	if network, cast := e.Resource.(*ocp.NetworkAttachmentDefinition); cast {
+		r.changed(network)
+	}
+}
+
+//
+// Resource deleted.
+func (r *Handler) Deleted(e libweb.Event) {
+	if !r.HasParity() {
+		return
+	}
+	if network, cast := e.Resource.(*ocp.NetworkAttachmentDefinition); cast {
+		r.changed(network)
+	}
+}
+
+//
+// Network changed.
+// Find all of the NetworkMap CRs the reference both the
+// provider and the changed network and enqueue reconcile events.
+func (r *Handler) changed(network *ocp.NetworkAttachmentDefinition) {
+	list := api.NetworkMapList{}
+	err := r.List(context.TODO(), &list)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	for _, mp := range list.Items {
+		ref := mp.Spec.Provider.Destination
+		if !r.MatchProvider(ref) {
+			continue
+		}
+		for _, pair := range mp.Spec.Map {
+			ref := pair.Destination
+			if ref.Namespace == network.Namespace && ref.Name == network.Name {
+				r.Enqueue(event.GenericEvent{
+					Meta:   &mp.ObjectMeta,
+					Object: &mp,
+				})
+				break
+			}
+		}
+	}
+}

--- a/pkg/controller/map/network/handler/vsphere/doc.go
+++ b/pkg/controller/map/network/handler/vsphere/doc.go
@@ -1,0 +1,23 @@
+package vsphere
+
+import (
+	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1"
+	"github.com/konveyor/forklift-controller/pkg/controller/watch/handler"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+//
+// Handler factory.
+func New(
+	client client.Client,
+	channel chan event.GenericEvent,
+	provider *api.Provider) (h *Handler, err error) {
+	//
+	b, err := handler.New(client, channel, provider)
+	if err != nil {
+		return
+	}
+	h = &Handler{Handler: b}
+	return
+}

--- a/pkg/controller/map/network/handler/vsphere/handler.go
+++ b/pkg/controller/map/network/handler/vsphere/handler.go
@@ -1,0 +1,81 @@
+package vsphere
+
+import (
+	liberr "github.com/konveyor/controller/pkg/error"
+	libweb "github.com/konveyor/controller/pkg/inventory/web"
+	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1"
+	"github.com/konveyor/forklift-controller/pkg/controller/provider/web/vsphere"
+	"github.com/konveyor/forklift-controller/pkg/controller/watch/handler"
+	"golang.org/x/net/context"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+//
+// Provider watch event handler.
+type Handler struct {
+	*handler.Handler
+}
+
+//
+// Ensure watch on networks.
+func (r *Handler) Watch(watch *handler.WatchManager) (err error) {
+	_, err = watch.Ensure(
+		r.Provider(),
+		&vsphere.Network{},
+		r)
+
+	return
+}
+
+//
+// Resource created.
+func (r *Handler) Created(e libweb.Event) {
+	if !r.HasParity() {
+		return
+	}
+	if network, cast := e.Resource.(*vsphere.Network); cast {
+		r.changed(network)
+	}
+}
+
+//
+// Resource deleted.
+func (r *Handler) Deleted(e libweb.Event) {
+	if !r.HasParity() {
+		return
+	}
+	if network, cast := e.Resource.(*vsphere.Network); cast {
+		r.changed(network)
+	}
+}
+
+//
+// vSphere network changed.
+// Find all of the NetworkMap CRs the reference both the
+// provider and the changed network and enqueue reconcile events.
+func (r *Handler) changed(network *vsphere.Network) {
+	list := api.NetworkMapList{}
+	err := r.List(context.TODO(), &list)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	for _, mp := range list.Items {
+		ref := mp.Spec.Provider.Source
+		if !r.MatchProvider(ref) {
+			continue
+		}
+		inventory := r.Inventory()
+		for _, pair := range mp.Spec.Map {
+			ref := pair.Source
+			_, err = inventory.Network(&ref)
+			if ref.ID == network.ID {
+				r.Enqueue(event.GenericEvent{
+					Meta:   &mp.ObjectMeta,
+					Object: &mp,
+				})
+				break
+			}
+		}
+	}
+}

--- a/pkg/controller/map/network/predicate.go
+++ b/pkg/controller/map/network/predicate.go
@@ -1,8 +1,11 @@
 package network
 
 import (
+	libcnd "github.com/konveyor/controller/pkg/condition"
 	libref "github.com/konveyor/controller/pkg/ref"
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1"
+	"github.com/konveyor/forklift-controller/pkg/controller/map/network/handler"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
@@ -44,11 +47,20 @@ func (r MapPredicate) Delete(e event.DeleteEvent) bool {
 	return false
 }
 
+//
+// Provider watch predicate.
+// Also ensures an inventory watch is created and
+// associated with the channel source.
 type ProviderPredicate struct {
+	handler.WatchManager
 	predicate.Funcs
+	channel chan event.GenericEvent
+	client  client.Client
 }
 
-func (r ProviderPredicate) Create(e event.CreateEvent) bool {
+//
+// Provider created event.
+func (r *ProviderPredicate) Create(e event.CreateEvent) bool {
 	p, cast := e.Object.(*api.Provider)
 	if cast {
 		reconciled := p.Status.ObservedGeneration == p.Generation
@@ -58,17 +70,24 @@ func (r ProviderPredicate) Create(e event.CreateEvent) bool {
 	return false
 }
 
-func (r ProviderPredicate) Update(e event.UpdateEvent) bool {
+//
+// Provider updated event.
+func (r *ProviderPredicate) Update(e event.UpdateEvent) bool {
 	p, cast := e.ObjectNew.(*api.Provider)
 	if cast {
 		reconciled := p.Status.ObservedGeneration == p.Generation
+		if reconciled {
+			r.ensureWatch(p)
+		}
 		return reconciled
 	}
 
 	return false
 }
 
-func (r ProviderPredicate) Delete(e event.DeleteEvent) bool {
+//
+// Provider deleted event.
+func (r *ProviderPredicate) Delete(e event.DeleteEvent) bool {
 	p, cast := e.Object.(*api.Provider)
 	if cast {
 		reconciled := p.Status.ObservedGeneration == p.Generation
@@ -78,7 +97,9 @@ func (r ProviderPredicate) Delete(e event.DeleteEvent) bool {
 	return false
 }
 
-func (r ProviderPredicate) Generic(e event.GenericEvent) bool {
+//
+// Generic provider watch event.
+func (r *ProviderPredicate) Generic(e event.GenericEvent) bool {
 	p, cast := e.Object.(*api.Provider)
 	if cast {
 		reconciled := p.Status.ObservedGeneration == p.Generation
@@ -86,4 +107,22 @@ func (r ProviderPredicate) Generic(e event.GenericEvent) bool {
 	}
 
 	return false
+}
+
+//
+// Ensure the there is a watch for the provider and kind.
+func (r *ProviderPredicate) ensureWatch(p *api.Provider) {
+	if !p.Status.HasCondition(libcnd.Ready) {
+		return
+	}
+	h, err := handler.New(r.client, r.channel, p)
+	if err != nil {
+		log.Trace(err)
+		return
+	}
+	err = h.Watch(&r.WatchManager)
+	if err != nil {
+		log.Trace(err)
+		return
+	}
 }

--- a/pkg/controller/map/network/validation.go
+++ b/pkg/controller/map/network/validation.go
@@ -58,7 +58,11 @@ func (r *Reconciler) validate(mp *api.NetworkMap) error {
 		return err
 	}
 	mp.Status.UpdateConditions(conditions)
-	if mp.Status.HasAnyCondition(validation.SourceProviderNotReady, validation.SourceProviderNotValid) {
+	if mp.Status.HasAnyCondition(
+		validation.SourceProviderNotValid,
+		validation.SourceProviderNotReady,
+		validation.DestinationProviderNotValid,
+		validation.DestinationProviderNotReady) {
 		return nil
 	}
 	mp.Referenced.Provider.Source = pv.Referenced.Source

--- a/pkg/controller/map/storage/validation.go
+++ b/pkg/controller/map/storage/validation.go
@@ -50,7 +50,11 @@ func (r *Reconciler) validate(mp *api.StorageMap) error {
 		return err
 	}
 	mp.Status.UpdateConditions(conditions)
-	if mp.Status.HasAnyCondition(validation.SourceProviderNotReady, validation.SourceProviderNotValid) {
+	if mp.Status.HasAnyCondition(
+		validation.SourceProviderNotValid,
+		validation.SourceProviderNotReady,
+		validation.DestinationProviderNotValid,
+		validation.DestinationProviderNotReady) {
 		return nil
 	}
 	mp.Referenced.Provider.Source = pv.Referenced.Source

--- a/pkg/controller/provider/container/vsphere/watch.go
+++ b/pkg/controller/provider/container/vsphere/watch.go
@@ -48,7 +48,7 @@ type ReportedEvent struct {
 //
 // Watch for VM changes and validate as needed.
 type VMEventHandler struct {
-	libmodel.StubEventHandler
+	libmodel.StockEventHandler
 	// Provider.
 	Provider *api.Provider
 	// DB.
@@ -275,7 +275,7 @@ func (r *VMEventHandler) validated(task *policy.Task) {
 //
 // Watch for cluster changes and validate as needed.
 type ClusterEventHandler struct {
-	libmodel.StubEventHandler
+	libmodel.StockEventHandler
 	// DB.
 	DB libmodel.DB
 }
@@ -318,7 +318,7 @@ func (r *ClusterEventHandler) validate(cluster *model.Cluster) {
 //
 // Watch for host changes and validate as needed.
 type HostEventHandler struct {
-	libmodel.StubEventHandler
+	libmodel.StockEventHandler
 	// DB.
 	DB libmodel.DB
 }

--- a/pkg/controller/provider/web/base/client.go
+++ b/pkg/controller/provider/web/base/client.go
@@ -139,7 +139,7 @@ type Client interface {
 	//   ProviderNotSupportedErr
 	//   ProviderNotReadyErr
 	//   NotFoundErr
-	Watch(list interface{}, h EventHandler) (*Watch, error)
+	Watch(resource interface{}, h EventHandler) (*Watch, error)
 	// Get a resource by ref.
 	// Returns:
 	//   ProviderNotSupportedErr

--- a/pkg/controller/watch/doc.go
+++ b/pkg/controller/watch/doc.go
@@ -1,0 +1,1 @@
+package watch

--- a/pkg/controller/watch/handler/doc.go
+++ b/pkg/controller/watch/handler/doc.go
@@ -1,0 +1,24 @@
+package handler
+
+import (
+	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1"
+	"github.com/konveyor/forklift-controller/pkg/controller/provider/web"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+//
+// Handler factory.
+func New(
+	client client.Client,
+	channel chan event.GenericEvent,
+	provider *api.Provider) (h *Handler, err error) {
+	//
+	h = &Handler{
+		Client:   client,
+		channel:  channel,
+		provider: provider,
+	}
+	h.inventory, err = web.NewClient(provider)
+	return
+}

--- a/pkg/controller/watch/handler/handler.go
+++ b/pkg/controller/watch/handler/handler.go
@@ -1,0 +1,97 @@
+package handler
+
+import (
+	libweb "github.com/konveyor/controller/pkg/inventory/web"
+	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1"
+	"github.com/konveyor/forklift-controller/pkg/controller/provider/web"
+	core "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+//
+// Generic event.
+type EventChannel chan event.GenericEvent
+
+//
+// Provider watch event handler.
+type Handler struct {
+	libweb.StockEventHandler
+	// k8s client.
+	client.Client
+	// Event channel.
+	channel EventChannel
+	// Associated provider.
+	provider *api.Provider
+	// Inventory API client.
+	inventory web.Client
+	// Watch ended by peer.
+	ended bool
+	// Parity marker.
+	parity bool
+}
+
+//
+// The associated provider.
+func (r *Handler) Provider() *api.Provider {
+	return r.provider
+}
+
+//
+// Get an inventory client.
+func (r *Handler) Inventory() web.Client {
+	return r.inventory
+}
+
+//
+// Enqueue reconcile request.
+func (r *Handler) Enqueue(event event.GenericEvent) {
+	defer func() {
+		recover()
+	}()
+	r.channel <- event
+}
+
+//
+// Match provider.
+func (r *Handler) MatchProvider(ref core.ObjectReference) bool {
+	return r.Match(r.provider, ref)
+}
+
+//
+// Ref matches object.
+func (r *Handler) Match(object meta.Object, ref core.ObjectReference) bool {
+	return ref.Namespace == object.GetNamespace() &&
+		ref.Name == object.GetName()
+}
+
+//
+// Inventory watch has parity.
+func (r *Handler) HasParity() bool {
+	return r.parity
+
+}
+
+//
+// Inventory watch has parity.
+func (r *Handler) Parity() {
+	r.parity = true
+}
+
+//
+// Watch ended by peer.
+// The database has been closed.
+func (r *Handler) End() {
+	r.parity = false
+	r.ended = true
+}
+
+//
+// Watch error.
+// Repair the watch.
+func (r *Handler) Error(w *libweb.Watch, err error) {
+	if !r.ended {
+		_ = w.Repair()
+	}
+}

--- a/pkg/controller/watch/handler/watch.go
+++ b/pkg/controller/watch/handler/watch.go
@@ -1,0 +1,65 @@
+package handler
+
+import (
+	libweb "github.com/konveyor/controller/pkg/inventory/web"
+	libref "github.com/konveyor/controller/pkg/ref"
+	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1"
+	"github.com/konveyor/forklift-controller/pkg/controller/provider/web"
+	"k8s.io/apimachinery/pkg/types"
+	"sync"
+)
+
+//
+// Watch map keyed by resource kind.
+type watchMap map[string]*libweb.Watch
+
+//
+// Provider map keyed by provider.UID.
+type ProviderMap map[types.UID]watchMap
+
+//
+// Watch manager.
+type WatchManager struct {
+	mutex sync.Mutex
+	// Provider map keyed by provider.UID.
+	providerMap ProviderMap
+}
+
+//
+// Ensure watch has been created.
+// An existing watch that is not `alive` will be replaced.
+func (m *WatchManager) Ensure(
+	provider *api.Provider,
+	resource interface{},
+	handler libweb.EventHandler) (watch *libweb.Watch, err error) {
+	//
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	if m.providerMap == nil {
+		m.providerMap = make(ProviderMap)
+	}
+	watchMap, found := m.providerMap[provider.UID]
+	if !found {
+		watchMap = make(map[string]*libweb.Watch)
+		m.providerMap[provider.UID] = watchMap
+	}
+	kind := libref.ToKind(resource)
+	if w, found := watchMap[kind]; found {
+		if w.Alive() {
+			watch = w
+			return
+		}
+	}
+	client, err := web.NewClient(provider)
+	if err != nil {
+		return
+	}
+	w, err := client.Watch(resource, handler)
+	if err != nil {
+		return
+	}
+	watchMap[kind] = w
+	watch = w
+
+	return
+}


### PR DESCRIPTION
PoC for remote watch of inventory.
Starting with the NetworkMap controller using the well established _factory_ pattern.
Adds the following new packages:
- **/controller/watch/handler** - Base _inventory_ watch event handler.
- **/controller/map/network/handler** - root _inventory_ watch event handler. package with factory.
- **/controller/map/network/handler/ocp** -  OCP _inventory_ watch event handler.
- **/controller/map/network/handler/vsphere** - vSphere _inventory_ watch event handler.

**Requires**:  https://github.com/konveyor/controller/pull/55

---

Each controller will:
- add a `Channel` source to support injecting events into the controller work queue.
- update the provider predicate to be composed of a `WatchManager` and ensure _inventory_ watches are created when a `Provider` is created.  Deleted provider inventory watches will be cleaned up automatically.
- Implement an inventory watch event handler factory and a provider (type) specific handler package.  Everything related to inventory watching is delegated to these handlers.
- Each handler is _wired up_ to the controller `Channel` source using the shared event _channel_.