### PR TITLE
Better logging

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -17,8 +17,10 @@ limitations under the License.
 package main
 
 import (
+	"github.com/konveyor/controller/pkg/logging"
 	"github.com/konveyor/forklift-controller/pkg/settings"
 	"os"
+	"strconv"
 
 	net "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	"github.com/konveyor/forklift-controller/pkg/apis"
@@ -41,7 +43,16 @@ import (
 var Settings = &settings.Settings
 
 func main() {
-	logf.SetLogger(logf.ZapLogger(false))
+	development := false
+	if s, found := os.LookupEnv(logging.EnvDevelopment); found {
+		parsed, err := strconv.ParseBool(s)
+		if err == nil {
+			development = parsed
+		}
+	}
+
+	logf.SetLogger(logf.ZapLogger(development))
+
 	log := logf.Log.WithName("entrypoint")
 
 	// Load settings.

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,9 @@ go 1.14
 
 require (
 	github.com/gin-gonic/gin v1.6.3
+	github.com/go-logr/logr v0.3.0
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.1.0
-	github.com/konveyor/controller v0.3.4
+	github.com/konveyor/controller v0.3.5
 	github.com/onsi/gomega v1.10.3
 	github.com/prometheus/client_golang v1.8.0 // indirect
 	github.com/vmware/govmomi v0.23.1
@@ -13,6 +14,7 @@ require (
 	gopkg.in/yaml.v2 v2.3.0
 	k8s.io/api v0.19.3
 	k8s.io/apimachinery v0.19.3
+	k8s.io/apiserver v0.19.3
 	k8s.io/client-go v12.0.0+incompatible
 	kubevirt.io/client-go v0.33.0
 	kubevirt.io/containerized-data-importer v1.27.0

--- a/go.sum
+++ b/go.sum
@@ -711,6 +711,8 @@ github.com/konveyor/controller v0.3.3 h1:SSeBhetJaaiBkFsNMg1142LOhT0Utw0drNw1Mx8
 github.com/konveyor/controller v0.3.3/go.mod h1:TYIj+tCq1ND66/GhXU4pS1ZePNfWZYlqxs57WdWVha8=
 github.com/konveyor/controller v0.3.4 h1:8PKesPq5G53dBt+jsK3K89Pa3xDfZi/jqPfQsLjQGgs=
 github.com/konveyor/controller v0.3.4/go.mod h1:uNotYH/9G9yE/uB4DYz0PsAaMqoq3vDQyQzTXpilxyE=
+github.com/konveyor/controller v0.3.5 h1:+G1rLpylkFVjmdPqo2QqAIGCHrBjPyhoN2NGPGkSQZo=
+github.com/konveyor/controller v0.3.5/go.mod h1:j0DSNesS0XHmqOLcJEuwB+qIRkdJ3mSIEJFA2byC12c=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=

--- a/pkg/controller/map/network/controller.go
+++ b/pkg/controller/map/network/controller.go
@@ -27,6 +27,7 @@ import (
 	"github.com/konveyor/forklift-controller/pkg/settings"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -62,6 +63,7 @@ func Add(mgr manager.Manager) error {
 		EventRecorder: mgr.GetEventRecorderFor(Name),
 		Client:        mgr.GetClient(),
 		scheme:        mgr.GetScheme(),
+		log:           log,
 	}
 	cnt, err := controller.New(
 		Name,
@@ -98,7 +100,7 @@ func Add(mgr manager.Manager) error {
 		&source.Kind{
 			Type: &api.Provider{},
 		},
-		libref.Handler(),
+		libref.Handler(&api.NetworkMap{}),
 		&ProviderPredicate{
 			client:  mgr.GetClient(),
 			channel: channel,
@@ -116,27 +118,36 @@ var _ reconcile.Reconciler = &Reconciler{}
 //
 // Reconciles a Map object.
 type Reconciler struct {
+	record.EventRecorder
 	client.Client
 	scheme *runtime.Scheme
-	record.EventRecorder
+	log    *logging.Logger
 }
 
 //
 // Reconcile a Map CR.
-func (r *Reconciler) Reconcile(request reconcile.Request) (result reconcile.Result, err error) {
+// Note: Must not a pointer receiver to ensure that the
+// logger and other state is not shared.
+func (r Reconciler) Reconcile(request reconcile.Request) (result reconcile.Result, err error) {
 	fastReQ := reconcile.Result{RequeueAfter: FastReQ}
 	slowReQ := reconcile.Result{RequeueAfter: SlowReQ}
 	noReQ := reconcile.Result{}
 	result = noReQ
 
-	// Reset the logger.
-	log.Reset()
-	log.SetValues("map", request)
-	log.Info("Reconcile")
+	r.log = logging.WithName(
+		names.SimpleNameGenerator.GenerateName(Name+"|"),
+		"map",
+		request)
+
+	r.log.Info("Reconcile")
 
 	defer func() {
 		if err != nil {
-			log.Trace(err)
+			if k8serr.IsConflict(err) {
+				r.log.Info(err.Error())
+			} else {
+				r.log.Trace(err)
+			}
 			err = nil
 		}
 	}()
@@ -151,7 +162,7 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (result reconcile.Resu
 		return
 	}
 	defer func() {
-		log.Info("Conditions.", "all", mp.Status.Conditions)
+		r.log.Info("Conditions.", "all", mp.Status.Conditions)
 	}()
 
 	// Begin staging conditions.
@@ -189,7 +200,6 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (result reconcile.Resu
 	mp.Status.ObservedGeneration = mp.Generation
 	err = r.Status().Update(context.TODO(), mp)
 	if err != nil {
-		log.Trace(err)
 		result = fastReQ
 		return
 	}

--- a/pkg/controller/map/storage/controller.go
+++ b/pkg/controller/map/storage/controller.go
@@ -27,6 +27,7 @@ import (
 	"github.com/konveyor/forklift-controller/pkg/settings"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -57,11 +58,14 @@ var Settings = &settings.Settings
 
 //
 // Creates a new Map Controller and adds it to the Manager.
+// Note: Must not a pointer receiver to ensure that the
+// logger and other state is not shared.
 func Add(mgr manager.Manager) error {
 	reconciler := &Reconciler{
 		EventRecorder: mgr.GetEventRecorderFor(Name),
 		Client:        mgr.GetClient(),
 		scheme:        mgr.GetScheme(),
+		log:           log,
 	}
 	cnt, err := controller.New(
 		Name,
@@ -98,7 +102,7 @@ func Add(mgr manager.Manager) error {
 		&source.Kind{
 			Type: &api.Provider{},
 		},
-		libref.Handler(),
+		libref.Handler(&api.StorageMap{}),
 		&ProviderPredicate{
 			client:  mgr.GetClient(),
 			channel: channel,
@@ -116,27 +120,36 @@ var _ reconcile.Reconciler = &Reconciler{}
 //
 // Reconciles a Map object.
 type Reconciler struct {
+	record.EventRecorder
 	client.Client
 	scheme *runtime.Scheme
-	record.EventRecorder
+	log    *logging.Logger
 }
 
 //
 // Reconcile a Map CR.
-func (r *Reconciler) Reconcile(request reconcile.Request) (result reconcile.Result, err error) {
+// Note: Must not a pointer receiver to ensure that the
+// logger and other state is not shared.
+func (r Reconciler) Reconcile(request reconcile.Request) (result reconcile.Result, err error) {
 	fastReQ := reconcile.Result{RequeueAfter: FastReQ}
 	slowReQ := reconcile.Result{RequeueAfter: SlowReQ}
 	noReQ := reconcile.Result{}
 	result = noReQ
 
-	// Reset the logger.
-	log.Reset()
-	log.SetValues("map", request.Name)
-	log.Info("Reconcile")
+	r.log = logging.WithName(
+		names.SimpleNameGenerator.GenerateName(Name+"|"),
+		"map",
+		request)
+
+	r.log.Info("Reconcile")
 
 	defer func() {
 		if err != nil {
-			log.Trace(err)
+			if k8serr.IsConflict(err) {
+				r.log.Info(err.Error())
+			} else {
+				r.log.Trace(err)
+			}
 			err = nil
 		}
 	}()
@@ -151,7 +164,7 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (result reconcile.Resu
 		return
 	}
 	defer func() {
-		log.Info("Conditions.", "all", mp.Status.Conditions)
+		r.log.Info("Conditions.", "all", mp.Status.Conditions)
 	}()
 
 	// Begin staging conditions.
@@ -189,7 +202,6 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (result reconcile.Resu
 	mp.Status.ObservedGeneration = mp.Generation
 	err = r.Status().Update(context.TODO(), mp)
 	if err != nil {
-		log.Trace(err)
 		result = fastReQ
 		return
 	}

--- a/pkg/controller/provider/container/doc.go
+++ b/pkg/controller/provider/container/doc.go
@@ -3,21 +3,11 @@ package container
 import (
 	libcontainer "github.com/konveyor/controller/pkg/inventory/container"
 	libmodel "github.com/konveyor/controller/pkg/inventory/model"
-	"github.com/konveyor/controller/pkg/logging"
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1"
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/container/ocp"
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/container/vsphere"
 	core "k8s.io/api/core/v1"
 )
-
-//
-// Shared logger.
-var Log *logging.Logger
-
-func init() {
-	log := logging.WithName("container")
-	Log = &log
-}
 
 //
 // Build
@@ -28,10 +18,8 @@ func Build(
 	//
 	switch provider.Type() {
 	case api.OpenShift:
-		ocp.Log = Log
 		return ocp.New(db, provider, secret)
 	case api.VSphere:
-		vsphere.Log = Log
 		return vsphere.New(db, provider, secret)
 	}
 

--- a/pkg/controller/provider/container/ocp/collection.go
+++ b/pkg/controller/provider/container/ocp/collection.go
@@ -2,6 +2,7 @@ package ocp
 
 import (
 	"context"
+	"github.com/go-logr/logr"
 	net "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	liberr "github.com/konveyor/controller/pkg/error"
 	libocp "github.com/konveyor/controller/pkg/inventory/container/ocp"
@@ -18,6 +19,7 @@ import (
 // StorageClass
 type StorageClass struct {
 	libocp.BaseCollection
+	log logr.Logger
 }
 
 //
@@ -53,7 +55,7 @@ func (r *StorageClass) Reconcile(ctx context.Context) (err error) {
 		m := &model.StorageClass{}
 		m.With(&resource)
 		r.Reconciler.UpdateThreshold(m)
-		Log.Info("Create", libref.ToKind(m), m.String())
+		r.log.Info("Create", libref.ToKind(m), m.String())
 		err = tx.Insert(m)
 		if err != nil {
 			err = liberr.Wrap(err)
@@ -121,6 +123,7 @@ func (r *StorageClass) Generic(e event.GenericEvent) bool {
 // NetworkAttachmentDefinition
 type NetworkAttachmentDefinition struct {
 	libocp.BaseCollection
+	log logr.Logger
 }
 
 //
@@ -156,7 +159,7 @@ func (r *NetworkAttachmentDefinition) Reconcile(ctx context.Context) (err error)
 		m := &model.NetworkAttachmentDefinition{}
 		m.With(&resource)
 		r.Reconciler.UpdateThreshold(m)
-		Log.Info("Create", libref.ToKind(m), m.String())
+		r.log.Info("Create", libref.ToKind(m), m.String())
 		err = tx.Insert(m)
 		if err != nil {
 			err = liberr.Wrap(err)
@@ -224,6 +227,7 @@ func (r *NetworkAttachmentDefinition) Generic(e event.GenericEvent) bool {
 // Namespace
 type Namespace struct {
 	libocp.BaseCollection
+	log logr.Logger
 }
 
 //
@@ -259,7 +263,7 @@ func (r *Namespace) Reconcile(ctx context.Context) (err error) {
 		m := &model.Namespace{}
 		m.With(&resource)
 		r.Reconciler.UpdateThreshold(m)
-		Log.Info("Create", libref.ToKind(m), m.String())
+		r.log.Info("Create", libref.ToKind(m), m.String())
 		err = tx.Insert(m)
 		if err != nil {
 			err = liberr.Wrap(err)
@@ -327,6 +331,7 @@ func (r *Namespace) Generic(e event.GenericEvent) bool {
 // VM
 type VM struct {
 	libocp.BaseCollection
+	log logr.Logger
 }
 
 //
@@ -362,7 +367,7 @@ func (r *VM) Reconcile(ctx context.Context) (err error) {
 		m := &model.VM{}
 		m.With(&resource)
 		r.Reconciler.UpdateThreshold(m)
-		Log.Info("Create", libref.ToKind(m), m.String())
+		r.log.Info("Create", libref.ToKind(m), m.String())
 		err = tx.Insert(m)
 		if err != nil {
 			err = liberr.Wrap(err)

--- a/pkg/controller/provider/container/ocp/doc.go
+++ b/pkg/controller/provider/container/ocp/doc.go
@@ -1,14 +1,1 @@
 package ocp
-
-import (
-	"github.com/konveyor/controller/pkg/logging"
-)
-
-//
-// Shared logger.
-var Log *logging.Logger
-
-func init() {
-	log := logging.WithName("ocp")
-	Log = &log
-}

--- a/pkg/controller/provider/container/ocp/reconciler.go
+++ b/pkg/controller/provider/container/ocp/reconciler.go
@@ -4,8 +4,10 @@ import (
 	libcontainer "github.com/konveyor/controller/pkg/inventory/container"
 	libocp "github.com/konveyor/controller/pkg/inventory/container/ocp"
 	libmodel "github.com/konveyor/controller/pkg/inventory/model"
+	"github.com/konveyor/controller/pkg/logging"
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1"
 	core "k8s.io/api/core/v1"
+	"path"
 )
 
 //
@@ -16,10 +18,34 @@ func New(db libmodel.DB, provider *api.Provider, secret *core.Secret) libcontain
 			db,
 			provider,
 			secret,
-			&Namespace{},
-			&NetworkAttachmentDefinition{},
-			&StorageClass{},
-			&VM{}),
+			&Namespace{
+				log: logging.WithName("collection|namespace").WithValues(
+					"provider",
+					path.Join(
+						provider.GetNamespace(),
+						provider.GetName())),
+			},
+			&NetworkAttachmentDefinition{
+				log: logging.WithName("collection|network").WithValues(
+					"provider",
+					path.Join(
+						provider.GetNamespace(),
+						provider.GetName())),
+			},
+			&StorageClass{
+				log: logging.WithName("collection|storageclass").WithValues(
+					"provider",
+					path.Join(
+						provider.GetNamespace(),
+						provider.GetName())),
+			},
+			&VM{
+				log: logging.WithName("collection|vm").WithValues(
+					"provider",
+					path.Join(
+						provider.GetNamespace(),
+						provider.GetName())),
+			}),
 	}
 }
 

--- a/pkg/controller/provider/container/vsphere/doc.go
+++ b/pkg/controller/provider/container/vsphere/doc.go
@@ -1,14 +1,1 @@
 package vsphere
-
-import (
-	"github.com/konveyor/controller/pkg/logging"
-)
-
-//
-// Shared logger.
-var Log *logging.Logger
-
-func init() {
-	log := logging.WithName("vsphere")
-	Log = &log
-}

--- a/pkg/controller/provider/model/doc.go
+++ b/pkg/controller/provider/model/doc.go
@@ -1,32 +1,20 @@
 package model
 
 import (
-	"github.com/konveyor/controller/pkg/logging"
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1"
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/model/ocp"
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/model/vsphere"
 )
 
 //
-// Shared logger.
-var Log *logging.Logger
-
-func init() {
-	log := logging.WithName("model")
-	Log = &log
-}
-
-//
 // All models.
 func Models(provider *api.Provider) (all []interface{}) {
 	switch provider.Type() {
 	case api.OpenShift:
-		ocp.Log = Log
 		all = append(
 			all,
 			ocp.All()...)
 	case api.VSphere:
-		vsphere.Log = Log
 		all = append(
 			all,
 			vsphere.All()...)

--- a/pkg/controller/provider/model/ocp/doc.go
+++ b/pkg/controller/provider/model/ocp/doc.go
@@ -1,16 +1,5 @@
 package ocp
 
-import "github.com/konveyor/controller/pkg/logging"
-
-//
-// Shared logger.
-var Log *logging.Logger
-
-func init() {
-	log := logging.WithName("ocp")
-	Log = &log
-}
-
 //
 // Build all models.
 func All() []interface{} {

--- a/pkg/controller/provider/model/vsphere/doc.go
+++ b/pkg/controller/provider/model/vsphere/doc.go
@@ -1,18 +1,8 @@
 package vsphere
 
 import (
-	"github.com/konveyor/controller/pkg/logging"
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/model/ocp"
 )
-
-//
-// Shared logger.
-var Log *logging.Logger
-
-func init() {
-	log := logging.WithName("vsphere")
-	Log = &log
-}
 
 //
 // Build all models.

--- a/pkg/controller/provider/web/doc.go
+++ b/pkg/controller/provider/web/doc.go
@@ -3,25 +3,14 @@ package web
 import (
 	"github.com/konveyor/controller/pkg/inventory/container"
 	libweb "github.com/konveyor/controller/pkg/inventory/web"
-	"github.com/konveyor/controller/pkg/logging"
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/web/base"
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/web/ocp"
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/web/vsphere"
 )
 
 //
-// Shared logger.
-var Log *logging.Logger
-
-func init() {
-	log := logging.WithName("web")
-	Log = &log
-}
-
-//
 // All handlers.
 func All(container *container.Container) (all []libweb.RequestHandler) {
-	vsphere.Log = Log
 	all = []libweb.RequestHandler{
 		&libweb.SchemaHandler{},
 		&ProviderHandler{

--- a/pkg/controller/provider/web/ocp/base.go
+++ b/pkg/controller/provider/web/ocp/base.go
@@ -3,8 +3,13 @@ package ocp
 import (
 	"github.com/gin-gonic/gin"
 	libmodel "github.com/konveyor/controller/pkg/inventory/model"
+	"github.com/konveyor/controller/pkg/logging"
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/web/base"
 )
+
+//
+// Package logger.
+var log = logging.WithName("web|ocp")
 
 //
 // Params.

--- a/pkg/controller/provider/web/ocp/doc.go
+++ b/pkg/controller/provider/web/ocp/doc.go
@@ -3,7 +3,6 @@ package ocp
 import (
 	"github.com/konveyor/controller/pkg/inventory/container"
 	libweb "github.com/konveyor/controller/pkg/inventory/web"
-	"github.com/konveyor/controller/pkg/logging"
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1"
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/web/base"
 )
@@ -13,15 +12,6 @@ import (
 const (
 	Root = base.ProvidersRoot + "/" + api.OpenShift
 )
-
-//
-// Shared logger.
-var Log *logging.Logger
-
-func init() {
-	log := logging.WithName("web")
-	Log = &log
-}
 
 //
 // Build all handlers.

--- a/pkg/controller/provider/web/ocp/namespace.go
+++ b/pkg/controller/provider/web/ocp/namespace.go
@@ -51,7 +51,10 @@ func (h NamespaceHandler) List(ctx *gin.Context) {
 	list := []model.Namespace{}
 	err := db.List(&list, h.ListOptions(ctx))
 	if err != nil {
-		Log.Trace(err)
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
 		ctx.Status(http.StatusInternalServerError)
 		return
 	}
@@ -86,7 +89,10 @@ func (h NamespaceHandler) Get(ctx *gin.Context) {
 		return
 	}
 	if err != nil {
-		Log.Trace(err)
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
 		ctx.Status(http.StatusInternalServerError)
 		return
 	}
@@ -126,7 +132,10 @@ func (h NamespaceHandler) watch(ctx *gin.Context) {
 			return
 		})
 	if err != nil {
-		Log.Trace(err)
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
 		ctx.Status(http.StatusInternalServerError)
 	}
 }

--- a/pkg/controller/provider/web/ocp/netattachdefinition.go
+++ b/pkg/controller/provider/web/ocp/netattachdefinition.go
@@ -52,7 +52,10 @@ func (h NadHandler) List(ctx *gin.Context) {
 	list := []model.NetworkAttachmentDefinition{}
 	err := db.List(&list, h.ListOptions(ctx))
 	if err != nil {
-		Log.Trace(err)
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
 		ctx.Status(http.StatusInternalServerError)
 		return
 	}
@@ -87,7 +90,10 @@ func (h NadHandler) Get(ctx *gin.Context) {
 		return
 	}
 	if err != nil {
-		Log.Trace(err)
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
 		ctx.Status(http.StatusInternalServerError)
 		return
 	}
@@ -127,7 +133,10 @@ func (h NadHandler) watch(ctx *gin.Context) {
 			return
 		})
 	if err != nil {
-		Log.Trace(err)
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
 		ctx.Status(http.StatusInternalServerError)
 	}
 }

--- a/pkg/controller/provider/web/ocp/provider.go
+++ b/pkg/controller/provider/web/ocp/provider.go
@@ -41,7 +41,10 @@ func (h ProviderHandler) List(ctx *gin.Context) {
 	}
 	content, err := h.ListContent(ctx)
 	if err != nil {
-		Log.Trace(err)
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
 		ctx.Status(http.StatusInternalServerError)
 		return
 	}
@@ -68,7 +71,10 @@ func (h ProviderHandler) Get(ctx *gin.Context) {
 	r.With(m)
 	err := h.AddCount(&r)
 	if err != nil {
-		Log.Trace(err)
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
 		ctx.Status(http.StatusInternalServerError)
 		return
 	}

--- a/pkg/controller/provider/web/ocp/storageclass.go
+++ b/pkg/controller/provider/web/ocp/storageclass.go
@@ -52,7 +52,10 @@ func (h StorageClassHandler) List(ctx *gin.Context) {
 	list := []model.StorageClass{}
 	err := db.List(&list, h.ListOptions(ctx))
 	if err != nil {
-		Log.Trace(err)
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
 		ctx.Status(http.StatusInternalServerError)
 		return
 	}
@@ -87,7 +90,10 @@ func (h StorageClassHandler) Get(ctx *gin.Context) {
 		return
 	}
 	if err != nil {
-		Log.Trace(err)
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
 		ctx.Status(http.StatusInternalServerError)
 		return
 	}
@@ -127,7 +133,10 @@ func (h StorageClassHandler) watch(ctx *gin.Context) {
 			return
 		})
 	if err != nil {
-		Log.Trace(err)
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
 		ctx.Status(http.StatusInternalServerError)
 	}
 }

--- a/pkg/controller/provider/web/ocp/vm.go
+++ b/pkg/controller/provider/web/ocp/vm.go
@@ -52,7 +52,10 @@ func (h VMHandler) List(ctx *gin.Context) {
 	list := []model.VM{}
 	err := db.List(&list, h.ListOptions(ctx))
 	if err != nil {
-		Log.Trace(err)
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
 		ctx.Status(http.StatusInternalServerError)
 		return
 	}
@@ -87,7 +90,10 @@ func (h VMHandler) Get(ctx *gin.Context) {
 		return
 	}
 	if err != nil {
-		Log.Trace(err)
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
 		ctx.Status(http.StatusInternalServerError)
 		return
 	}
@@ -127,7 +133,10 @@ func (h VMHandler) watch(ctx *gin.Context) {
 			return
 		})
 	if err != nil {
-		Log.Trace(err)
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
 		ctx.Status(http.StatusInternalServerError)
 	}
 }

--- a/pkg/controller/provider/web/provider.go
+++ b/pkg/controller/provider/web/provider.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/konveyor/controller/pkg/logging"
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1"
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/web/base"
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/web/ocp"
@@ -9,6 +10,10 @@ import (
 
 	"net/http"
 )
+
+//
+// Package logger.
+var log = logging.WithName("web|provider")
 
 //
 // Routes.
@@ -50,7 +55,10 @@ func (h ProviderHandler) List(ctx *gin.Context) {
 	}
 	ocpList, err := ocpHandler.ListContent(ctx)
 	if err != nil {
-		Log.Trace(err)
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
 		ctx.Status(http.StatusInternalServerError)
 		return
 	}
@@ -67,7 +75,10 @@ func (h ProviderHandler) List(ctx *gin.Context) {
 	}
 	vSphereList, err := vSphereHandler.ListContent(ctx)
 	if err != nil {
-		Log.Trace(err)
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
 		ctx.Status(http.StatusInternalServerError)
 		return
 	}

--- a/pkg/controller/provider/web/vsphere/base.go
+++ b/pkg/controller/provider/web/vsphere/base.go
@@ -3,9 +3,14 @@ package vsphere
 import (
 	"github.com/gin-gonic/gin"
 	libmodel "github.com/konveyor/controller/pkg/inventory/model"
+	"github.com/konveyor/controller/pkg/logging"
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/web/base"
 	"strings"
 )
+
+//
+// Package logger.
+var log = logging.WithName("web|vsphere")
 
 //
 // Fields.

--- a/pkg/controller/provider/web/vsphere/cluster.go
+++ b/pkg/controller/provider/web/vsphere/cluster.go
@@ -54,7 +54,10 @@ func (h ClusterHandler) List(ctx *gin.Context) {
 	list := []model.Cluster{}
 	err := db.List(&list, h.ListOptions(ctx))
 	if err != nil {
-		Log.Trace(err)
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
 		ctx.Status(http.StatusInternalServerError)
 		return
 	}
@@ -89,7 +92,10 @@ func (h ClusterHandler) Get(ctx *gin.Context) {
 		return
 	}
 	if err != nil {
-		Log.Trace(err)
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
 		ctx.Status(http.StatusInternalServerError)
 		return
 	}
@@ -97,8 +103,10 @@ func (h ClusterHandler) Get(ctx *gin.Context) {
 	r.With(m)
 	r.Path, err = m.Path(db)
 	if err != nil {
-		Log.Trace(err)
-		ctx.Status(http.StatusInternalServerError)
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
 		return
 	}
 	r.SelfLink = h.Link(h.Provider, m)
@@ -136,7 +144,10 @@ func (h ClusterHandler) watch(ctx *gin.Context) {
 			return
 		})
 	if err != nil {
-		Log.Trace(err)
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
 		ctx.Status(http.StatusInternalServerError)
 	}
 }

--- a/pkg/controller/provider/web/vsphere/datacenter.go
+++ b/pkg/controller/provider/web/vsphere/datacenter.go
@@ -54,7 +54,10 @@ func (h DatacenterHandler) List(ctx *gin.Context) {
 	list := []model.Datacenter{}
 	err := db.List(&list, h.ListOptions(ctx))
 	if err != nil {
-		Log.Trace(err)
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
 		ctx.Status(http.StatusInternalServerError)
 		return
 	}
@@ -89,7 +92,10 @@ func (h DatacenterHandler) Get(ctx *gin.Context) {
 		return
 	}
 	if err != nil {
-		Log.Trace(err)
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
 		ctx.Status(http.StatusInternalServerError)
 		return
 	}
@@ -97,7 +103,10 @@ func (h DatacenterHandler) Get(ctx *gin.Context) {
 	r.With(m)
 	r.Path, err = m.Path(db)
 	if err != nil {
-		Log.Trace(err)
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
 		ctx.Status(http.StatusInternalServerError)
 		return
 	}
@@ -136,7 +145,10 @@ func (h DatacenterHandler) watch(ctx *gin.Context) {
 			return
 		})
 	if err != nil {
-		Log.Trace(err)
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
 		ctx.Status(http.StatusInternalServerError)
 	}
 }

--- a/pkg/controller/provider/web/vsphere/datastore.go
+++ b/pkg/controller/provider/web/vsphere/datastore.go
@@ -53,14 +53,20 @@ func (h DatastoreHandler) List(ctx *gin.Context) {
 	list := []model.Datastore{}
 	err := db.List(&list, h.ListOptions(ctx))
 	if err != nil {
-		Log.Trace(err)
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
 		ctx.Status(http.StatusInternalServerError)
 		return
 	}
 	content := []interface{}{}
 	err = h.filter(ctx, &list)
 	if err != nil {
-		Log.Trace(err)
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
 		ctx.Status(http.StatusInternalServerError)
 		return
 	}
@@ -94,7 +100,10 @@ func (h DatastoreHandler) Get(ctx *gin.Context) {
 		return
 	}
 	if err != nil {
-		Log.Trace(err)
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
 		ctx.Status(http.StatusInternalServerError)
 		return
 	}
@@ -102,7 +111,10 @@ func (h DatastoreHandler) Get(ctx *gin.Context) {
 	r.With(m)
 	r.Path, err = m.Path(db)
 	if err != nil {
-		Log.Trace(err)
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
 		ctx.Status(http.StatusInternalServerError)
 		return
 	}
@@ -141,7 +153,10 @@ func (h DatastoreHandler) watch(ctx *gin.Context) {
 			return
 		})
 	if err != nil {
-		Log.Trace(err)
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
 		ctx.Status(http.StatusInternalServerError)
 	}
 }

--- a/pkg/controller/provider/web/vsphere/doc.go
+++ b/pkg/controller/provider/web/vsphere/doc.go
@@ -3,7 +3,6 @@ package vsphere
 import (
 	"github.com/konveyor/controller/pkg/inventory/container"
 	libweb "github.com/konveyor/controller/pkg/inventory/web"
-	"github.com/konveyor/controller/pkg/logging"
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1"
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/web/base"
 )
@@ -13,15 +12,6 @@ import (
 const (
 	Root = base.ProvidersRoot + "/" + api.VSphere
 )
-
-//
-// Shared logger.
-var Log *logging.Logger
-
-func init() {
-	log := logging.WithName("web")
-	Log = &log
-}
 
 //
 // Build all handlers.

--- a/pkg/controller/provider/web/vsphere/folder.go
+++ b/pkg/controller/provider/web/vsphere/folder.go
@@ -54,7 +54,10 @@ func (h FolderHandler) List(ctx *gin.Context) {
 	list := []model.Folder{}
 	err := db.List(&list, h.ListOptions(ctx))
 	if err != nil {
-		Log.Trace(err)
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
 		ctx.Status(http.StatusInternalServerError)
 		return
 	}
@@ -89,7 +92,10 @@ func (h FolderHandler) Get(ctx *gin.Context) {
 		return
 	}
 	if err != nil {
-		Log.Trace(err)
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
 		ctx.Status(http.StatusInternalServerError)
 		return
 	}
@@ -97,7 +103,10 @@ func (h FolderHandler) Get(ctx *gin.Context) {
 	r.With(m)
 	r.Path, err = m.Path(db)
 	if err != nil {
-		Log.Trace(err)
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
 		ctx.Status(http.StatusInternalServerError)
 		return
 	}
@@ -136,7 +145,10 @@ func (h FolderHandler) watch(ctx *gin.Context) {
 			return
 		})
 	if err != nil {
-		Log.Trace(err)
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
 		ctx.Status(http.StatusInternalServerError)
 	}
 }

--- a/pkg/controller/provider/web/vsphere/host.go
+++ b/pkg/controller/provider/web/vsphere/host.go
@@ -54,13 +54,19 @@ func (h HostHandler) List(ctx *gin.Context) {
 	list := []model.Host{}
 	err := db.List(&list, h.ListOptions(ctx))
 	if err != nil {
-		Log.Trace(err)
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
 		ctx.Status(http.StatusInternalServerError)
 		return
 	}
 	err = h.filter(ctx, &list)
 	if err != nil {
-		Log.Trace(err)
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
 		ctx.Status(http.StatusInternalServerError)
 		return
 	}
@@ -70,7 +76,10 @@ func (h HostHandler) List(ctx *gin.Context) {
 		r.With(&m)
 		err = h.buildAdapters(r)
 		if err != nil {
-			Log.Trace(err)
+			log.Trace(
+				err,
+				"url",
+				ctx.Request.URL)
 			ctx.Status(http.StatusInternalServerError)
 			return
 		}
@@ -102,7 +111,10 @@ func (h HostHandler) Get(ctx *gin.Context) {
 		return
 	}
 	if err != nil {
-		Log.Trace(err)
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
 		ctx.Status(http.StatusInternalServerError)
 		return
 	}
@@ -110,13 +122,19 @@ func (h HostHandler) Get(ctx *gin.Context) {
 	r.With(m)
 	r.Path, err = m.Path(db)
 	if err != nil {
-		Log.Trace(err)
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
 		ctx.Status(http.StatusInternalServerError)
 		return
 	}
 	err = h.buildAdapters(r)
 	if err != nil {
-		Log.Trace(err)
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
 		ctx.Status(http.StatusInternalServerError)
 		return
 	}
@@ -155,7 +173,10 @@ func (h HostHandler) watch(ctx *gin.Context) {
 			return
 		})
 	if err != nil {
-		Log.Trace(err)
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
 		ctx.Status(http.StatusInternalServerError)
 	}
 }

--- a/pkg/controller/provider/web/vsphere/network.go
+++ b/pkg/controller/provider/web/vsphere/network.go
@@ -53,13 +53,19 @@ func (h NetworkHandler) List(ctx *gin.Context) {
 	list := []model.Network{}
 	err := db.List(&list, h.ListOptions(ctx))
 	if err != nil {
-		Log.Trace(err)
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
 		ctx.Status(http.StatusInternalServerError)
 		return
 	}
 	err = h.filter(ctx, &list)
 	if err != nil {
-		Log.Trace(err)
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
 		ctx.Status(http.StatusInternalServerError)
 		return
 	}
@@ -94,7 +100,10 @@ func (h NetworkHandler) Get(ctx *gin.Context) {
 		return
 	}
 	if err != nil {
-		Log.Trace(err)
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
 		ctx.Status(http.StatusInternalServerError)
 		return
 	}
@@ -102,7 +111,10 @@ func (h NetworkHandler) Get(ctx *gin.Context) {
 	r.With(m)
 	r.Path, err = m.Path(db)
 	if err != nil {
-		Log.Trace(err)
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
 		ctx.Status(http.StatusInternalServerError)
 		return
 	}
@@ -141,7 +153,10 @@ func (h NetworkHandler) watch(ctx *gin.Context) {
 			return
 		})
 	if err != nil {
-		Log.Trace(err)
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
 		ctx.Status(http.StatusInternalServerError)
 	}
 }

--- a/pkg/controller/provider/web/vsphere/provider.go
+++ b/pkg/controller/provider/web/vsphere/provider.go
@@ -46,7 +46,10 @@ func (h ProviderHandler) List(ctx *gin.Context) {
 	}
 	content, err := h.ListContent(ctx)
 	if err != nil {
-		Log.Trace(err)
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
 		ctx.Status(http.StatusInternalServerError)
 		return
 	}
@@ -73,7 +76,10 @@ func (h ProviderHandler) Get(ctx *gin.Context) {
 	r.With(m)
 	err := h.AddDerived(&r)
 	if err != nil {
-		Log.Trace(err)
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
 		ctx.Status(http.StatusInternalServerError)
 		return
 	}

--- a/pkg/controller/provider/web/vsphere/tree.go
+++ b/pkg/controller/provider/web/vsphere/tree.go
@@ -47,7 +47,10 @@ func (h *TreeHandler) Prepare(ctx *gin.Context) int {
 			Detail: 1,
 		})
 	if err != nil {
-		Log.Trace(err)
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
 		return http.StatusInternalServerError
 	}
 
@@ -89,7 +92,10 @@ func (h TreeHandler) VmTree(ctx *gin.Context) {
 		}
 		err := db.Get(folder)
 		if err != nil {
-			Log.Trace(err)
+			log.Trace(
+				err,
+				"url",
+				ctx.Request.URL)
 			ctx.Status(http.StatusInternalServerError)
 			return
 		}
@@ -110,7 +116,10 @@ func (h TreeHandler) VmTree(ctx *gin.Context) {
 		}
 		branch, err := tr.Build(folder, navigator)
 		if err != nil {
-			Log.Trace(err)
+			log.Trace(
+				err,
+				"url",
+				ctx.Request.URL)
 			ctx.Status(http.StatusInternalServerError)
 			return
 		}
@@ -148,7 +157,10 @@ func (h TreeHandler) HostTree(ctx *gin.Context) {
 		}
 		err := db.Get(folder)
 		if err != nil {
-			Log.Trace(err)
+			log.Trace(
+				err,
+				"url",
+				ctx.Request.URL)
 			ctx.Status(http.StatusInternalServerError)
 			return
 		}
@@ -175,7 +187,10 @@ func (h TreeHandler) HostTree(ctx *gin.Context) {
 		}
 		branch, err := tr.Build(folder, navigator)
 		if err != nil {
-			Log.Trace(err)
+			log.Trace(
+				err,
+				"url",
+				ctx.Request.URL)
 			ctx.Status(http.StatusInternalServerError)
 			return
 		}

--- a/pkg/controller/provider/web/vsphere/vm.go
+++ b/pkg/controller/provider/web/vsphere/vm.go
@@ -54,14 +54,20 @@ func (h VMHandler) List(ctx *gin.Context) {
 	list := []model.VM{}
 	err := db.List(&list, h.ListOptions(ctx))
 	if err != nil {
-		Log.Trace(err)
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
 		ctx.Status(http.StatusInternalServerError)
 		return
 	}
 	content := []interface{}{}
 	err = h.filter(ctx, &list)
 	if err != nil {
-		Log.Trace(err)
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
 		ctx.Status(http.StatusInternalServerError)
 		return
 	}
@@ -95,7 +101,10 @@ func (h VMHandler) Get(ctx *gin.Context) {
 		return
 	}
 	if err != nil {
-		Log.Trace(err)
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
 		ctx.Status(http.StatusInternalServerError)
 		return
 	}
@@ -103,7 +112,10 @@ func (h VMHandler) Get(ctx *gin.Context) {
 	r.With(m)
 	r.Path, err = m.Path(db)
 	if err != nil {
-		Log.Trace(err)
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
 		ctx.Status(http.StatusInternalServerError)
 		return
 	}
@@ -142,7 +154,10 @@ func (h VMHandler) watch(ctx *gin.Context) {
 			return
 		})
 	if err != nil {
-		Log.Trace(err)
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
 		ctx.Status(http.StatusInternalServerError)
 	}
 }

--- a/pkg/controller/provider/web/vsphere/workload.go
+++ b/pkg/controller/provider/web/vsphere/workload.go
@@ -55,7 +55,10 @@ func (h WorkloadHandler) Get(ctx *gin.Context) {
 		return
 	}
 	if err != nil {
-		Log.Trace(err)
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
 		ctx.Status(http.StatusInternalServerError)
 		return
 	}
@@ -85,7 +88,10 @@ func (h WorkloadHandler) Get(ctx *gin.Context) {
 	}
 	root, err := tr.Ancestry(m, navigator)
 	if err != nil {
-		Log.Trace(err)
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
 		ctx.Status(http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
Logging improved.
Few systemic changes for all controllers and added _some_ logging statements.
- The logging.Logger.Reset() removed so added this logic to reconciler.
- Replaced package level logger with a logger on 1st class objects.  Eg: Reconcile.log.  The Reconciler.Reconcile() method updated to be non-pointer receiver.  This ensures the logger is not shared between _workers_.
- The logging.Logger no longer filters out k8s `Conflict` errors.  Each reconciler needs to do it instead.

Updated the _reference_ watch event handler to be configured with the controller's CR as the _owner_.  This is required to comply with the new signature and to support proper event filtering.


Requires: https://github.com/konveyor/controller/pull/63