### PR TITLE
BZ 1952312 - Add VM name to builder error messages

### DIFF
--- a/pkg/apis/forklift/v1beta1/ref/ref.go
+++ b/pkg/apis/forklift/v1beta1/ref/ref.go
@@ -25,14 +25,16 @@ func (r Ref) NotSet() bool {
 //
 // String representation.
 func (r *Ref) String() (s string) {
-	if r.ID != "" {
-		s = r.ID
-	} else {
-		s = r.Name
-	}
 	if r.Type != "" {
-		s = "/" + r.Type + s
+		s = fmt.Sprintf(
+			"(%s)",
+			r.Type)
 	}
+	s = fmt.Sprintf(
+		"%s id:%s name:'%s' ",
+		s,
+		r.ID,
+		r.Name)
 
 	return
 }

--- a/pkg/apis/forklift/v1beta1/ref/ref.go
+++ b/pkg/apis/forklift/v1beta1/ref/ref.go
@@ -1,5 +1,7 @@
 package ref
 
+import "fmt"
+
 //
 // Source reference.
 // Either the ID or Name must be specified.

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -95,8 +95,7 @@ func (r *Builder) Import(vmRef ref.Ref, object *vmio.VirtualMachineImportSpec) (
 	if pErr != nil {
 		err = liberr.New(
 			fmt.Sprintf(
-				"VM %s (%s) lookup failed: %s",
-				vm.Name,
+				"VM %s lookup failed: %s",
 				vmRef.String(),
 				pErr.Error()))
 		return
@@ -104,16 +103,14 @@ func (r *Builder) Import(vmRef ref.Ref, object *vmio.VirtualMachineImportSpec) (
 	if types.VirtualMachineConnectionState(vm.ConnectionState) != types.VirtualMachineConnectionStateConnected {
 		err = liberr.New(
 			fmt.Sprintf(
-				"VM %s (%s) is not connected",
-				vm.Name,
+				"VM %s is not connected",
 				vmRef.String()))
 		return
 	}
 	if r.Plan.Spec.Warm && !vm.ChangeTrackingEnabled {
 		err = liberr.New(
 			fmt.Sprintf(
-				"Changed Block Tracking (CBT) is disabled for VM %s (%s)",
-				vm.Name,
+				"Changed Block Tracking (CBT) is disabled for VM %s",
 				vmRef.String()))
 		return
 	}
@@ -142,8 +139,7 @@ func (r *Builder) Tasks(vmRef ref.Ref) (list []*plan.Task, err error) {
 	if pErr != nil {
 		err = liberr.New(
 			fmt.Sprintf(
-				"VM %s (%s) lookup failed: %s",
-				vm.Name,
+				"VM %s lookup failed: %s",
 				vmRef.String(),
 				pErr.Error()))
 		return
@@ -261,8 +257,7 @@ func (r *Builder) hostID(vmRef ref.Ref) (hostID string, err error) {
 	if pErr != nil {
 		err = liberr.New(
 			fmt.Sprintf(
-				"VM %s (%s) lookup failed: %s",
-				vm.Name,
+				"VM %s lookup failed: %s",
 				vmRef.String(),
 				pErr.Error()))
 		return

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -95,7 +95,8 @@ func (r *Builder) Import(vmRef ref.Ref, object *vmio.VirtualMachineImportSpec) (
 	if pErr != nil {
 		err = liberr.New(
 			fmt.Sprintf(
-				"VM %s lookup failed: %s",
+				"VM %s (%s) lookup failed: %s",
+				vm.Name,
 				vmRef.String(),
 				pErr.Error()))
 		return
@@ -103,14 +104,16 @@ func (r *Builder) Import(vmRef ref.Ref, object *vmio.VirtualMachineImportSpec) (
 	if types.VirtualMachineConnectionState(vm.ConnectionState) != types.VirtualMachineConnectionStateConnected {
 		err = liberr.New(
 			fmt.Sprintf(
-				"VM %s is not connected",
+				"VM %s (%s) is not connected",
+				vm.Name,
 				vmRef.String()))
 		return
 	}
 	if r.Plan.Spec.Warm && !vm.ChangeTrackingEnabled {
 		err = liberr.New(
 			fmt.Sprintf(
-				"Changed Block Tracking (CBT) is disabled for VM %s",
+				"Changed Block Tracking (CBT) is disabled for VM %s (%s)",
+				vm.Name,
 				vmRef.String()))
 		return
 	}
@@ -139,7 +142,8 @@ func (r *Builder) Tasks(vmRef ref.Ref) (list []*plan.Task, err error) {
 	if pErr != nil {
 		err = liberr.New(
 			fmt.Sprintf(
-				"VM %s lookup failed: %s",
+				"VM %s (%s) lookup failed: %s",
+				vm.Name,
 				vmRef.String(),
 				pErr.Error()))
 		return
@@ -257,7 +261,8 @@ func (r *Builder) hostID(vmRef ref.Ref) (hostID string, err error) {
 	if pErr != nil {
 		err = liberr.New(
 			fmt.Sprintf(
-				"VM %s lookup failed: %s",
+				"VM %s (%s) lookup failed: %s",
+				vm.Name,
 				vmRef.String(),
 				pErr.Error()))
 		return


### PR DESCRIPTION
When the VirtualMachineImport builder fails, the VM MoRef is not user friendly in the error. This pull request adds the VM name.