### PR TITLE
Make TransferNetwork field an ObjectReference

### DIFF
--- a/config/crds/forklift.konveyor.io_plans.yaml
+++ b/config/crds/forklift.konveyor.io_plans.yaml
@@ -172,8 +172,30 @@ spec:
                 description: Target namespace.
                 type: string
               transferNetwork:
-                description: Name of the network attachment definition in the target namespace which should be used for disk transfer.
-                type: string
+                description: The network attachment definition that should be used for disk transfer.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
               vms:
                 description: List of VMs.
                 items:

--- a/config/forklift.konveyor.io_plans.yaml
+++ b/config/forklift.konveyor.io_plans.yaml
@@ -172,8 +172,30 @@ spec:
                 description: Target namespace.
                 type: string
               transferNetwork:
-                description: Name of the network attachment definition in the target namespace which should be used for disk transfer.
-                type: string
+                description: The network attachment definition that should be used for disk transfer.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
               vms:
                 description: List of VMs.
                 items:

--- a/pkg/apis/forklift/v1beta1/plan.go
+++ b/pkg/apis/forklift/v1beta1/plan.go
@@ -21,6 +21,7 @@ import (
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/plan"
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/provider"
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/ref"
+	core "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -41,9 +42,8 @@ type PlanSpec struct {
 	Warm bool `json:"warm,omitempty"`
 	// Date and time to finalize a warm migration.
 	Cutover *meta.Time `json:"cutover,omitempty"`
-	// Name of the network attachment definition in the target namespace
-	// which should be used for disk transfer.
-	TransferNetwork string `json:"transferNetwork,omitempty"`
+	// The network attachment definition that should be used for disk transfer.
+	TransferNetwork *core.ObjectReference `json:"transferNetwork,omitempty"`
 }
 
 //

--- a/pkg/apis/forklift/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/forklift/v1beta1/zz_generated.deepcopy.go
@@ -23,6 +23,7 @@ package v1beta1
 import (
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/plan"
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/ref"
+	"k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -562,6 +563,11 @@ func (in *PlanSpec) DeepCopyInto(out *PlanSpec) {
 	if in.Cutover != nil {
 		in, out := &in.Cutover, &out.Cutover
 		*out = (*in).DeepCopy()
+	}
+	if in.TransferNetwork != nil {
+		in, out := &in.TransferNetwork, &out.TransferNetwork
+		*out = new(v1.ObjectReference)
+		**out = **in
 	}
 }
 

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -327,8 +327,9 @@ func (r *KubeVirt) vmImport(
 		return
 	}
 	annotations := make(map[string]string)
-	if r.Plan.Spec.TransferNetwork != "" {
-		annotations[annDefaultNetwork] = r.Plan.Spec.TransferNetwork
+	if r.Plan.Spec.TransferNetwork != nil {
+		annotations[annDefaultNetwork] = path.Join(
+			r.Plan.Spec.TransferNetwork.Namespace, r.Plan.Spec.TransferNetwork.Name)
 	}
 	object = &vmio.VirtualMachineImport{
 		ObjectMeta: meta.ObjectMeta{

--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -402,7 +402,7 @@ func (r *Reconciler) validateVM(plan *api.Plan) error {
 //
 // Validate transfer network selection.
 func (r *Reconciler) validateTransferNetwork(plan *api.Plan) (err error) {
-	if plan.Spec.TransferNetwork == "" {
+	if plan.Spec.TransferNetwork == nil {
 		return
 	}
 	notFound := libcnd.Condition{
@@ -413,8 +413,8 @@ func (r *Reconciler) validateTransferNetwork(plan *api.Plan) (err error) {
 		Message:  "Transfer network is not valid.",
 	}
 	key := client.ObjectKey{
-		Namespace: plan.TargetNamespace(),
-		Name:      plan.Spec.TransferNetwork,
+		Namespace: plan.Spec.TransferNetwork.Namespace,
+		Name:      plan.Spec.TransferNetwork.Name,
 	}
 	netAttachDef := &net.NetworkAttachmentDefinition{}
 	err = r.Get(context.TODO(), key, netAttachDef)


### PR DESCRIPTION
When the `v1.multus-cni.io/default-network` annotation is set with the name of a network attachment definition, it looks for that NAD in `kube-system`, not in the pod's namespace as I previously thought. It's also valid in some circumstances to choose a NAD in a namespace outside of the pod's namespace. As such, the `transferNetwork` field on the Plan needs to be an object reference to properly identify the desired network.

This requires a corresponding change to the UI which I've already discussed with @mturley. 

https://github.com/k8snetworkplumbingwg/multus-cni/blob/a52680b3bfa026087879f89fae331b0dfc8dffe0/docs/configuration.md