### PR TITLE
Provider API: add authorization.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	github.com/gin-gonic/gin v1.6.3
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.1.0
-	github.com/konveyor/controller v0.3.1
+	github.com/konveyor/controller v0.3.2
 	github.com/onsi/gomega v1.10.3
 	github.com/prometheus/client_golang v1.8.0 // indirect
 	github.com/vmware/govmomi v0.23.1

--- a/go.sum
+++ b/go.sum
@@ -705,6 +705,8 @@ github.com/konveyor/controller v0.3.0 h1:S5GQZcoxIfai+ETzlzcDvSmoEVy6nc1hp94TFyk
 github.com/konveyor/controller v0.3.0/go.mod h1:TYIj+tCq1ND66/GhXU4pS1ZePNfWZYlqxs57WdWVha8=
 github.com/konveyor/controller v0.3.1 h1:iO5DPlSC4gRzPpzcv757qNBQY+aYN0bfDC47cytbf5E=
 github.com/konveyor/controller v0.3.1/go.mod h1:TYIj+tCq1ND66/GhXU4pS1ZePNfWZYlqxs57WdWVha8=
+github.com/konveyor/controller v0.3.2 h1:q2r+0Wgmp2wNv6gbi6bcVhftbyttmWnfe0QVhuPMySE=
+github.com/konveyor/controller v0.3.2/go.mod h1:TYIj+tCq1ND66/GhXU4pS1ZePNfWZYlqxs57WdWVha8=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=

--- a/pkg/controller/host/predicate.go
+++ b/pkg/controller/host/predicate.go
@@ -78,6 +78,7 @@ func (r *ProviderPredicate) Update(e event.UpdateEvent) bool {
 		reconciled := p.Status.ObservedGeneration == p.Generation
 		if reconciled {
 			r.ensureWatch(p)
+			return true
 		}
 	}
 

