### PR TITLE
Skip VMs that are not connected

### DIFF
--- a/pkg/controller/plan/builder/vsphere/builder.go
+++ b/pkg/controller/plan/builder/vsphere/builder.go
@@ -100,6 +100,13 @@ func (r *Builder) Import(vmRef ref.Ref, object *vmio.VirtualMachineImportSpec) (
 				pErr.Error()))
 		return
 	}
+	if types.VirtualMachineConnectionState(vm.ConnectionState) != types.VirtualMachineConnectionStateConnected {
+		err = liberr.New(
+			fmt.Sprintf(
+				"VM %s is not connected",
+				vmRef.String()))
+		return
+	}
 	uuid := vm.UUID
 	object.TargetVMName = &vm.Name
 	start := vm.PowerState == string(types.VirtualMachinePowerStatePoweredOn)

--- a/pkg/controller/provider/container/vsphere/model.go
+++ b/pkg/controller/provider/container/vsphere/model.go
@@ -504,6 +504,10 @@ func (v *VmAdapter) Apply(u types.ObjectUpdate) {
 				if s, cast := p.Val.(types.VirtualMachinePowerState); cast {
 					v.model.PowerState = string(s)
 				}
+			case fConnectionState:
+				if s, cast := p.Val.(types.VirtualMachineConnectionState); cast {
+					v.model.ConnectionState = string(s)
+				}
 			case fSnapshot:
 				if snapshot, cast := p.Val.(types.VirtualMachineSnapshotInfo); cast {
 					ref := snapshot.CurrentSnapshot

--- a/pkg/controller/provider/container/vsphere/reconciler.go
+++ b/pkg/controller/provider/container/vsphere/reconciler.go
@@ -108,6 +108,7 @@ const (
 	fStorageUsed         = "summary.storage.committed"
 	fRuntimeHost         = "runtime.host"
 	fPowerState          = "runtime.powerState"
+	fConnectionState     = "runtime.connectionState"
 	fSnapshot            = "snapshot"
 )
 
@@ -685,6 +686,7 @@ func (r *Reconciler) propertySpec() []types.PropertySpec {
 				fNetwork,
 				fRuntimeHost,
 				fPowerState,
+				fConnectionState,
 				fSnapshot,
 				fChangeTracking,
 			},

--- a/pkg/controller/provider/model/vsphere/model.go
+++ b/pkg/controller/provider/model/vsphere/model.go
@@ -341,6 +341,7 @@ type VM struct {
 	UUID                  string    `sql:""`
 	Firmware              string    `sql:""`
 	PowerState            string    `sql:""`
+	ConnectionState       string    `sql:""`
 	CpuAffinity           []int32   `sql:""`
 	CpuHotAddEnabled      bool      `sql:""`
 	CpuHotRemoveEnabled   bool      `sql:""`

--- a/pkg/controller/provider/web/vsphere/vm.go
+++ b/pkg/controller/provider/web/vsphere/vm.go
@@ -189,6 +189,7 @@ type VM struct {
 	UUID                  string          `json:"uuid"`
 	Firmware              string          `json:"firmware"`
 	PowerState            string          `json:"powerState"`
+	ConnectionState       string          `json:"connectionState"`
 	Snapshot              model.Ref       `json:"snapshot"`
 	ChangeTrackingEnabled bool            `json:"changeTrackingEnabled"`
 	CpuAffinity           []int32         `json:"cpuAffinity"`
@@ -220,6 +221,7 @@ func (r *VM) With(m *model.VM) {
 	r.UUID = m.UUID
 	r.Firmware = m.Firmware
 	r.PowerState = m.PowerState
+	r.ConnectionState = m.ConnectionState
 	r.Snapshot = m.Snapshot
 	r.ChangeTrackingEnabled = m.ChangeTrackingEnabled
 	r.CpuAffinity = m.CpuAffinity


### PR DESCRIPTION
If a VMware VM connection state is not "Connected", the migration will fail. This pull request adds the `ConnectionState` attribute for the VM in the VMware inventory and errors out when building the VirtualMachineImport CR if the value is not `VirtualMachineConnectionStateConnected`.

Fixes #138.