### PR TITLE
Bug: 1948965 - Fix storageclass lookup and swallowed error.

### DIFF
--- a/pkg/controller/plan/builder/vsphere/builder.go
+++ b/pkg/controller/plan/builder/vsphere/builder.go
@@ -357,7 +357,7 @@ func (r *Builder) mapping(vm *model.VM) (out *vmio.VmwareMappings, err error) {
 		}
 		mErr := r.defaultModes(&mapped.Destination)
 		if mErr != nil {
-			err = liberr.Wrap(pErr)
+			err = liberr.Wrap(mErr)
 			return
 		}
 		item := vmio.StorageResourceMappingItem{
@@ -467,7 +467,8 @@ func (r *Builder) esxHost(vm *model.VM) (esxHost *EsxHost, found bool, err error
 // Set volume and access modes.
 func (r *Builder) defaultModes(dm *api.DestinationStorage) (err error) {
 	model := &ocp.StorageClass{}
-	err = r.Destination.Inventory.Get(model, dm.StorageClass)
+	ref := ref.Ref{Name: dm.StorageClass}
+	err = r.Destination.Inventory.Find(model, ref)
 	if err != nil {
 		err = liberr.Wrap(err)
 		return

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -309,6 +309,7 @@ func (r *KubeVirt) vmImport(
 	err = r.Builder.Import(vm.Ref, &object.Spec)
 	if err != nil {
 		err = liberr.Wrap(err)
+		return
 	}
 	if vm.Name != "" {
 		object.Spec.TargetVMName = &vm.Name


### PR DESCRIPTION
The StorageClass name lookup needs to be done using `client.Find(model, Ref)` instead of `client.Get(object, id)`.
The VM migration was not failing because the error was not being returned properly.
Best I can tell, ALL of the VMIO CRs would not be created with a storage mapping.

https://bugzilla.redhat.com/show_bug.cgi?id=1948965