--- a/pkg/controller/map/network/predicate.go
+++ b/pkg/controller/map/network/predicate.go
@@ -72,12 +72,13 @@ func (r *ProviderPredicate) Create(e event.CreateEvent) bool {
 
 //
 // Provider updated event.
-func (r *ProviderPredicate) Update(e event.UpdateEvent) (approved bool) {
+func (r *ProviderPredicate) Update(e event.UpdateEvent) bool {
 	p, cast := e.ObjectNew.(*api.Provider)
 	if cast {
 		reconciled := p.Status.ObservedGeneration == p.Generation
 		if reconciled {
 			r.ensureWatch(p)
+			return true
 		}
 	}
 

--- a/pkg/controller/map/storage/predicate.go
+++ b/pkg/controller/map/storage/predicate.go
@@ -72,12 +72,13 @@ func (r *ProviderPredicate) Create(e event.CreateEvent) bool {
 
 //
 // Provider updated event.
-func (r *ProviderPredicate) Update(e event.UpdateEvent) (approved bool) {
+func (r *ProviderPredicate) Update(e event.UpdateEvent) bool {
 	p, cast := e.ObjectNew.(*api.Provider)
 	if cast {
 		reconciled := p.Status.ObservedGeneration == p.Generation
 		if reconciled {
 			r.ensureWatch(p)
+			return true
 		}
 	}
 

--- a/pkg/controller/plan/controller.go
+++ b/pkg/controller/plan/controller.go
@@ -106,7 +106,10 @@ func Add(mgr manager.Manager) error {
 			Type: &api.Provider{},
 		},
 		libref.Handler(),
-		&ProviderPredicate{})
+		&ProviderPredicate{
+			client:  mgr.GetClient(),
+			channel: channel,
+		})
 	if err != nil {
 		log.Trace(err)
 		return err

--- a/pkg/controller/plan/predicate.go
+++ b/pkg/controller/plan/predicate.go
@@ -75,12 +75,13 @@ func (r *ProviderPredicate) Create(e event.CreateEvent) bool {
 
 //
 // Provider updated event.
-func (r *ProviderPredicate) Update(e event.UpdateEvent) (approved bool) {
+func (r *ProviderPredicate) Update(e event.UpdateEvent) bool {
 	p, cast := e.ObjectNew.(*api.Provider)
 	if cast {
 		reconciled := p.Status.ObservedGeneration == p.Generation
 		if reconciled {
 			r.ensureWatch(p)
+			return true
 		}
 	}
 

--- a/pkg/controller/provider/web/base/auth.go
+++ b/pkg/controller/provider/web/base/auth.go
@@ -1,0 +1,178 @@
+package base
+
+import (
+	"context"
+	"github.com/gin-gonic/gin"
+	liberr "github.com/konveyor/controller/pkg/error"
+	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1"
+	auth "k8s.io/api/authentication/v1"
+	auth2 "k8s.io/api/authorization/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"net/http"
+	"path"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	"strings"
+	"sync"
+	"time"
+)
+
+//
+// Default auth provider.
+var DefaultAuth = Auth{
+	TTL: time.Second * 10,
+}
+
+//
+// Authorized by k8s bearer token SAR.
+// Token must have "*" on the provider CR.
+type Auth struct {
+	// k8s API writer.
+	Writer client.Writer
+	// Cached token TTL.
+	TTL time.Duration
+	// Mutex.
+	mutex sync.Mutex
+	// Token cache.
+	cache map[string]time.Time
+}
+
+//
+// Authenticate token.
+func (r *Auth) Permit(ctx *gin.Context, p *api.Provider) (status int) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	status = http.StatusOK
+	if r.cache == nil {
+		r.cache = make(map[string]time.Time)
+	}
+	r.prune()
+	token := r.token(ctx)
+	if token == "" {
+		status = http.StatusUnauthorized
+		return
+	}
+	key := r.key(token, p)
+	if t, found := r.cache[key]; found {
+		if time.Since(t) <= r.TTL {
+			return
+		}
+	}
+	allowed, err := r.permit(token, p)
+	if err != nil {
+		status = http.StatusInternalServerError
+		return
+	}
+	if allowed {
+		r.cache[key] = time.Now()
+	} else {
+		status = http.StatusForbidden
+		delete(r.cache, token)
+	}
+
+	return
+}
+
+//
+// Authenticate token.
+func (r *Auth) permit(token string, p *api.Provider) (allowed bool, err error) {
+	tr := &auth.TokenReview{
+		Spec: auth.TokenReviewSpec{
+			Token: token,
+		},
+	}
+	w, err := r.writer()
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	err = w.Create(context.TODO(), tr)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	if !tr.Status.Authenticated {
+		return
+	}
+	user := tr.Status.User
+	kind := p.GetObjectKind()
+	gvk := kind.GroupVersionKind()
+	ar := &auth2.SubjectAccessReview{
+		Spec: auth2.SubjectAccessReviewSpec{
+			ResourceAttributes: &auth2.ResourceAttributes{
+				Group:     gvk.Group,
+				Resource:  gvk.Kind,
+				Namespace: p.Namespace,
+				Name:      p.Name,
+				Verb:      "*",
+			},
+			Groups: user.Groups,
+			User:   user.UID,
+		},
+	}
+	err = w.Create(context.TODO(), ar)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+
+	allowed = ar.Status.Allowed
+	return
+}
+
+//
+// Extract token.
+func (r *Auth) token(ctx *gin.Context) (token string) {
+	header := ctx.GetHeader("Authorization")
+	fields := strings.Fields(header)
+	if len(fields) == 2 && fields[0] == "Bearer" {
+		token = fields[1]
+	}
+
+	return
+}
+
+//
+// Prune the cache.
+// Evacuate expired tokens.
+func (r *Auth) prune() {
+	for token, t := range r.cache {
+		if time.Since(t) > r.TTL {
+			delete(r.cache, token)
+		}
+	}
+}
+
+//
+// Cache key.
+func (r *Auth) key(token string, p *api.Provider) string {
+	return path.Join(
+		token,
+		p.Namespace,
+		p.Name)
+}
+
+//
+// Build API writer.
+func (r *Auth) writer() (w client.Writer, err error) {
+	if r.Writer != nil {
+		w = r.Writer
+		return
+	}
+	cfg, err := config.GetConfig()
+	if err != nil {
+		return
+	}
+	cfg.Burst = 1000
+	cfg.QPS = 100
+	w, err = client.New(
+		cfg,
+		client.Options{
+			Scheme: scheme.Scheme,
+		})
+	if err == nil {
+		r.Writer = w
+	}
+
+	return
+}

--- a/pkg/controller/provider/web/base/auth_test.go
+++ b/pkg/controller/provider/web/base/auth_test.go
@@ -1,0 +1,125 @@
+package base
+
+import (
+	"context"
+	"github.com/gin-gonic/gin"
+	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1"
+	"github.com/onsi/gomega"
+	auth "k8s.io/api/authentication/v1"
+	auth2 "k8s.io/api/authorization/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"net/http"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"testing"
+	"time"
+)
+
+type fakeWriter struct {
+	allowed bool
+	trCount int
+	arCount int
+}
+
+func (r *fakeWriter) Create(
+	ctx context.Context,
+	object runtime.Object,
+	option ...client.CreateOption) (err error) {
+	//
+	if tr, cast := object.(*auth.TokenReview); cast {
+		tr.Status.Authenticated = r.allowed
+		r.trCount++
+		return
+	}
+	if ar, cast := object.(*auth2.SubjectAccessReview); cast {
+		ar.Status.Allowed = r.allowed
+		r.arCount++
+		return
+	}
+
+	return
+}
+
+func (r *fakeWriter) Delete(
+	context.Context,
+	runtime.Object,
+	...client.DeleteOption) error {
+	//
+	return nil
+}
+
+func (r *fakeWriter) Update(
+	context.Context,
+	runtime.Object,
+	...client.UpdateOption) error {
+	//
+	return nil
+}
+
+func (r *fakeWriter) Patch(
+	context.Context,
+	runtime.Object,
+	client.Patch,
+	...client.PatchOption) error {
+	//
+	return nil
+}
+
+func (r *fakeWriter) DeleteAllOf(
+	context.Context,
+	runtime.Object,
+	...client.DeleteAllOfOption) error {
+	//
+	return nil
+}
+
+func TestAuth(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	ttl := time.Millisecond * 50
+	writer := &fakeWriter{allowed: true}
+	auth := Auth{
+		Writer: writer,
+		TTL:    ttl,
+	}
+	token := "12345"
+	ctx := &gin.Context{
+		Request: &http.Request{
+			Header: map[string][]string{
+				"Authorization": {"Bearer " + token},
+			},
+		},
+	}
+	provider := &api.Provider{
+		ObjectMeta: meta.ObjectMeta{
+			Namespace: "konveyor-forklift",
+			Name:      "test",
+		},
+	}
+	// token.
+	g.Expect(auth.token(ctx)).To(gomega.Equal(token))
+	// First call with no cached token.
+	status := auth.Permit(ctx, provider)
+	g.Expect(auth.cache[token]).ToNot(gomega.BeNil())
+	g.Expect(1).To(gomega.Equal(writer.trCount))
+	g.Expect(1).To(gomega.Equal(writer.arCount))
+	g.Expect(http.StatusOK).To(gomega.Equal(status))
+	// Second call with cached token.
+	status = auth.Permit(ctx, provider)
+	g.Expect(auth.cache[token]).ToNot(gomega.BeNil())
+	g.Expect(1).To(gomega.Equal(writer.trCount))
+	g.Expect(1).To(gomega.Equal(writer.arCount))
+	g.Expect(http.StatusOK).To(gomega.Equal(status))
+	// Third call after TTL.
+	time.Sleep(ttl)
+	status = auth.Permit(ctx, provider)
+	g.Expect(auth.cache[token]).ToNot(gomega.BeNil())
+	g.Expect(2).To(gomega.Equal(writer.trCount))
+	g.Expect(2).To(gomega.Equal(writer.arCount))
+	g.Expect(http.StatusOK).To(gomega.Equal(status))
+	// Prune
+	auth.prune()
+	g.Expect(auth.cache[token]).ToNot(gomega.BeNil())
+	time.Sleep(ttl * 2)
+	auth.prune()
+	g.Expect(0).To(gomega.Equal(len(auth.cache)))
+}

--- a/pkg/controller/provider/web/base/client.go
+++ b/pkg/controller/provider/web/base/client.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	liburl "net/url"
 	"reflect"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
 //
@@ -196,8 +197,6 @@ type Param struct {
 type RestClient struct {
 	LibClient
 	Resolver
-	// Bearer token.
-	Token string
 	// Host <host>:<port>
 	Host string
 	// Parameters
@@ -321,12 +320,10 @@ func (c *RestClient) buildTransport() (err error) {
 //
 // Build header.
 func (c *RestClient) buildHeader() {
-	if c.Token == "" {
-		return
-	}
+	cfg, _ := config.GetConfig()
 	c.Header = http.Header{
 		"Authorization": []string{
-			fmt.Sprintf("Bearer %s", c.Token),
+			fmt.Sprintf("Bearer %s", cfg.BearerToken),
 		},
 	}
 }

--- a/pkg/settings/inventory.go
+++ b/pkg/settings/inventory.go
@@ -17,7 +17,7 @@ const (
 const (
 	AllowedOrigins = "CORS_ALLOWED_ORIGINS"
 	WorkingDir     = "WORKING_DIR"
-	AuthOptional   = "AUTH_OPTIONAL"
+	AuthRequired   = "AUTH_REQUIRED"
 	Host           = "API_HOST"
 	Port           = "API_PORT"
 	TLSEnabled     = "API_TLS_ENABLED"
@@ -40,8 +40,8 @@ type Inventory struct {
 	CORS CORS
 	// DB working directory.
 	WorkingDir string
-	// Authorization disabled.
-	AuthOptional bool
+	// Authorization required.
+	AuthRequired bool
 	// Host.
 	Host string
 	// Port
@@ -81,7 +81,7 @@ func (r *Inventory) Load() error {
 		r.WorkingDir = os.TempDir()
 	}
 	// Auth
-	r.AuthOptional = getEnvBool(AuthOptional, false)
+	r.AuthRequired = getEnvBool(AuthRequired, false)
 	// Host
 	if s, found := os.LookupEnv(Host); found {
 		r.Host = s


### PR DESCRIPTION
Token must have verb="*" on the `Provider` CR to access associated endpoints.
Perform TokenReview/SAR.  The API is hit many times per second so the result is cached for 10 seconds to prevent spamming the API server and for better performance.

Requires: https://github.com/konveyor/controller/pull/57

Also fixes some issues related to watching other forklift resources and a SEGV in the plan controller.  These issues introduced in: 
- https://github.com/konveyor/forklift-controller/pull/201
-  https://github.com/konveyor/forklift-controller/pull/194