### PR TITLE
Backport to Release v2.0.0: Make Scheduler import web.VM, not model.VM

### DIFF
--- a/pkg/controller/plan/scheduler/vsphere/scheduler.go
+++ b/pkg/controller/plan/scheduler/vsphere/scheduler.go
@@ -8,7 +8,7 @@ import (
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1"
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1/plan"
 	plancontext "github.com/konveyor/forklift-controller/pkg/controller/plan/context"
-	model "github.com/konveyor/forklift-controller/pkg/controller/provider/model/vsphere"
+	model "github.com/konveyor/forklift-controller/pkg/controller/provider/web/vsphere"
 )
 
 //


### PR DESCRIPTION
This fixes a bug with the Scheduler importing the VM struct from the wrong package, resulting in reconciles failing.