### PR TITLE
Backport to release-v2.0.0: Trim suffix from the backing file name

### DIFF
--- a/pkg/controller/plan/builder/doc.go
+++ b/pkg/controller/plan/builder/doc.go
@@ -8,6 +8,7 @@ import (
 	"github.com/konveyor/forklift-controller/pkg/controller/plan/builder/vsphere"
 	plancontext "github.com/konveyor/forklift-controller/pkg/controller/plan/context"
 	core "k8s.io/api/core/v1"
+	cdi "kubevirt.io/containerized-data-importer/pkg/apis/core/v1beta1"
 	vmio "kubevirt.io/vm-import-operator/pkg/apis/v2v/v1beta1"
 )
 
@@ -22,6 +23,8 @@ type Builder interface {
 	Import(vmRef ref.Ref, object *vmio.VirtualMachineImportSpec) error
 	// Build tasks.
 	Tasks(vmRef ref.Ref) ([]*plan.Task, error)
+	// Return a stable identifier for a DataVolume.
+	ResolveDataVolumeIdentifier(dv *cdi.DataVolume) string
 }
 
 //

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -5,7 +5,6 @@ import (
 	libcnd "github.com/konveyor/controller/pkg/condition"
 	liberr "github.com/konveyor/controller/pkg/error"
 	libitr "github.com/konveyor/controller/pkg/itinerary"
-	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1"
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1/plan"
 	"github.com/konveyor/forklift-controller/pkg/controller/plan/builder"
 	plancontext "github.com/konveyor/forklift-controller/pkg/controller/plan/context"
@@ -610,12 +609,7 @@ func (r *Migration) updatePipeline(vm *plan.VMStatus, imp *VmImport) {
 			var task *plan.Task
 		nextDv:
 			for _, dv := range imp.DataVolumes {
-				switch r.Type() {
-				case api.VSphere:
-					name = dv.Spec.Source.VDDK.BackingFile
-				default:
-					continue nextDv
-				}
+				name = r.builder.ResolveDataVolumeIdentifier(dv.DataVolume)
 				found := false
 				task, found = step.FindTask(name)
 				if !found {


### PR DESCRIPTION
buildPipeline uses the disk backing file name from
the inventory to create the VM pipeline tasks, but
updatePipeline uses the disk backing name from the
DataVolumes to find those tasks.

When VMIO creates a DataVolume for a VM that is being warm
migrated, it creates a snapshot first. This will cause
the disk backing file name to differ from what the inventory
saw, and means updatePipeline won't be able to find
the task that buildPipeline created.

This patch causes the backing file suffixes to be trimmed
before comparing them, enabling pipeline updates to
work correctly.