### PR TITLE
More logging.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/gin-gonic/gin v1.6.3
 	github.com/go-logr/logr v0.3.0
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.1.0
-	github.com/konveyor/controller v0.3.5
+	github.com/konveyor/controller v0.3.6
 	github.com/onsi/gomega v1.10.3
 	github.com/prometheus/client_golang v1.8.0 // indirect
 	github.com/vmware/govmomi v0.23.1

--- a/go.sum
+++ b/go.sum
@@ -713,6 +713,8 @@ github.com/konveyor/controller v0.3.4 h1:8PKesPq5G53dBt+jsK3K89Pa3xDfZi/jqPfQsLj
 github.com/konveyor/controller v0.3.4/go.mod h1:uNotYH/9G9yE/uB4DYz0PsAaMqoq3vDQyQzTXpilxyE=
 github.com/konveyor/controller v0.3.5 h1:+G1rLpylkFVjmdPqo2QqAIGCHrBjPyhoN2NGPGkSQZo=
 github.com/konveyor/controller v0.3.5/go.mod h1:j0DSNesS0XHmqOLcJEuwB+qIRkdJ3mSIEJFA2byC12c=
+github.com/konveyor/controller v0.3.6 h1:cq3C0RQyDzb5DYVU7IbhJ2oOL+c993faE8H7QLZJSJs=
+github.com/konveyor/controller v0.3.6/go.mod h1:j0DSNesS0XHmqOLcJEuwB+qIRkdJ3mSIEJFA2byC12c=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=

--- a/pkg/controller/base/controller.go
+++ b/pkg/controller/base/controller.go
@@ -1,0 +1,59 @@
+package base
+
+import (
+	"errors"
+	"github.com/konveyor/controller/pkg/logging"
+	"github.com/konveyor/forklift-controller/pkg/controller/provider/web"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"time"
+)
+
+const (
+	FastReQ = time.Millisecond * 500
+	SlowReQ = time.Second * 3
+	LongReQ = time.Second * 30
+)
+
+//
+// Base reconciler.
+type Reconciler struct {
+	record.EventRecorder
+	client.Client
+	Log *logging.Logger
+}
+
+//
+// Reconcile started.
+func (r *Reconciler) Started() {
+	r.Log.Info("Reconcile started.")
+}
+
+//
+// Reconcile ended.
+func (r *Reconciler) Ended(reQin time.Duration, err error) (reQ time.Duration) {
+	defer r.Log.Info(
+		"Reconcile ended.",
+		"reQ",
+		reQ)
+	reQ = reQin
+	if err == nil {
+		return
+	}
+	reQ = SlowReQ
+	if k8serr.IsConflict(err) {
+		r.Log.Info(err.Error())
+		return
+	}
+	if errors.As(err, &web.ProviderNotReadyError{}) {
+		r.Log.V(1).Info(
+			"Provider inventory not ready.")
+		return
+	}
+	r.Log.Error(
+		err,
+		"Reconcile failed.")
+
+	return
+}

--- a/pkg/controller/base/controller.go
+++ b/pkg/controller/base/controller.go
@@ -2,9 +2,12 @@ package base
 
 import (
 	"errors"
+	libcnd "github.com/konveyor/controller/pkg/condition"
 	"github.com/konveyor/controller/pkg/logging"
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/web"
+	core "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"time"
@@ -56,4 +59,48 @@ func (r *Reconciler) Ended(reQin time.Duration, err error) (reQ time.Duration) {
 		"Reconcile failed.")
 
 	return
+}
+
+//
+// Record for changes in conditions.
+// Logged and recorded as `Event`.
+func (r *Reconciler) Record(object runtime.Object, cnd libcnd.Conditions) {
+	explain := cnd.Explain()
+	record := func(cnd libcnd.Condition) {
+		event := ""
+		switch cnd.Category {
+		case libcnd.Critical,
+			libcnd.Error,
+			libcnd.Warn:
+			event = core.EventTypeWarning
+		default:
+			event = core.EventTypeNormal
+		}
+		r.EventRecorder.Event(
+			object,
+			event,
+			cnd.Type,
+			cnd.Message)
+	}
+	for _, cnd := range explain.Added {
+		r.Log.Info(
+			"Condition added.",
+			"condition",
+			cnd)
+		record(cnd)
+	}
+	for _, cnd := range explain.Updated {
+		r.Log.Info(
+			"Condition updated.",
+			"condition",
+			cnd)
+		record(cnd)
+	}
+	for _, cnd := range explain.Deleted {
+		r.Log.Info(
+			"Condition deleted.",
+			"condition",
+			cnd)
+		record(cnd)
+	}
 }

