### PR TITLE
[BZ 1951395] Warm Migration - Skip VMs with CBT disabled

### DIFF
--- a/pkg/controller/plan/builder/vsphere/builder.go
+++ b/pkg/controller/plan/builder/vsphere/builder.go
@@ -107,6 +107,13 @@ func (r *Builder) Import(vmRef ref.Ref, object *vmio.VirtualMachineImportSpec) (
 				vmRef.String()))
 		return
 	}
+	if r.Plan.Spec.Warm && !vm.changeTrackingEnabled {
+		err = liberr.New(
+			fmt.Sprintf(
+				"Changed Block Tracking (CBT) is disabled for VM %s",
+				vmRef.String()))
+		return
+	}
 	uuid := vm.UUID
 	object.TargetVMName = &vm.Name
 	start := vm.PowerState == string(types.VirtualMachinePowerStatePoweredOn)


### PR DESCRIPTION
When a plan is set to be warm, the VM needs to have Changed Block Tracking (CBT) enabled, in order to identify the delta between two snapshots. Without this feature, the warm migration will not work.

In VMIO, the check for CBT will raise a validation error and requeue, which leaves the migration stuck from a Forklift perspective. So, we decided to add a check in the plan migration builder to fail VMs with CBT disabled directly in the controller. This will avoid creating a VirtualMachineImport CR that will be stuck.

This pull request implements this new behavior.