### PR TITLE
Add VM indexes; Install tar in Dockerfile; controller 0.3.4.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,6 @@ LABEL name="konveyor/forklift-controller" \
 
 COPY --from=builder /opt/app-root/src/manager /usr/local/bin/manager
 
+RUN microdnf -y install tar && microdnf clean all
+
 ENTRYPOINT ["/usr/local/bin/manager"]

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/gin-gonic/gin v1.6.3
 	github.com/go-logr/logr v0.3.0
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.1.0
-	github.com/konveyor/controller v0.3.6
+	github.com/konveyor/controller v0.3.7
 	github.com/onsi/gomega v1.10.3
 	github.com/prometheus/client_golang v1.8.0 // indirect
 	github.com/vmware/govmomi v0.23.1

--- a/go.sum
+++ b/go.sum
@@ -715,6 +715,8 @@ github.com/konveyor/controller v0.3.5 h1:+G1rLpylkFVjmdPqo2QqAIGCHrBjPyhoN2NGPGk
 github.com/konveyor/controller v0.3.5/go.mod h1:j0DSNesS0XHmqOLcJEuwB+qIRkdJ3mSIEJFA2byC12c=
 github.com/konveyor/controller v0.3.6 h1:cq3C0RQyDzb5DYVU7IbhJ2oOL+c993faE8H7QLZJSJs=
 github.com/konveyor/controller v0.3.6/go.mod h1:j0DSNesS0XHmqOLcJEuwB+qIRkdJ3mSIEJFA2byC12c=
+github.com/konveyor/controller v0.3.7 h1:6ebqNhoA/kyOT5SnO4xN+vYaAnWf7mPTzLKQjGbSAOs=
+github.com/konveyor/controller v0.3.7/go.mod h1:j0DSNesS0XHmqOLcJEuwB+qIRkdJ3mSIEJFA2byC12c=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=

--- a/pkg/controller/provider/model/vsphere/model.go
+++ b/pkg/controller/provider/model/vsphere/model.go
@@ -27,11 +27,11 @@ type Base struct {
 	// Managed object ID.
 	ID string `sql:"pk"`
 	// Name
-	Name string `sql:"d0,index(b)"`
+	Name string `sql:"d0,index(name)"`
 	// Parent
-	Parent Ref `sql:"d0,index(a)"`
+	Parent Ref `sql:"d0,index(parent)"`
 	// Revision
-	Revision int64 `sql:"d0"`
+	Revision int64 `sql:"d0,index(revision)"`
 }
 
 //
@@ -336,8 +336,8 @@ type Datastore struct {
 
 type VM struct {
 	Base
-	RevisionValidated     int64     `sql:"d0"`
-	PolicyVersion         int       `sql:"d0"`
+	RevisionValidated     int64     `sql:"d0,index(revisionValidated)"`
+	PolicyVersion         int       `sql:"d0,index(policyVersion)"`
 	UUID                  string    `sql:""`
 	Firmware              string    `sql:""`
 	PowerState            string    `sql:""`


### PR DESCRIPTION
Add VM indexes; Install tar in Dockerfile; controller 0.3.4.
The indexes are needed for recurring search for VM that needs to be validated.
`tar` is needed to support `oc cp` command so we can download the files created by the profiler.