### PR TITLE
Remove the cutover field from the Plan CRD

### DIFF
--- a/config/crds/forklift.konveyor.io_plans.yaml
+++ b/config/crds/forklift.konveyor.io_plans.yaml
@@ -47,10 +47,6 @@ spec:
           spec:
             description: PlanSpec defines the desired state of Plan.
             properties:
-              cutover:
-                description: Date and time to finalize a warm migration.
-                format: date-time
-                type: string
               description:
                 description: Description
                 type: string

--- a/config/forklift.konveyor.io_plans.yaml
+++ b/config/forklift.konveyor.io_plans.yaml
@@ -47,10 +47,6 @@ spec:
           spec:
             description: PlanSpec defines the desired state of Plan.
             properties:
-              cutover:
-                description: Date and time to finalize a warm migration.
-                format: date-time
-                type: string
               description:
                 description: Description
                 type: string

--- a/pkg/apis/forklift/v1beta1/plan.go
+++ b/pkg/apis/forklift/v1beta1/plan.go
@@ -40,8 +40,6 @@ type PlanSpec struct {
 	VMs []plan.VM `json:"vms"`
 	// Whether this is a warm migration.
 	Warm bool `json:"warm,omitempty"`
-	// Date and time to finalize a warm migration.
-	Cutover *meta.Time `json:"cutover,omitempty"`
 	// The network attachment definition that should be used for disk transfer.
 	TransferNetwork *core.ObjectReference `json:"transferNetwork,omitempty"`
 }

--- a/pkg/apis/forklift/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/forklift/v1beta1/zz_generated.deepcopy.go
@@ -560,10 +560,6 @@ func (in *PlanSpec) DeepCopyInto(out *PlanSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.Cutover != nil {
-		in, out := &in.Cutover, &out.Cutover
-		*out = (*in).DeepCopy()
-	}
 	if in.TransferNetwork != nil {
 		in, out := &in.TransferNetwork, &out.TransferNetwork
 		*out = new(v1.ObjectReference)

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -362,8 +362,6 @@ func (r *KubeVirt) vmImport(
 		object.Spec.Warm = true
 		if r.Migration.Spec.Cutover != nil {
 			object.Spec.FinalizeDate = r.Migration.Spec.Cutover
-		} else {
-			object.Spec.FinalizeDate = r.Plan.Spec.Cutover
 		}
 	}
 

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -360,9 +360,7 @@ func (r *KubeVirt) vmImport(
 	// the value set on the migration, if any, takes precedence over the value set on the plan.
 	if r.Plan.Spec.Warm {
 		object.Spec.Warm = true
-		if r.Migration.Spec.Cutover != nil {
-			object.Spec.FinalizeDate = r.Migration.Spec.Cutover
-		}
+		object.Spec.FinalizeDate = r.Migration.Spec.Cutover
 	}
 
 	return


### PR DESCRIPTION
In the migration flow, the cutover date/time is set on the Migration CR by the user interface. We expect user to do the same through the API to keep a consistent flow. This means that the `cutover` field of the `Plan` is not needed anymore. Since we will soon release Forklift 2.0.0 with the API in v1beta1 version, it would be cleaner to do it soon, even if we add it back in the future.