### PR TITLE
Fix compiler error introduced by pull/223.

### DIFF
--- a/pkg/controller/plan/builder/vsphere/builder.go
+++ b/pkg/controller/plan/builder/vsphere/builder.go
@@ -107,7 +107,7 @@ func (r *Builder) Import(vmRef ref.Ref, object *vmio.VirtualMachineImportSpec) (
 				vmRef.String()))
 		return
 	}
-	if r.Plan.Spec.Warm && !vm.changeTrackingEnabled {
+	if r.Plan.Spec.Warm && !vm.ChangeTrackingEnabled {
 		err = liberr.New(
 			fmt.Sprintf(
 				"Changed Block Tracking (CBT) is disabled for VM %s",


### PR DESCRIPTION
Fix compiler error introduced by [pull/223](https://github.com/konveyor/forklift-controller/pull/223).
```
[jortel@f28a forklift-controller][AWS4]$ make manager
/home/jortel/go/bin/controller-gen object:headerFile="./hack/boilerplate.go.txt" paths="./..."
go fmt ./pkg/... ./cmd/...
go vet ./pkg/... ./cmd/...
# github.com/konveyor/forklift-controller/pkg/controller/plan/builder/vsphere
pkg/controller/plan/builder/vsphere/builder.go:110:28: vm.changeTrackingEnabled undefined (type *"github.com/konveyor/forklift-controller/pkg/controller/provider/web/vsphere".VM has no field or method changeTrackingEnabled, but does have ChangeTrackingEnabled)
make: *** [Makefile:45: vet] Error 2
```