--- a/pkg/controller/hook/controller.go
+++ b/pkg/controller/hook/controller.go
@@ -18,32 +18,23 @@ package hook
 
 import (
 	"context"
-	"errors"
 	libcnd "github.com/konveyor/controller/pkg/condition"
 	"github.com/konveyor/controller/pkg/logging"
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1"
-	"github.com/konveyor/forklift-controller/pkg/controller/provider/web"
+	"github.com/konveyor/forklift-controller/pkg/controller/base"
 	"github.com/konveyor/forklift-controller/pkg/settings"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/storage/names"
-	"k8s.io/client-go/tools/record"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
-	"time"
 )
 
 const (
-	// Controller name.
+	// Name.
 	Name = "hook"
-	// Fast re-queue delay.
-	FastReQ = time.Millisecond * 500
-	// Slow re-queue delay.
-	SlowReQ = time.Second * 3
 )
 
 //
@@ -58,10 +49,11 @@ var Settings = &settings.Settings
 // Creates a new Hook Controller and adds it to the Manager.
 func Add(mgr manager.Manager) error {
 	reconciler := &Reconciler{
-		EventRecorder: mgr.GetEventRecorderFor(Name),
-		Client:        mgr.GetClient(),
-		scheme:        mgr.GetScheme(),
-		log:           log,
+		Reconciler: base.Reconciler{
+			EventRecorder: mgr.GetEventRecorderFor(Name),
+			Client:        mgr.GetClient(),
+			Log:           log,
+		},
 	}
 	cnt, err := controller.New(
 		Name,
@@ -91,10 +83,7 @@ var _ reconcile.Reconciler = &Reconciler{}
 //
 // Reconciles a Hook object.
 type Reconciler struct {
-	record.EventRecorder
-	client.Client
-	scheme *runtime.Scheme
-	log    *logging.Logger
+	base.Reconciler
 }
 
 //
@@ -102,27 +91,16 @@ type Reconciler struct {
 // Note: Must not a pointer receiver to ensure that the
 // logger and other state is not shared.
 func (r Reconciler) Reconcile(request reconcile.Request) (result reconcile.Result, err error) {
-	fastReQ := reconcile.Result{RequeueAfter: FastReQ}
-	slowReQ := reconcile.Result{RequeueAfter: SlowReQ}
-	noReQ := reconcile.Result{}
-	result = noReQ
-
-	r.log = logging.WithName(
+	r.Log = logging.WithName(
 		names.SimpleNameGenerator.GenerateName(Name+"|"),
 		"hook",
 		request)
-
-	r.log.Info("Reconcile")
-
+	r.Started()
 	defer func() {
-		if err != nil {
-			if k8serr.IsConflict(err) {
-				r.log.Info(err.Error())
-			} else {
-				r.log.Trace(err)
-			}
-			err = nil
-		}
+		result.RequeueAfter = r.Ended(
+			result.RequeueAfter,
+			err)
+		err = nil
 	}()
 
 	// Fetch the CR.
@@ -130,12 +108,13 @@ func (r Reconciler) Reconcile(request reconcile.Request) (result reconcile.Resul
 	err = r.Get(context.TODO(), request.NamespacedName, hook)
 	if err != nil {
 		if k8serr.IsNotFound(err) {
+			r.Log.Info("Hook deleted.")
 			err = nil
 		}
 		return
 	}
 	defer func() {
-		r.log.Info("Conditions.", "all", hook.Status.Conditions)
+		r.Log.Info("Conditions.", "all", hook.Status.Conditions)
 	}()
 
 	// Begin staging conditions.
@@ -144,12 +123,6 @@ func (r Reconciler) Reconcile(request reconcile.Request) (result reconcile.Resul
 	// Validations.
 	err = r.validate(hook)
 	if err != nil {
-		if errors.As(err, &web.ProviderNotReadyError{}) {
-			result = slowReQ
-			err = nil
-		} else {
-			result = fastReQ
-		}
 		return
 	}
 
@@ -173,7 +146,6 @@ func (r Reconciler) Reconcile(request reconcile.Request) (result reconcile.Resul
 	hook.Status.ObservedGeneration = hook.Generation
 	err = r.Status().Update(context.TODO(), hook)
 	if err != nil {
-		result = fastReQ
 		return
 	}
 

--- a/pkg/controller/hook/controller.go
+++ b/pkg/controller/hook/controller.go
@@ -114,7 +114,7 @@ func (r Reconciler) Reconcile(request reconcile.Request) (result reconcile.Resul
 		return
 	}
 	defer func() {
-		r.Log.Info("Conditions.", "all", hook.Status.Conditions)
+		r.Log.V(1).Info("Conditions.", "all", hook.Status.Conditions)
 	}()
 
 	// Begin staging conditions.
@@ -140,7 +140,7 @@ func (r Reconciler) Reconcile(request reconcile.Request) (result reconcile.Resul
 	hook.Status.EndStagingConditions()
 
 	// Record events.
-	hook.Status.RecordEvents(hook, r)
+	r.Record(hook, hook.Status.Conditions)
 
 	// Apply changes.
 	hook.Status.ObservedGeneration = hook.Generation

--- a/pkg/controller/host/controller.go
+++ b/pkg/controller/host/controller.go
@@ -141,7 +141,7 @@ func (r Reconciler) Reconcile(request reconcile.Request) (result reconcile.Resul
 		return
 	}
 	defer func() {
-		r.Log.Info("Conditions.", "all", host.Status.Conditions)
+		r.Log.V(1).Info("Conditions.", "all", host.Status.Conditions)
 	}()
 
 	// Begin staging conditions.
@@ -167,7 +167,7 @@ func (r Reconciler) Reconcile(request reconcile.Request) (result reconcile.Resul
 	host.Status.EndStagingConditions()
 
 	// Record events.
-	host.Status.RecordEvents(host, r)
+	r.Record(host, host.Status.Conditions)
 
 	// Apply changes.
 	host.Status.ObservedGeneration = host.Generation

--- a/pkg/controller/host/validation.go
+++ b/pkg/controller/host/validation.go
@@ -285,7 +285,19 @@ func (r *Reconciler) testConnection(host *api.Host) (err error) {
 			Secret: secret,
 			URL:    url,
 		}
+		r.Log.V(1).Info(
+			"Testing connection.",
+			"url",
+			url)
 		testErr = h.TestConnection()
+		if testErr != nil {
+			r.Log.V(1).Info(
+				"Connection test, failed",
+				"url",
+				url,
+				"reason",
+				testErr.Error())
+		}
 	default:
 		return
 	}

--- a/pkg/controller/map/network/controller.go
+++ b/pkg/controller/map/network/controller.go
@@ -141,7 +141,7 @@ func (r Reconciler) Reconcile(request reconcile.Request) (result reconcile.Resul
 		return
 	}
 	defer func() {
-		r.Log.Info("Conditions.", "all", mp.Status.Conditions)
+		r.Log.V(1).Info("Conditions.", "all", mp.Status.Conditions)
 	}()
 
 	// Begin staging conditions.
@@ -167,7 +167,7 @@ func (r Reconciler) Reconcile(request reconcile.Request) (result reconcile.Resul
 	mp.Status.EndStagingConditions()
 
 	// Record events.
-	mp.Status.RecordEvents(mp, r)
+	r.Record(mp, mp.Status.Conditions)
 
 	// Apply changes.
 	mp.Status.ObservedGeneration = mp.Generation

--- a/pkg/controller/map/network/controller.go
+++ b/pkg/controller/map/network/controller.go
@@ -18,34 +18,25 @@ package network
 
 import (
 	"context"
-	"errors"
 	libcnd "github.com/konveyor/controller/pkg/condition"
 	"github.com/konveyor/controller/pkg/logging"
 	libref "github.com/konveyor/controller/pkg/ref"
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1"
-	"github.com/konveyor/forklift-controller/pkg/controller/provider/web"
+	"github.com/konveyor/forklift-controller/pkg/controller/base"
 	"github.com/konveyor/forklift-controller/pkg/settings"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/storage/names"
-	"k8s.io/client-go/tools/record"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
-	"time"
 )
 
 const (
-	// Controller name.
+	// Name.
 	Name = "network-map"
-	// Fast re-queue delay.
-	FastReQ = time.Millisecond * 500
-	// Slow re-queue delay.
-	SlowReQ = time.Second * 3
 )
 
 //
@@ -60,10 +51,11 @@ var Settings = &settings.Settings
 // Creates a new Map Controller and adds it to the Manager.
 func Add(mgr manager.Manager) error {
 	reconciler := &Reconciler{
-		EventRecorder: mgr.GetEventRecorderFor(Name),
-		Client:        mgr.GetClient(),
-		scheme:        mgr.GetScheme(),
-		log:           log,
+		Reconciler: base.Reconciler{
+			EventRecorder: mgr.GetEventRecorderFor(Name),
+			Client:        mgr.GetClient(),
+			Log:           log,
+		},
 	}
 	cnt, err := controller.New(
 		Name,
@@ -118,10 +110,7 @@ var _ reconcile.Reconciler = &Reconciler{}
 //
 // Reconciles a Map object.
 type Reconciler struct {
-	record.EventRecorder
-	client.Client
-	scheme *runtime.Scheme
-	log    *logging.Logger
+	base.Reconciler
 }
 
 //
@@ -129,27 +118,16 @@ type Reconciler struct {
 // Note: Must not a pointer receiver to ensure that the
 // logger and other state is not shared.
 func (r Reconciler) Reconcile(request reconcile.Request) (result reconcile.Result, err error) {
-	fastReQ := reconcile.Result{RequeueAfter: FastReQ}
-	slowReQ := reconcile.Result{RequeueAfter: SlowReQ}
-	noReQ := reconcile.Result{}
-	result = noReQ
-
-	r.log = logging.WithName(
+	r.Log = logging.WithName(
 		names.SimpleNameGenerator.GenerateName(Name+"|"),
 		"map",
 		request)
-
-	r.log.Info("Reconcile")
-
+	r.Started()
 	defer func() {
-		if err != nil {
-			if k8serr.IsConflict(err) {
-				r.log.Info(err.Error())
-			} else {
-				r.log.Trace(err)
-			}
-			err = nil
-		}
+		result.RequeueAfter = r.Ended(
+			result.RequeueAfter,
+			err)
+		err = nil
 	}()
 
 	// Fetch the CR.
@@ -157,12 +135,13 @@ func (r Reconciler) Reconcile(request reconcile.Request) (result reconcile.Resul
 	err = r.Get(context.TODO(), request.NamespacedName, mp)
 	if err != nil {
 		if k8serr.IsNotFound(err) {
+			r.Log.Info("Host deleted.")
 			err = nil
 		}
 		return
 	}
 	defer func() {
-		r.log.Info("Conditions.", "all", mp.Status.Conditions)
+		r.Log.Info("Conditions.", "all", mp.Status.Conditions)
 	}()
 
 	// Begin staging conditions.
@@ -171,12 +150,6 @@ func (r Reconciler) Reconcile(request reconcile.Request) (result reconcile.Resul
 	// Validations.
 	err = r.validate(mp)
 	if err != nil {
-		if errors.As(err, &web.ProviderNotReadyError{}) {
-			result = slowReQ
-			err = nil
-		} else {
-			result = fastReQ
-		}
 		return
 	}
 
@@ -200,7 +173,6 @@ func (r Reconciler) Reconcile(request reconcile.Request) (result reconcile.Resul
 	mp.Status.ObservedGeneration = mp.Generation
 	err = r.Status().Update(context.TODO(), mp)
 	if err != nil {
-		result = fastReQ
 		return
 	}
 

--- a/pkg/controller/map/storage/controller.go
+++ b/pkg/controller/map/storage/controller.go
@@ -18,34 +18,25 @@ package storage
 
 import (
 	"context"
-	"errors"
 	libcnd "github.com/konveyor/controller/pkg/condition"
 	"github.com/konveyor/controller/pkg/logging"
 	libref "github.com/konveyor/controller/pkg/ref"
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1"
-	"github.com/konveyor/forklift-controller/pkg/controller/provider/web"
+	"github.com/konveyor/forklift-controller/pkg/controller/base"
 	"github.com/konveyor/forklift-controller/pkg/settings"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/storage/names"
-	"k8s.io/client-go/tools/record"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
-	"time"
 )
 
 const (
-	// Controller name.
+	// Name.
 	Name = "storage-map"
-	// Fast re-queue delay.
-	FastReQ = time.Millisecond * 500
-	// Slow re-queue delay.
-	SlowReQ = time.Second * 3
 )
 
 //
@@ -62,10 +53,11 @@ var Settings = &settings.Settings
 // logger and other state is not shared.
 func Add(mgr manager.Manager) error {
 	reconciler := &Reconciler{
-		EventRecorder: mgr.GetEventRecorderFor(Name),
-		Client:        mgr.GetClient(),
-		scheme:        mgr.GetScheme(),
-		log:           log,
+		Reconciler: base.Reconciler{
+			EventRecorder: mgr.GetEventRecorderFor(Name),
+			Client:        mgr.GetClient(),
+			Log:           log,
+		},
 	}
 	cnt, err := controller.New(
 		Name,
@@ -120,10 +112,7 @@ var _ reconcile.Reconciler = &Reconciler{}
 //
 // Reconciles a Map object.
 type Reconciler struct {
-	record.EventRecorder
-	client.Client
-	scheme *runtime.Scheme
-	log    *logging.Logger
+	base.Reconciler
 }
 
 //
@@ -131,27 +120,16 @@ type Reconciler struct {
 // Note: Must not a pointer receiver to ensure that the
 // logger and other state is not shared.
 func (r Reconciler) Reconcile(request reconcile.Request) (result reconcile.Result, err error) {
-	fastReQ := reconcile.Result{RequeueAfter: FastReQ}
-	slowReQ := reconcile.Result{RequeueAfter: SlowReQ}
-	noReQ := reconcile.Result{}
-	result = noReQ
-
-	r.log = logging.WithName(
+	r.Log = logging.WithName(
 		names.SimpleNameGenerator.GenerateName(Name+"|"),
 		"map",
 		request)
-
-	r.log.Info("Reconcile")
-
+	r.Started()
 	defer func() {
-		if err != nil {
-			if k8serr.IsConflict(err) {
-				r.log.Info(err.Error())
-			} else {
-				r.log.Trace(err)
-			}
-			err = nil
-		}
+		result.RequeueAfter = r.Ended(
+			result.RequeueAfter,
+			err)
+		err = nil
 	}()
 
 	// Fetch the CR.
@@ -159,12 +137,13 @@ func (r Reconciler) Reconcile(request reconcile.Request) (result reconcile.Resul
 	err = r.Get(context.TODO(), request.NamespacedName, mp)
 	if err != nil {
 		if k8serr.IsNotFound(err) {
+			r.Log.Info("Map deleted.")
 			err = nil
 		}
 		return
 	}
 	defer func() {
-		r.log.Info("Conditions.", "all", mp.Status.Conditions)
+		r.Log.Info("Conditions.", "all", mp.Status.Conditions)
 	}()
 
 	// Begin staging conditions.
@@ -176,12 +155,6 @@ func (r Reconciler) Reconcile(request reconcile.Request) (result reconcile.Resul
 	// Validations.
 	err = r.validate(mp)
 	if err != nil {
-		if errors.As(err, &web.ProviderNotReadyError{}) {
-			result = slowReQ
-			err = nil
-		} else {
-			result = fastReQ
-		}
 		return
 	}
 
@@ -202,7 +175,6 @@ func (r Reconciler) Reconcile(request reconcile.Request) (result reconcile.Resul
 	mp.Status.ObservedGeneration = mp.Generation
 	err = r.Status().Update(context.TODO(), mp)
 	if err != nil {
-		result = fastReQ
 		return
 	}
 

--- a/pkg/controller/map/storage/controller.go
+++ b/pkg/controller/map/storage/controller.go
@@ -143,14 +143,14 @@ func (r Reconciler) Reconcile(request reconcile.Request) (result reconcile.Resul
 		return
 	}
 	defer func() {
-		r.Log.Info("Conditions.", "all", mp.Status.Conditions)
+		r.Log.V(1).Info("Conditions.", "all", mp.Status.Conditions)
 	}()
 
 	// Begin staging conditions.
 	mp.Status.BeginStagingConditions()
 
 	// Record events.
-	mp.Status.RecordEvents(mp, r)
+	r.Record(mp, mp.Status.Conditions)
 
 	// Validations.
 	err = r.validate(mp)

--- a/pkg/controller/migration/controller.go
+++ b/pkg/controller/migration/controller.go
@@ -128,7 +128,7 @@ func (r Reconciler) Reconcile(request reconcile.Request) (result reconcile.Resul
 		return
 	}
 	defer func() {
-		r.Log.Info("Conditions.", "all", migration.Status.Conditions)
+		r.Log.V(1).Info("Conditions.", "all", migration.Status.Conditions)
 	}()
 
 	// Detected completed.

--- a/pkg/controller/migration/controller.go
+++ b/pkg/controller/migration/controller.go
@@ -18,32 +18,24 @@ package migration
 
 import (
 	"context"
-	"errors"
 	libcnd "github.com/konveyor/controller/pkg/condition"
 	"github.com/konveyor/controller/pkg/logging"
 	libref "github.com/konveyor/controller/pkg/ref"
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1"
-	"github.com/konveyor/forklift-controller/pkg/controller/provider/web"
+	"github.com/konveyor/forklift-controller/pkg/controller/base"
 	"github.com/konveyor/forklift-controller/pkg/settings"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/storage/names"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
-	"time"
 )
 
 const (
-	// Controller name.
+	// Name.
 	Name = "migration"
-	// Fast re-queue delay.
-	FastReQ = time.Millisecond * 500
-	// Slow re-queue delay.
-	SlowReQ = time.Second * 3
 )
 
 //
@@ -58,9 +50,11 @@ var Settings = &settings.Settings
 // Creates a new Migration Controller and adds it to the Manager.
 func Add(mgr manager.Manager) error {
 	reconciler := &Reconciler{
-		Client: mgr.GetClient(),
-		scheme: mgr.GetScheme(),
-		log:    log,
+		Reconciler: base.Reconciler{
+			EventRecorder: mgr.GetEventRecorderFor(Name),
+			Client:        mgr.GetClient(),
+			Log:           log,
+		},
 	}
 	cnt, err := controller.New(
 		Name,
@@ -103,9 +97,7 @@ var _ reconcile.Reconciler = &Reconciler{}
 //
 // Reconciles a Migration object.
 type Reconciler struct {
-	client.Client
-	scheme *runtime.Scheme
-	log    *logging.Logger
+	base.Reconciler
 }
 
 //
@@ -113,27 +105,16 @@ type Reconciler struct {
 // Note: Must not a pointer receiver to ensure that the
 // logger and other state is not shared.
 func (r Reconciler) Reconcile(request reconcile.Request) (result reconcile.Result, err error) {
-	fastReQ := reconcile.Result{RequeueAfter: FastReQ}
-	slowReQ := reconcile.Result{RequeueAfter: SlowReQ}
-	noReQ := reconcile.Result{}
-	result = noReQ
-
-	r.log = logging.WithName(
+	r.Log = logging.WithName(
 		names.SimpleNameGenerator.GenerateName(Name+"|"),
-		"migration",
+		"map",
 		request)
-
-	r.log.Info("Reconcile")
-
+	r.Started()
 	defer func() {
-		if err != nil {
-			if k8serr.IsConflict(err) {
-				r.log.Info(err.Error())
-			} else {
-				r.log.Trace(err)
-			}
-			err = nil
-		}
+		result.RequeueAfter = r.Ended(
+			result.RequeueAfter,
+			err)
+		err = nil
 	}()
 
 	// Fetch the CR.
@@ -141,17 +122,17 @@ func (r Reconciler) Reconcile(request reconcile.Request) (result reconcile.Resul
 	err = r.Get(context.TODO(), request.NamespacedName, migration)
 	if err != nil {
 		if k8serr.IsNotFound(err) {
+			r.Log.Info("migration deleted.")
 			err = nil
 		}
 		return
 	}
 	defer func() {
-		r.log.Info("Conditions.", "all", migration.Status.Conditions)
+		r.Log.Info("Conditions.", "all", migration.Status.Conditions)
 	}()
 
 	// Detected completed.
 	if migration.Status.MarkedCompleted() {
-		result = noReQ
 		return
 	}
 
@@ -161,12 +142,6 @@ func (r Reconciler) Reconcile(request reconcile.Request) (result reconcile.Resul
 	// Validations.
 	plan, err := r.validate(migration)
 	if err != nil {
-		if errors.As(err, &web.ProviderNotReadyError{}) {
-			result = slowReQ
-			err = nil
-		} else {
-			result = fastReQ
-		}
 		return
 	}
 
@@ -190,7 +165,6 @@ func (r Reconciler) Reconcile(request reconcile.Request) (result reconcile.Resul
 	migration.Status.ObservedGeneration = migration.Generation
 	err = r.Status().Update(context.TODO(), migration)
 	if err != nil {
-		result = fastReQ
 		return
 	}
 

--- a/pkg/controller/migration/controller.go
+++ b/pkg/controller/migration/controller.go
@@ -107,7 +107,7 @@ type Reconciler struct {
 func (r Reconciler) Reconcile(request reconcile.Request) (result reconcile.Result, err error) {
 	r.Log = logging.WithName(
 		names.SimpleNameGenerator.GenerateName(Name+"|"),
-		"map",
+		"migration",
 		request)
 	r.Started()
 	defer func() {

--- a/pkg/controller/plan/controller.go
+++ b/pkg/controller/plan/controller.go
@@ -198,7 +198,7 @@ func (r Reconciler) Reconcile(request reconcile.Request) (result reconcile.Resul
 		return
 	}
 	defer func() {
-		r.Log.Info("Conditions.", "all", plan.Status.Conditions)
+		r.Log.V(1).Info("Conditions.", "all", plan.Status.Conditions)
 	}()
 
 	// Postpone as needed.
@@ -234,7 +234,7 @@ func (r Reconciler) Reconcile(request reconcile.Request) (result reconcile.Resul
 	plan.Status.EndStagingConditions()
 
 	// Record events.
-	plan.Status.RecordEvents(plan, r)
+	r.Record(plan, plan.Status.Conditions)
 
 	// Apply changes.
 	plan.Status.ObservedGeneration = plan.Generation

--- a/pkg/controller/provider/controller.go
+++ b/pkg/controller/provider/controller.go
@@ -60,13 +60,10 @@ var log = logging.WithName(Name)
 // Application settings.
 var Settings = &settings.Settings
 
-func init() {
-	libfb.WorkingDir = Settings.WorkingDir
-}
-
 //
 // Creates a new Inventory Controller and adds it to the Manager.
 func Add(mgr manager.Manager) error {
+	libfb.WorkingDir = Settings.WorkingDir
 	container := libcontainer.New()
 	web := libweb.New(container, web.All(container)...)
 	web.Port = Settings.Inventory.Port
@@ -139,7 +136,7 @@ type Reconciler struct {
 func (r Reconciler) Reconcile(request reconcile.Request) (result reconcile.Result, err error) {
 	r.Log = logging.WithName(
 		names.SimpleNameGenerator.GenerateName(Name+"|"),
-		"hook",
+		"provider",
 		request)
 	r.Started()
 	defer func() {

--- a/pkg/controller/provider/controller.go
+++ b/pkg/controller/provider/controller.go
@@ -169,7 +169,7 @@ func (r Reconciler) Reconcile(request reconcile.Request) (result reconcile.Resul
 	}
 
 	defer func() {
-		r.Log.Info("Conditions.", "all", provider.Status.Conditions)
+		r.Log.V(1).Info("Conditions.", "all", provider.Status.Conditions)
 	}()
 
 	// Updated.
@@ -211,7 +211,7 @@ func (r Reconciler) Reconcile(request reconcile.Request) (result reconcile.Resul
 	provider.Status.EndStagingConditions()
 
 	// Record events.
-	provider.Status.RecordEvents(provider, r)
+	r.Record(provider, provider.Status.Conditions)
 
 	// Apply changes.
 	provider.Status.ObservedGeneration = provider.Generation

--- a/pkg/controller/provider/validation.go
+++ b/pkg/controller/provider/validation.go
@@ -221,6 +221,8 @@ func (r *Reconciler) testConnection(provider *api.Provider, secret *core.Secret)
 	rl := container.Build(nil, provider, secret)
 	err := rl.Test()
 	if err == nil {
+		log.Info(
+			"Connection test succeeded.")
 		provider.Status.SetCondition(
 			libcnd.Condition{
 				Type:     ConnectionTestSucceeded,
@@ -230,6 +232,10 @@ func (r *Reconciler) testConnection(provider *api.Provider, secret *core.Secret)
 				Message:  "Connection test, succeeded.",
 			})
 	} else {
+		log.Info(
+			"Connection test failed.",
+			"reason",
+			err.Error())
 		provider.Status.SetCondition(
 			libcnd.Condition{
 				Type:     ConnectionTestFailed,

--- a/pkg/controller/watch/handler/handler.go
+++ b/pkg/controller/watch/handler/handler.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	libweb "github.com/konveyor/controller/pkg/inventory/web"
+	"github.com/konveyor/controller/pkg/logging"
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1"
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/web"
 	core "k8s.io/api/core/v1"
@@ -9,6 +10,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 )
+
+var log = logging.WithName("watch")
 
 //
 // Generic event.
@@ -76,6 +79,7 @@ func (r *Handler) HasParity() bool {
 //
 // Inventory watch has parity.
 func (r *Handler) Parity() {
+	log.V(1).Info("event: parity.")
 	r.parity = true
 }
 
@@ -83,6 +87,7 @@ func (r *Handler) Parity() {
 // Watch ended by peer.
 // The database has been closed.
 func (r *Handler) End() {
+	log.V(1).Info("event: ended.")
 	r.parity = false
 	r.ended = true
 }
@@ -91,6 +96,10 @@ func (r *Handler) End() {
 // Watch error.
 // Repair the watch.
 func (r *Handler) Error(w *libweb.Watch, err error) {
+	log.Info(
+		"event: error.",
+		"error",
+		err.Error())
 	if !r.ended {
 		_ = w.Repair()
 	}

--- a/pkg/controller/watch/handler/handler.go
+++ b/pkg/controller/watch/handler/handler.go
@@ -29,6 +29,8 @@ type Handler struct {
 	provider *api.Provider
 	// Inventory API client.
 	inventory web.Client
+	// Watch ID.
+	id uint64
 	// Watch ended by peer.
 	ended bool
 	// Parity marker.
@@ -78,18 +80,34 @@ func (r *Handler) HasParity() bool {
 
 //
 // Inventory watch has parity.
+func (r *Handler) Started(id uint64) {
+	r.id = id
+	log.V(1).Info(
+		"event: started.",
+		"id",
+		r.id)
+}
+
+//
+// Inventory watch has parity.
 func (r *Handler) Parity() {
-	log.V(1).Info("event: parity.")
 	r.parity = true
+	log.V(1).Info(
+		"event: parity.",
+		"id",
+		r.id)
 }
 
 //
 // Watch ended by peer.
 // The database has been closed.
 func (r *Handler) End() {
-	log.V(1).Info("event: ended.")
 	r.parity = false
 	r.ended = true
+	log.V(1).Info(
+		"event: ended.",
+		"id",
+		r.id)
 }
 
 //
@@ -98,6 +116,8 @@ func (r *Handler) End() {
 func (r *Handler) Error(w *libweb.Watch, err error) {
 	log.Info(
 		"event: error.",
+		"id",
+		r.id,
 		"error",
 		err.Error())
 	if !r.ended {


### PR DESCRIPTION
Add base reconciler to deduplicate fields and begin/end reconcile behavior and refit controllers.
Add additional logging statements to `controller.go` in each controller.
Add additional logging statements to other top level packages.

Requires:
- https://github.com/konveyor/controller/pull/65
- https://github.com/konveyor/controller/pull/66