### PR TITLE
Fix inventory watch handler for Deleted resources.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	github.com/gin-gonic/gin v1.6.3
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.1.0
-	github.com/konveyor/controller v0.3.3
+	github.com/konveyor/controller v0.3.4
 	github.com/onsi/gomega v1.10.3
 	github.com/prometheus/client_golang v1.8.0 // indirect
 	github.com/vmware/govmomi v0.23.1

--- a/go.sum
+++ b/go.sum
@@ -709,6 +709,8 @@ github.com/konveyor/controller v0.3.2 h1:q2r+0Wgmp2wNv6gbi6bcVhftbyttmWnfe0QVhuP
 github.com/konveyor/controller v0.3.2/go.mod h1:TYIj+tCq1ND66/GhXU4pS1ZePNfWZYlqxs57WdWVha8=
 github.com/konveyor/controller v0.3.3 h1:SSeBhetJaaiBkFsNMg1142LOhT0Utw0drNw1Mx8pUlM=
 github.com/konveyor/controller v0.3.3/go.mod h1:TYIj+tCq1ND66/GhXU4pS1ZePNfWZYlqxs57WdWVha8=
+github.com/konveyor/controller v0.3.4 h1:8PKesPq5G53dBt+jsK3K89Pa3xDfZi/jqPfQsLjQGgs=
+github.com/konveyor/controller v0.3.4/go.mod h1:uNotYH/9G9yE/uB4DYz0PsAaMqoq3vDQyQzTXpilxyE=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=

--- a/pkg/controller/map/network/handler/vsphere/handler.go
+++ b/pkg/controller/map/network/handler/vsphere/handler.go
@@ -8,6 +8,7 @@ import (
 	"github.com/konveyor/forklift-controller/pkg/controller/watch/handler"
 	"golang.org/x/net/context"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	"strings"
 )
 
 //
@@ -39,6 +40,20 @@ func (r *Handler) Created(e libweb.Event) {
 }
 
 //
+// Resource created.
+func (r *Handler) Updated(e libweb.Event) {
+	if !r.HasParity() {
+		return
+	}
+	if network, cast := e.Resource.(*vsphere.Network); cast {
+		updated := e.Updated.(*vsphere.Network)
+		if updated.Path != network.Path {
+			r.changed(network, updated)
+		}
+	}
+}
+
+//
 // Resource deleted.
 func (r *Handler) Deleted(e libweb.Event) {
 	if !r.HasParity() {
@@ -53,7 +68,7 @@ func (r *Handler) Deleted(e libweb.Event) {
 // Network changed.
 // Find all of the NetworkMap CRs the reference both the
 // provider and the changed network and enqueue reconcile events.
-func (r *Handler) changed(network *vsphere.Network) {
+func (r *Handler) changed(models ...*vsphere.Network) {
 	list := api.NetworkMapList{}
 	err := r.List(context.TODO(), &list)
 	if err != nil {
@@ -65,17 +80,24 @@ func (r *Handler) changed(network *vsphere.Network) {
 		if !r.MatchProvider(ref) {
 			continue
 		}
-		inventory := r.Inventory()
+		referenced := false
 		for _, pair := range mp.Spec.Map {
 			ref := pair.Source
-			_, err = inventory.Network(&ref)
-			if ref.ID == network.ID {
-				r.Enqueue(event.GenericEvent{
-					Meta:   &mp.ObjectMeta,
-					Object: &mp,
-				})
+			for _, network := range models {
+				if ref.ID == network.ID || strings.HasSuffix(network.Path, ref.Name) {
+					referenced = true
+					break
+				}
+			}
+			if referenced {
 				break
 			}
+		}
+		if referenced {
+			r.Enqueue(event.GenericEvent{
+				Meta:   &mp.ObjectMeta,
+				Object: &mp,
+			})
 		}
 	}
 }

--- a/pkg/controller/provider/controller.go
+++ b/pkg/controller/provider/controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	libcnd "github.com/konveyor/controller/pkg/condition"
 	liberr "github.com/konveyor/controller/pkg/error"
+	libfb "github.com/konveyor/controller/pkg/filebacked"
 	libcontainer "github.com/konveyor/controller/pkg/inventory/container"
 	libmodel "github.com/konveyor/controller/pkg/inventory/model"
 	libweb "github.com/konveyor/controller/pkg/inventory/web"
@@ -67,6 +68,7 @@ var log = logging.WithName(Name)
 var Settings = &settings.Settings
 
 func init() {
+	libfb.WorkingDir = Settings.WorkingDir
 	container.Log = &log
 	web.Log = &log
 	model.Log = &log


### PR DESCRIPTION
Fix inventory watch handler for `Deleted` resources.  The logic that resolves the Refs in each CR is flawed because in the case of a `Deleted` resource, the lookup will never be successful which results in the affected CR never being matched.  This logic replaced with _smart_ comparison of the Ref to the deleted/changed resource.  This does not affect OCP resources.

Also, noticed that the predicate should be handling renamed vSphere resources.