### PR TITLE
reflectPlan should always sync the VM from the Plan status to the Migration

### DIFF
--- a/pkg/controller/migration/controller.go
+++ b/pkg/controller/migration/controller.go
@@ -193,7 +193,6 @@ func (r *Reconciler) reflectPlan(plan *api.Plan, migration *api.Migration) {
 	}
 	if snapshot.HasCondition(Executing) {
 		migration.Status.MarkStarted()
-		migration.Status.VMs = plan.Status.Migration.VMs
 		migration.Status.SetCondition(libcnd.Condition{
 			Type:     Running,
 			Status:   True,
@@ -221,4 +220,5 @@ func (r *Reconciler) reflectPlan(plan *api.Plan, migration *api.Migration) {
 			Durable:  true,
 		})
 	}
+	migration.Status.VMs = plan.Status.Migration.VMs
 }


### PR DESCRIPTION
The list of VMs in the Migration CR's status is only updated while the Plan has the Executing condition, so VM status updates can get missed when the Plan is completed or canceled. This PR ensures that the list of VMs on the Migration is always up to date with the Plan.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1952362