### PR TITLE
BZ 1957105 - Skip VMs that are actually templates

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -100,6 +100,13 @@ func (r *Builder) Import(vmRef ref.Ref, object *vmio.VirtualMachineImportSpec) (
 				pErr.Error()))
 		return
 	}
+	if vm.IsTemplate {
+		err = liberr.New(
+			fmt.Sprintf(
+				"VM %s is a template",
+				vmRef.String()))
+		return
+	}
 	if types.VirtualMachineConnectionState(vm.ConnectionState) != types.VirtualMachineConnectionStateConnected {
 		err = liberr.New(
 			fmt.Sprintf(

--- a/pkg/controller/provider/container/vsphere/model.go
+++ b/pkg/controller/provider/container/vsphere/model.go
@@ -508,6 +508,10 @@ func (v *VmAdapter) Apply(u types.ObjectUpdate) {
 				if s, cast := p.Val.(types.VirtualMachineConnectionState); cast {
 					v.model.ConnectionState = string(s)
 				}
+			case fIsTemplate:
+				if b, cast := p.Val.(bool); cast {
+					v.model.IsTemplate = b
+				}
 			case fSnapshot:
 				if snapshot, cast := p.Val.(types.VirtualMachineSnapshotInfo); cast {
 					ref := snapshot.CurrentSnapshot

--- a/pkg/controller/provider/container/vsphere/reconciler.go
+++ b/pkg/controller/provider/container/vsphere/reconciler.go
@@ -112,6 +112,7 @@ const (
 	fPowerState          = "runtime.powerState"
 	fConnectionState     = "runtime.connectionState"
 	fSnapshot            = "snapshot"
+	fIsTemplate          = "config.template"
 )
 
 //
@@ -725,6 +726,7 @@ func (r *Reconciler) propertySpec() []types.PropertySpec {
 				fRuntimeHost,
 				fPowerState,
 				fConnectionState,
+				fIsTemplate,
 				fSnapshot,
 				fChangeTracking,
 			},

--- a/pkg/controller/provider/model/vsphere/model.go
+++ b/pkg/controller/provider/model/vsphere/model.go
@@ -356,6 +356,7 @@ type VM struct {
 	NumaNodeAffinity      []string  `sql:""`
 	StorageUsed           int64     `sql:""`
 	Snapshot              Ref       `sql:""`
+	IsTemplate            bool      `sql:""`
 	ChangeTrackingEnabled bool      `sql:""`
 	Devices               []Device  `sql:""`
 	Disks                 []Disk    `sql:""`

--- a/pkg/controller/provider/web/vsphere/vm.go
+++ b/pkg/controller/provider/web/vsphere/vm.go
@@ -206,6 +206,7 @@ type VM struct {
 	PowerState            string          `json:"powerState"`
 	ConnectionState       string          `json:"connectionState"`
 	Snapshot              model.Ref       `json:"snapshot"`
+	IsTemplate            bool            `json:"isTemplate"`
 	ChangeTrackingEnabled bool            `json:"changeTrackingEnabled"`
 	CpuAffinity           []int32         `json:"cpuAffinity"`
 	CpuHotAddEnabled      bool            `json:"cpuHotAddEnabled"`
@@ -238,6 +239,7 @@ func (r *VM) With(m *model.VM) {
 	r.PowerState = m.PowerState
 	r.ConnectionState = m.ConnectionState
 	r.Snapshot = m.Snapshot
+	r.IsTemplate = m.IsTemplate
 	r.ChangeTrackingEnabled = m.ChangeTrackingEnabled
 	r.CpuAffinity = m.CpuAffinity
 	r.CpuHotAddEnabled = m.CpuHotAddEnabled


### PR DESCRIPTION
In VMware, a template is a VM with a boolean property that says it is a template. The property is `config.template`.
Templates don't support warm migration, so we have decided to hide all the templates from the VM selection list in the UI.

This pull request does two things:
1. add a new field in the inventory: `IsTemplate` in the database, `isTemplate` is the JSON API response.
2. error out the templates in the VMImport builder, so that their migration is skipped.

Signed-off-by: Fabien Dupont <fdupont@redhat.com>