### PR TITLE
Detect ensure watch error.

### DIFF
--- a/pkg/apis/forklift/v1alpha1/host.go
+++ b/pkg/apis/forklift/v1alpha1/host.go
@@ -34,7 +34,7 @@ type HostSpec struct {
 	// Certificate SHA-1 fingerprint, called thumbprint by VMware.
 	Thumbprint string `json:"thumbprint,omitempty"`
 	// Credentials.
-	Secret core.ObjectReference `json:"secret"`
+	Secret core.ObjectReference `json:"secret" ref:"Secret"`
 }
 
 //

--- a/pkg/controller/host/controller.go
+++ b/pkg/controller/host/controller.go
@@ -24,6 +24,7 @@ import (
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1alpha1"
 	"github.com/konveyor/forklift-controller/pkg/controller/base"
 	"github.com/konveyor/forklift-controller/pkg/settings"
+	core "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apiserver/pkg/storage/names"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -97,6 +98,15 @@ func Add(mgr manager.Manager) error {
 			client:  mgr.GetClient(),
 			channel: channel,
 		})
+	if err != nil {
+		log.Trace(err)
+		return err
+	}
+	err = cnt.Watch(
+		&source.Kind{
+			Type: &core.Secret{},
+		},
+		libref.Handler(&api.Host{}))
 	if err != nil {
 		log.Trace(err)
 		return err

--- a/pkg/controller/host/handler/vsphere/handler.go
+++ b/pkg/controller/host/handler/vsphere/handler.go
@@ -30,6 +30,9 @@ func (r *Handler) Watch(watch *handler.WatchManager) (err error) {
 		r.Provider(),
 		&vsphere.Host{},
 		r)
+	if err != nil {
+		return
+	}
 
 	log.Info(
 		"Inventory watch ensured.",

--- a/pkg/controller/map/network/handler/ocp/handler.go
+++ b/pkg/controller/map/network/handler/ocp/handler.go
@@ -29,6 +29,9 @@ func (r *Handler) Watch(watch *handler.WatchManager) (err error) {
 		r.Provider(),
 		&ocp.NetworkAttachmentDefinition{},
 		r)
+	if err != nil {
+		return
+	}
 
 	log.Info(
 		"Inventory watch ensured.",

--- a/pkg/controller/map/network/handler/vsphere/handler.go
+++ b/pkg/controller/map/network/handler/vsphere/handler.go
@@ -30,6 +30,9 @@ func (r *Handler) Watch(watch *handler.WatchManager) (err error) {
 		r.Provider(),
 		&vsphere.Network{},
 		r)
+	if err != nil {
+		return
+	}
 
 	log.Info(
 		"Inventory watch ensured.",

--- a/pkg/controller/map/storage/handler/ocp/handler.go
+++ b/pkg/controller/map/storage/handler/ocp/handler.go
@@ -29,6 +29,9 @@ func (r *Handler) Watch(watch *handler.WatchManager) (err error) {
 		r.Provider(),
 		&ocp.StorageClass{},
 		r)
+	if err != nil {
+		return
+	}
 
 	log.Info(
 		"Inventory watch ensured.",

--- a/pkg/controller/map/storage/handler/vsphere/handler.go
+++ b/pkg/controller/map/storage/handler/vsphere/handler.go
@@ -30,6 +30,9 @@ func (r *Handler) Watch(watch *handler.WatchManager) (err error) {
 		r.Provider(),
 		&vsphere.Datastore{},
 		r)
+	if err != nil {
+		return
+	}
 
 	log.Info(
 		"Inventory watch ensured.",

--- a/pkg/controller/plan/handler/ocp/handler.go
+++ b/pkg/controller/plan/handler/ocp/handler.go
@@ -29,6 +29,9 @@ func (r *Handler) Watch(watch *handler.WatchManager) (err error) {
 		r.Provider(),
 		&ocp.VM{},
 		r)
+	if err != nil {
+		return
+	}
 
 	log.Info(
 		"Inventory watch ensured.",

--- a/pkg/controller/plan/handler/vsphere/handler.go
+++ b/pkg/controller/plan/handler/vsphere/handler.go
@@ -30,6 +30,9 @@ func (r *Handler) Watch(watch *handler.WatchManager) (err error) {
 		r.Provider(),
 		&vsphere.VM{},
 		r)
+	if err != nil {
+		return
+	}
 
 	log.Info(
 		"Inventory watch ensured.",

--- a/pkg/controller/provider/web/base/client.go
+++ b/pkg/controller/provider/web/base/client.go
@@ -305,7 +305,6 @@ func (c *RestClient) buildTransport() (err error) {
 			Timeout:   10 * time.Second,
 			KeepAlive: 10 * time.Second,
 		}).DialContext,
-		ForceAttemptHTTP2:     true,
 		MaxIdleConns:          10,
 		IdleConnTimeout:       10 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,

--- a/pkg/controller/validation/policy/client.go
+++ b/pkg/controller/validation/policy/client.go
@@ -210,7 +210,6 @@ func (c *Client) buildTransport() (err error) {
 			Timeout:   10 * time.Second,
 			KeepAlive: 10 * time.Second,
 		}).DialContext,
-		ForceAttemptHTTP2:     true,
 		MaxIdleConns:          10,
 		IdleConnTimeout:       10 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,


### PR DESCRIPTION
1. Detect ensure watch error and NOT attempt log the watch.  Caused SEGV when (2) failed.

2. Disabled `ForceAttemptHTTP2` because it was causing _websocket_ connection to fail.  Regression added by https://github.com/konveyor/forklift-controller/pull/229.

3. Fix policy-agent determining TLS using the (incorrect) setting.  Regression added by https://github.com/konveyor/forklift-controller/pull/229.

4. Add Host watch on referenced secret.  Testing and noticed this.