### PR TITLE
ReQ host connection failed 15 min to prevent DOS issues.

### DIFF
--- a/pkg/controller/base/controller.go
+++ b/pkg/controller/base/controller.go
@@ -36,10 +36,12 @@ func (r *Reconciler) Started() {
 //
 // Reconcile ended.
 func (r *Reconciler) Ended(reQin time.Duration, err error) (reQ time.Duration) {
-	defer r.Log.Info(
-		"Reconcile ended.",
-		"reQ",
-		reQ)
+	defer func() {
+		r.Log.Info(
+			"Reconcile ended.",
+			"reQ",
+			reQ)
+	}()
 	reQ = reQin
 	if err == nil {
 		return

--- a/pkg/controller/host/controller.go
+++ b/pkg/controller/host/controller.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+	"time"
 )
 
 const (
@@ -186,9 +187,11 @@ func (r Reconciler) Reconcile(request reconcile.Request) (result reconcile.Resul
 		return
 	}
 
-	// ReQ.
-	if !host.Status.HasCondition(ConnectionTestSucceeded) {
-		result.RequeueAfter = base.SlowReQ
+	// Connection test failed.
+	// Determined that ESX host retry of 15 minutes
+	// will not trigger DOS response.
+	if host.Status.HasCondition(ConnectionTestFailed) {
+		result.RequeueAfter = time.Minute * 15
 	}
 
 	// Done


### PR DESCRIPTION
Reduce the retry time to 15 minutes to prevent DOS rejection.
While testing, noticed/fixed that `reQ` was not logging correctly.

https://bugzilla.redhat.com/show_bug.cgi?id=1953307