### PR TITLE
Add OCP provider counts.

### DIFF
--- a/pkg/controller/provider/web/ocp/provider.go
+++ b/pkg/controller/provider/web/ocp/provider.go
@@ -2,6 +2,7 @@ package ocp
 
 import (
 	"github.com/gin-gonic/gin"
+	liberr "github.com/konveyor/controller/pkg/error"
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1"
 	model "github.com/konveyor/forklift-controller/pkg/controller/provider/model/ocp"
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/web/base"
@@ -117,13 +118,29 @@ func (h *ProviderHandler) ListContent(ctx *gin.Context) (content []interface{}, 
 
 //
 // Add counts.
-func (h ProviderHandler) AddCount(r *Provider) error {
+func (h ProviderHandler) AddCount(r *Provider) (err error) {
 	if !h.Detail {
 		return nil
 	}
-
-	//
-	// TODO:
+	db := h.Reconciler.DB()
+	// VM
+	n, err := db.Count(&model.VM{}, nil)
+	if err != nil {
+		return liberr.Wrap(err)
+	}
+	r.VMCount = n
+	// Network
+	n, err = db.Count(&model.NetworkAttachmentDefinition{}, nil)
+	if err != nil {
+		return liberr.Wrap(err)
+	}
+	r.NetworkCount = n + 1
+	// StorageClass
+	n, err = db.Count(&model.StorageClass{}, nil)
+	if err != nil {
+		return liberr.Wrap(err)
+	}
+	r.StorageClassCount = n
 
 	return nil
 }
@@ -142,11 +159,11 @@ func (h ProviderHandler) Link(m *model.Provider) string {
 // REST Resource.
 type Provider struct {
 	Resource
-	Type           string       `json:"type"`
-	Object         api.Provider `json:"object"`
-	VMCount        int64        `json:"vmCount"`
-	NetworkCount   int64        `json:"networkCount"`
-	NamespaceCount int64        `json:"namespaceCount"`
+	Type              string       `json:"type"`
+	Object            api.Provider `json:"object"`
+	VMCount           int64        `json:"vmCount"`
+	NetworkCount      int64        `json:"networkCount"`
+	StorageClassCount int64        `json:"storageClassCount"`
 }
 
 //


### PR DESCRIPTION
Add counts to the OCP provider resource.
- vmCount
- storageClassCount
- networkCount

Looks like Fabien added this in Feb in https://github.com/konveyor/forklift-controller/pull/150 but got accidentally reverted.

Re-add but without namespceCount no longer needed (or relevant).