### PR TITLE
Add tree endpoint for oVirt.

### DIFF
--- a/pkg/controller/provider/container/ovirt/resource.go
+++ b/pkg/controller/provider/container/ovirt/resource.go
@@ -64,10 +64,7 @@ type Cluster struct {
 func (r *Cluster) ApplyTo(m *model.Cluster) {
 	m.Name = r.Name
 	m.Name = r.Description
-	m.Parent = model.Ref{
-		Kind: model.DataCenterKind,
-		ID:   r.DataCenter.ID,
-	}
+	m.DataCenter = r.DataCenter.ID
 }
 
 //
@@ -88,10 +85,7 @@ type Host struct {
 func (r *Host) ApplyTo(m *model.Host) {
 	m.Name = r.Name
 	m.Description = r.Description
-	m.Parent = model.Ref{
-		Kind: model.ClusterKind,
-		ID:   r.Cluster.ID,
-	}
+	m.Cluster = r.Cluster.ID
 }
 
 //
@@ -104,6 +98,7 @@ type HostList struct {
 // VM.
 type VM struct {
 	Base
+	Cluster Ref `json:"cluster"`
 	Host Ref `json:"host"`
 }
 
@@ -112,10 +107,8 @@ type VM struct {
 func (r *VM) ApplyTo(m *model.VM) {
 	m.Name = r.Name
 	m.Description = r.Description
-	m.Parent = model.Ref{
-		Kind: model.HostKind,
-		ID:   r.Host.ID,
-	}
+	m.Cluster = r.Cluster.ID
+	m.Host = r.Host.ID
 }
 
 //
@@ -140,10 +133,7 @@ type Network struct {
 func (r *Network) ApplyTo(m *model.Network) {
 	m.Name = r.Name
 	m.Description = r.Description
-	m.Parent = model.Ref{
-		Kind: model.DataCenterKind,
-		ID:   r.DataCenter.ID,
-	}
+	m.DataCenter = r.DataCenter.ID
 	m.VLan = model.Ref{
 		Kind: "VLan",
 		ID:   r.VLan.ID,
@@ -182,10 +172,7 @@ func (r *StorageDomain) ApplyTo(m *model.StorageDomain) {
 	m.Available, _ = strconv.ParseInt(r.Available, 10, 64)
 	m.Used, _ = strconv.ParseInt(r.Used, 10, 64)
 	for _, ref := range r.DataCenter.List {
-		m.Parent = model.Ref{
-			Kind: model.DataCenterKind,
-			ID:   ref.ID,
-		}
+		m.DataCenter = ref.ID
 		break
 	}
 }

--- a/pkg/controller/provider/model/base/model.go
+++ b/pkg/controller/provider/model/base/model.go
@@ -1,0 +1,38 @@
+package base
+
+import (
+	"fmt"
+	libmodel "github.com/konveyor/controller/pkg/inventory/model"
+)
+
+type Model = libmodel.Model
+type ListOptions = libmodel.ListOptions
+
+//
+// An object reference.
+type Ref struct {
+	// The kind (type) of the referenced.
+	Kind string `json:"kind"`
+	// The ID of object referenced.
+	ID string `json:"id"`
+}
+
+//
+// Invalid reference.
+type InvalidRefError struct {
+	Ref
+}
+
+func (r InvalidRefError) Error() string {
+	return fmt.Sprintf("Reference %#v not valid.", r.Ref)
+}
+
+//
+// Invalid kind.
+type InvalidKindError struct {
+	Object interface{}
+}
+
+func (r InvalidKindError) Error() string {
+	return fmt.Sprintf("Kind %#v not valid.", r.Object)
+}

--- a/pkg/controller/provider/model/base/tree.go
+++ b/pkg/controller/provider/model/base/tree.go
@@ -1,0 +1,120 @@
+package base
+
+import (
+	libref "github.com/konveyor/controller/pkg/ref"
+)
+
+//
+// Tree.
+type Tree struct {
+	// Depth limit (0=unlimited).
+	Depth int
+}
+
+//
+// Build the tree.
+func (r *Tree) Build(root Model, navigator BranchNavigator) (treeRoot *TreeNode, err error) {
+	node := &TreeNode{
+		Kind:  libref.ToKind(root),
+		Model: root,
+	}
+	treeRoot = node
+	depth := 0
+	var walk func(Model, bool) error
+	walk = func(model Model, asChild bool) error {
+		kind := libref.ToKind(model)
+		if asChild {
+			child := &TreeNode{
+				Parent: node,
+				Kind:   kind,
+				Model:  model,
+			}
+			depth++
+			defer func() {
+				depth--
+			}()
+			if r.Depth > 0 && depth > r.Depth {
+				return nil
+			}
+			node.Children = append(node.Children, child)
+			node = child
+			defer func() {
+				node = node.Parent
+			}()
+		}
+		list, err := navigator.Next(model)
+		if err != nil {
+			return err
+		}
+		for _, m := range list {
+			err = walk(m, true)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+	err = walk(root, false)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+//
+// Build the (ancestry) tree.
+func (r *Tree) Ancestry(leaf Model, navigator ParentNavigator) (treeRoot *TreeNode, err error) {
+	node := &TreeNode{
+		Kind:  libref.ToKind(leaf),
+		Model: leaf,
+	}
+	treeRoot = node
+	for {
+		parent, nErr := navigator.Next(node.Model)
+		if nErr != nil {
+			err = nErr
+			return
+		}
+		if parent == nil {
+			break
+		}
+		treeRoot = &TreeNode{
+			Kind:  libref.ToKind(parent),
+			Model: parent,
+		}
+		treeRoot.Children = append(treeRoot.Children, node)
+		node.Parent = treeRoot
+		node = treeRoot
+	}
+
+	return
+}
+
+//
+// Tree node.
+type TreeNode struct {
+	// Parent node.
+	Parent *TreeNode
+	// Kind of model.
+	Kind string
+	// Model.
+	Model Model
+	// Child nodes.
+	Children []*TreeNode
+}
+
+//
+// Tree navigator.
+// Navigate up the parent tree.
+type ParentNavigator interface {
+	Next(Model) (Model, error)
+}
+
+//
+// Tree navigator.
+// Navigate down the children.
+type BranchNavigator interface {
+	Next(Model) ([]Model, error)
+}

--- a/pkg/controller/provider/model/ocp/model.go
+++ b/pkg/controller/provider/model/ocp/model.go
@@ -4,6 +4,7 @@ import (
 	net "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	libmodel "github.com/konveyor/controller/pkg/inventory/model"
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
+	"github.com/konveyor/forklift-controller/pkg/controller/provider/model/base"
 	core "k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -13,12 +14,17 @@ import (
 	"strconv"
 )
 
+//
 // Errors
 var NotFound = libmodel.NotFound
 
+type InvalidRefError = base.InvalidRefError
+
 //
 // Types
-type Model = libmodel.Model
+type Model = base.Model
+type ListOptions = base.ListOptions
+type Ref = base.Ref
 
 //
 // k8s Resource.

--- a/pkg/controller/provider/model/ovirt/tree.go
+++ b/pkg/controller/provider/model/ovirt/tree.go
@@ -1,8 +1,8 @@
 package ovirt
 
 import (
-	"fmt"
 	libref "github.com/konveyor/controller/pkg/ref"
+	"github.com/konveyor/forklift-controller/pkg/controller/provider/model/base"
 )
 
 //
@@ -18,11 +18,8 @@ var (
 )
 
 //
-// Invalid reference.
-type InvalidRefError struct {
-	Ref
-}
-
-func (r InvalidRefError) Error() string {
-	return fmt.Sprintf("Reference %#v not valid.", r.Ref)
-}
+// Types.
+type Tree = base.Tree
+type TreeNode = base.TreeNode
+type BranchNavigator = base.BranchNavigator
+type ParentNavigator = base.ParentNavigator

--- a/pkg/controller/provider/model/vsphere/model.go
+++ b/pkg/controller/provider/model/vsphere/model.go
@@ -2,6 +2,7 @@ package vsphere
 
 import (
 	libmodel "github.com/konveyor/controller/pkg/inventory/model"
+	"github.com/konveyor/forklift-controller/pkg/controller/provider/model/base"
 	"strings"
 )
 
@@ -17,9 +18,13 @@ const (
 // Errors
 var NotFound = libmodel.NotFound
 
+type InvalidRefError = base.InvalidRefError
+
 //
 // Types
-type Model = libmodel.Model
+type Model = base.Model
+type ListOptions = base.ListOptions
+type Ref = base.Ref
 
 //
 // Base VMWare model.
@@ -154,46 +159,6 @@ Walk:
 	}
 
 	path = strings.Join(reversed, "/")
-
-	return
-}
-
-//
-// An object reference.
-type Ref struct {
-	// The kind (type) of the referenced.
-	Kind string `json:"kind"`
-	// The ID of object referenced.
-	ID string `json:"id"`
-}
-
-//
-// Get referenced model.
-func (r *Ref) Get(db libmodel.DB) (model Model, err error) {
-	base := Base{
-		ID: r.ID,
-	}
-	switch r.Kind {
-	case FolderKind:
-		model = &Folder{Base: base}
-	case DatacenterKind:
-		model = &Datacenter{Base: base}
-	case ClusterKind:
-		model = &Cluster{Base: base}
-	case HostKind:
-		model = &Host{Base: base}
-	case VmKind:
-		model = &VM{Base: base}
-	case NetKind:
-		model = &Network{Base: base}
-	case DsKind:
-		model = &Datastore{Base: base}
-	default:
-		err = InvalidRefError{*r}
-	}
-	if model != nil {
-		err = db.Get(model)
-	}
 
 	return
 }

--- a/pkg/controller/provider/model/vsphere/tree.go
+++ b/pkg/controller/provider/model/vsphere/tree.go
@@ -1,9 +1,8 @@
 package vsphere
 
 import (
-	"fmt"
-	libmodel "github.com/konveyor/controller/pkg/inventory/model"
 	libref "github.com/konveyor/controller/pkg/ref"
+	"github.com/konveyor/forklift-controller/pkg/controller/provider/model/base"
 )
 
 //
@@ -19,134 +18,8 @@ var (
 )
 
 //
-// Invalid reference.
-type InvalidRefError struct {
-	Ref
-}
-
-func (r InvalidRefError) Error() string {
-	return fmt.Sprintf("Reference %#v not valid.", r.Ref)
-}
-
-//
-// Invalid kind.
-type InvalidKindError struct {
-	Object interface{}
-}
-
-func (r InvalidKindError) Error() string {
-	return fmt.Sprintf("Kind %#v not valid.", r.Object)
-}
-
-//
-// Tree.
-type Tree struct {
-	// DB connection.
-	DB libmodel.DB
-	// Depth limit (0=unlimited).
-	Depth int
-}
-
-//
-// Build the tree.
-func (r *Tree) Build(root Model, navigator BranchNavigator) (*TreeNode, error) {
-	node := &TreeNode{
-		Kind:  libref.ToKind(root),
-		Model: root,
-	}
-	treeRoot := node
-	depth := 0
-	var walk func(Model, bool) error
-	walk = func(model Model, asChild bool) error {
-		kind := libref.ToKind(model)
-		if asChild {
-			child := &TreeNode{
-				Parent: node,
-				Kind:   kind,
-				Model:  model,
-			}
-			depth++
-			defer func() {
-				depth--
-			}()
-			if r.Depth > 0 && depth > r.Depth {
-				return nil
-			}
-			node.Children = append(node.Children, child)
-			node = child
-			defer func() {
-				node = node.Parent
-			}()
-		}
-		for _, ref := range navigator(model) {
-			m, err := ref.Get(r.DB)
-			if err != nil {
-				return err
-			}
-			err = walk(m, true)
-			if err != nil {
-				return err
-			}
-		}
-
-		return nil
-	}
-	err := walk(root, false)
-	if err != nil {
-		return nil, err
-	}
-
-	return treeRoot, nil
-}
-
-//
-// Build the (ancestry) tree.
-func (r *Tree) Ancestry(leaf Model, navigator ParentNavigator) (*TreeNode, error) {
-	node := &TreeNode{
-		Kind:  libref.ToKind(leaf),
-		Model: leaf,
-	}
-	root := node
-	for {
-		ref := navigator(node.Model)
-		if ref.Kind == "" {
-			break
-		}
-		m, err := ref.Get(r.DB)
-		if err != nil {
-			return nil, err
-		}
-		root = &TreeNode{
-			Kind:  ref.Kind,
-			Model: m,
-		}
-		root.Children = append(root.Children, node)
-		node.Parent = root
-		node = root
-	}
-
-	return root, nil
-}
-
-//
-// Tree node.
-type TreeNode struct {
-	// Parent node.
-	Parent *TreeNode
-	// Kind of model.
-	Kind string
-	// Model.
-	Model Model
-	// Child nodes.
-	Children []*TreeNode
-}
-
-//
-// Tree navigator.
-// Navigate up the parent tree.
-type ParentNavigator func(Model) Ref
-
-//
-// Tree navigator.
-// Navigate down the children.
-type BranchNavigator func(Model) []Ref
+// Types.
+type Tree = base.Tree
+type TreeNode = base.TreeNode
+type BranchNavigator = base.BranchNavigator
+type ParentNavigator = base.ParentNavigator

--- a/pkg/controller/provider/web/base/tree.go
+++ b/pkg/controller/provider/web/base/tree.go
@@ -1,0 +1,97 @@
+package base
+
+import (
+	libmodel "github.com/konveyor/controller/pkg/inventory/model"
+	model "github.com/konveyor/forklift-controller/pkg/controller/provider/model/base"
+)
+
+//
+// Node builder.
+type NodeBuilder interface {
+	Node(p *TreeNode, m libmodel.Model) *TreeNode
+}
+
+//
+// Tree.
+type Tree struct {
+	NodeBuilder
+	// Depth limit.
+	Depth int
+}
+
+//
+// Build the tree
+func (r *Tree) Build(m model.Model, navigator model.BranchNavigator) (*TreeNode, error) {
+	root := r.Node(nil, m)
+	node := root
+	var walk func(*model.TreeNode)
+	walk = func(n *model.TreeNode) {
+		child := r.Node(node, n.Model)
+		node.Children = append(node.Children, child)
+		node = child
+		defer func() {
+			node = node.Parent
+		}()
+		for _, mt := range n.Children {
+			walk(mt)
+		}
+	}
+	tree := model.Tree{
+		Depth: r.Depth,
+	}
+	modelRoot, err := tree.Build(m, navigator)
+	if err != nil {
+		return nil, err
+	}
+	for _, child := range modelRoot.Children {
+		walk(child)
+	}
+
+	return root, nil
+}
+
+//
+// Ancestry (Tree).
+func (r *Tree) Ancestry(leaf model.Model, navigator model.ParentNavigator) (*TreeNode, error) {
+	root := &TreeNode{}
+	node := root
+	var walk func(*model.TreeNode)
+	walk = func(n *model.TreeNode) {
+		child := r.Node(node, n.Model)
+		node.Children = append(node.Children, child)
+		node = child
+		defer func() {
+			node = node.Parent
+		}()
+		for _, mt := range n.Children {
+			walk(mt)
+		}
+	}
+	tree := model.Tree{
+		Depth: r.Depth,
+	}
+	modelRoot, err := tree.Ancestry(leaf, navigator)
+	if err != nil {
+		return nil, err
+	}
+	root = r.Node(nil, modelRoot.Model)
+	node = root
+	for _, child := range modelRoot.Children {
+		walk(child)
+	}
+
+	return root, nil
+}
+
+//
+// Tree node resource.
+type TreeNode struct {
+	// Parent node.
+	Parent *TreeNode `json:"-"`
+	// Object kind.
+	Kind string `json:"kind"`
+	// Object (resource).
+	Object interface{} `json:"object"`
+	// Child nodes.
+	Children []*TreeNode `json:"children"`
+}

--- a/pkg/controller/provider/web/ovirt/cluster.go
+++ b/pkg/controller/provider/web/ovirt/cluster.go
@@ -147,12 +147,14 @@ func (h ClusterHandler) watch(ctx *gin.Context) {
 // REST Resource.
 type Cluster struct {
 	Resource
+	DataCenter string `json:"dataCenter"`
 }
 
 //
 // Build the resource using the model.
 func (r *Cluster) With(m *model.Cluster) {
 	r.Resource.With(&m.Base)
+	r.DataCenter = m.DataCenter
 }
 
 //

--- a/pkg/controller/provider/web/ovirt/doc.go
+++ b/pkg/controller/provider/web/ovirt/doc.go
@@ -57,5 +57,15 @@ func Handlers(container *container.Container) []libweb.RequestHandler {
 				base.Handler{Container: container},
 			},
 		},
+		&TreeHandler{
+			Handler: Handler{
+				base.Handler{Container: container},
+			},
+		},
+		&WorkloadHandler{
+			Handler: Handler{
+				base.Handler{Container: container},
+			},
+		},
 	}
 }

--- a/pkg/controller/provider/web/ovirt/host.go
+++ b/pkg/controller/provider/web/ovirt/host.go
@@ -146,12 +146,14 @@ func (h HostHandler) watch(ctx *gin.Context) {
 // REST Resource.
 type Host struct {
 	Resource
+	Cluster string `json:"cluster"`
 }
 
 //
 // Build the resource using the model.
 func (r *Host) With(m *model.Host) {
 	r.Resource.With(&m.Base)
+	r.Cluster = m.Cluster
 }
 
 //

--- a/pkg/controller/provider/web/ovirt/network.go
+++ b/pkg/controller/provider/web/ovirt/network.go
@@ -145,6 +145,7 @@ func (h NetworkHandler) watch(ctx *gin.Context) {
 // REST Resource.
 type Network struct {
 	Resource
+	DataCenter   string      `json:"dataCenter"`
 	VLan         model.Ref   `json:"vlan"`
 	Usages       []string    `json:"usages"`
 	VNICProfiles []model.Ref `json:"vnicProfiles"`
@@ -154,6 +155,7 @@ type Network struct {
 // Build the resource using the model.
 func (r *Network) With(m *model.Network) {
 	r.Resource.With(&m.Base)
+	r.DataCenter = m.DataCenter
 	r.VLan = m.VLan
 	r.Usages = m.Usages
 	r.VNICProfiles = m.VNICProfiles

--- a/pkg/controller/provider/web/ovirt/resource.go
+++ b/pkg/controller/provider/web/ovirt/resource.go
@@ -11,8 +11,6 @@ type Resource struct {
 	ID string `json:"id"`
 	// Revision
 	Revision int64 `json:"revision"`
-	// Parent ID.
-	Parent model.Ref `json:"parent,omitempty"`
 	// Path
 	Path string `json:"path,omitempty"`
 	// Object name.
@@ -28,7 +26,6 @@ type Resource struct {
 func (r *Resource) With(m *model.Base) {
 	r.ID = m.ID
 	r.Revision = m.Revision
-	r.Parent = m.Parent
 	r.Name = m.Name
 	r.Description = m.Description
 }

--- a/pkg/controller/provider/web/ovirt/storage.go
+++ b/pkg/controller/provider/web/ovirt/storage.go
@@ -145,10 +145,11 @@ func (h StorageDomainHandler) watch(ctx *gin.Context) {
 // REST Resource.
 type StorageDomain struct {
 	Resource
-	Type     string `json:"type"`
-	Capacity int64  `json:"capacity"`
-	Free     int64  `json:"free"`
-	Storage  struct {
+	DataCenter string `json:"dataCenter"`
+	Type       string `json:"type"`
+	Capacity   int64  `json:"capacity"`
+	Free       int64  `json:"free"`
+	Storage    struct {
 		Type string `json:"type"`
 	} `json:"storage"`
 }
@@ -157,6 +158,7 @@ type StorageDomain struct {
 // Build the resource using the model.
 func (r *StorageDomain) With(m *model.StorageDomain) {
 	r.Resource.With(&m.Base)
+	r.DataCenter = m.DataCenter
 	r.Type = m.Type
 	r.Capacity = m.Available
 	r.Free = m.Available - m.Used

--- a/pkg/controller/provider/web/ovirt/tree.go
+++ b/pkg/controller/provider/web/ovirt/tree.go
@@ -1,0 +1,290 @@
+package ovirt
+
+import (
+	"github.com/gin-gonic/gin"
+	libmodel "github.com/konveyor/controller/pkg/inventory/model"
+	libref "github.com/konveyor/controller/pkg/ref"
+	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
+	model "github.com/konveyor/forklift-controller/pkg/controller/provider/model/ovirt"
+	"github.com/konveyor/forklift-controller/pkg/controller/provider/web/base"
+	"net/http"
+)
+
+//
+// Routes.
+const (
+	TreeRoot   = ProviderRoot + "/tree"
+	TreeVmRoot = TreeRoot + "/vm"
+)
+
+//
+// Types.
+type Tree = base.Tree
+type TreeNode = base.TreeNode
+
+//
+// Tree handler.
+type TreeHandler struct {
+	Handler
+	// DataCenters list.
+	datacenters []model.DataCenter
+}
+
+//
+// Add routes to the `gin` router.
+func (h *TreeHandler) AddRoutes(e *gin.Engine) {
+	e.GET(TreeVmRoot, h.Tree)
+}
+
+//
+// Prepare to handle the request.
+func (h *TreeHandler) Prepare(ctx *gin.Context) int {
+	status := h.Handler.Prepare(ctx)
+	if status != http.StatusOK {
+		ctx.Status(status)
+		return status
+	}
+	db := h.Reconciler.DB()
+	err := db.List(
+		&h.datacenters,
+		model.ListOptions{
+			Detail: 1,
+		})
+	if err != nil {
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
+		return http.StatusInternalServerError
+	}
+
+	return http.StatusOK
+}
+
+//
+// List not supported.
+func (h TreeHandler) List(ctx *gin.Context) {
+	ctx.Status(http.StatusMethodNotAllowed)
+}
+
+//
+// Get not supported.
+func (h TreeHandler) Get(ctx *gin.Context) {
+	ctx.Status(http.StatusMethodNotAllowed)
+}
+
+//
+// Tree.
+func (h TreeHandler) Tree(ctx *gin.Context) {
+	status := h.Prepare(ctx)
+	if status != http.StatusOK {
+		ctx.Status(status)
+		return
+	}
+	if h.WatchRequest {
+		ctx.Status(http.StatusBadRequest)
+		return
+	}
+	db := h.Reconciler.DB()
+	content := TreeNode{}
+	for _, dc := range h.datacenters {
+		tr := Tree{
+			NodeBuilder: &NodeBuilder{
+				provider: h.Provider,
+				detail: map[string]bool{
+					model.ClusterKind: h.Detail,
+					model.HostKind:    h.Detail,
+					model.VmKind:      h.Detail,
+				},
+			},
+		}
+		branch, err := tr.Build(&dc, &BranchNavigator{db})
+		if err != nil {
+			log.Trace(
+				err,
+				"url",
+				ctx.Request.URL)
+			ctx.Status(http.StatusInternalServerError)
+			return
+		}
+		r := DataCenter{}
+		r.With(&dc)
+		r.SelfLink = DataCenterHandler{}.Link(h.Provider, &dc)
+		branch.Kind = model.DataCenterKind
+		branch.Object = r
+		content.Children = append(content.Children, branch)
+	}
+
+	ctx.JSON(http.StatusOK, content)
+}
+
+//
+// Tree (branch) navigator.
+type BranchNavigator struct {
+	db libmodel.DB
+}
+
+//
+// Next (children) on the branch.
+func (n *BranchNavigator) Next(p libmodel.Model) (r []model.Model, err error) {
+	switch p.(type) {
+	case *model.DataCenter:
+		list, nErr := n.listCluster(p.(*model.DataCenter))
+		if nErr == nil {
+			for i := range list {
+				m := &list[i]
+				r = append(r, m)
+			}
+		} else {
+			err = nErr
+		}
+	case *model.Cluster:
+		list, nErr := n.listHost(p.(*model.Cluster))
+		if nErr == nil {
+			for i := range list {
+				m := &list[i]
+				r = append(r, m)
+			}
+		} else {
+			err = nErr
+		}
+	case *model.Host:
+		list, nErr := n.listVM(p.(*model.Host))
+		if nErr == nil {
+			for i := range list {
+				m := &list[i]
+				r = append(r, m)
+			}
+		} else {
+			err = nErr
+		}
+	}
+
+	return
+}
+
+func (n *BranchNavigator) listCluster(p *model.DataCenter) (list []model.Cluster, err error) {
+	list = []model.Cluster{}
+	err = n.db.List(
+		&list,
+		model.ListOptions{
+			Predicate: libmodel.Eq("DataCenter", p.ID),
+		})
+	return
+}
+
+func (n *BranchNavigator) listHost(p *model.Cluster) (list []model.Host, err error) {
+	list = []model.Host{}
+	err = n.db.List(
+		&list,
+		model.ListOptions{
+			Predicate: libmodel.Eq("Cluster", p.ID),
+		})
+	return
+}
+
+func (n *BranchNavigator) listVM(p *model.Host) (list []model.VM, err error) {
+	list = []model.VM{}
+	err = n.db.List(
+		&list,
+		model.ListOptions{
+			Predicate: libmodel.Eq("Host", p.ID),
+		})
+	return
+}
+
+//
+// Tree node builder.
+type NodeBuilder struct {
+	// Provider.
+	provider *api.Provider
+	// Resource details by kind.
+	detail map[string]bool
+}
+
+//
+// Build a node for the model.
+func (r *NodeBuilder) Node(parent *TreeNode, m model.Model) *TreeNode {
+	kind := libref.ToKind(m)
+	node := &TreeNode{}
+	switch kind {
+	case model.DataCenterKind:
+		resource := &DataCenter{}
+		resource.With(m.(*model.DataCenter))
+		resource.SelfLink =
+			DataCenterHandler{}.Link(r.provider, m.(*model.DataCenter))
+		object := resource.Content(r.withDetail(kind))
+		node = &TreeNode{
+			Parent: parent,
+			Kind:   kind,
+			Object: object,
+		}
+	case model.ClusterKind:
+		resource := &Cluster{}
+		resource.With(m.(*model.Cluster))
+		resource.SelfLink =
+			ClusterHandler{}.Link(r.provider, m.(*model.Cluster))
+		object := resource.Content(r.withDetail(kind))
+		node = &TreeNode{
+			Parent: parent,
+			Kind:   kind,
+			Object: object,
+		}
+	case model.HostKind:
+		resource := &Host{}
+		resource.With(m.(*model.Host))
+		resource.SelfLink =
+			HostHandler{}.Link(r.provider, m.(*model.Host))
+		object := resource.Content(r.withDetail(kind))
+		node = &TreeNode{
+			Parent: parent,
+			Kind:   kind,
+			Object: object,
+		}
+	case model.VmKind:
+		resource := &VM{}
+		resource.With(m.(*model.VM))
+		resource.SelfLink =
+			VMHandler{}.Link(r.provider, m.(*model.VM))
+		object := resource.Content(r.withDetail(kind))
+		node = &TreeNode{
+			Parent: parent,
+			Kind:   kind,
+			Object: object,
+		}
+	case model.NetKind:
+		resource := &Network{}
+		resource.With(m.(*model.Network))
+		resource.SelfLink =
+			NetworkHandler{}.Link(r.provider, m.(*model.Network))
+		object := resource.Content(r.withDetail(kind))
+		node = &TreeNode{
+			Parent: parent,
+			Kind:   kind,
+			Object: object,
+		}
+	case model.StorageKind:
+		resource := &StorageDomain{}
+		resource.With(m.(*model.StorageDomain))
+		resource.SelfLink =
+			StorageDomainHandler{}.Link(r.provider, m.(*model.StorageDomain))
+		object := resource.Content(r.withDetail(kind))
+		node = &TreeNode{
+			Parent: parent,
+			Kind:   kind,
+			Object: object,
+		}
+	}
+
+	return node
+}
+
+//
+// Build with detail.
+func (r *NodeBuilder) withDetail(kind string) bool {
+	if b, found := r.detail[kind]; found {
+		return b
+	}
+
+	return false
+}

--- a/pkg/controller/provider/web/ovirt/vm.go
+++ b/pkg/controller/provider/web/ovirt/vm.go
@@ -145,12 +145,16 @@ func (h VMHandler) watch(ctx *gin.Context) {
 // REST Resource.
 type VM struct {
 	Resource
+	Cluster string `json:"cluster"`
+	Host string `json:"host"`
 }
 
 //
 // Build the resource using the model.
 func (r *VM) With(m *model.VM) {
 	r.Resource.With(&m.Base)
+	r.Cluster = m.Cluster
+	r.Host = m.Host
 }
 
 //

--- a/pkg/controller/provider/web/ovirt/vnicprofile.go
+++ b/pkg/controller/provider/web/ovirt/vnicprofile.go
@@ -145,13 +145,15 @@ func (h VNICProfileHandler) watch(ctx *gin.Context) {
 // REST Resource.
 type VNICProfile struct {
 	Resource
-	QoS model.Ref `json:"qos"`
+	DataCenter string    `json:"dataCenter"`
+	QoS        model.Ref `json:"qos"`
 }
 
 //
 // Build the resource using the model.
 func (r *VNICProfile) With(m *model.VNICProfile) {
 	r.Resource.With(&m.Base)
+	r.DataCenter = m.DataCenter
 	r.QoS = m.QoS
 }
 


### PR DESCRIPTION
Add tree & workload endpoints for oVirt.

There was a good bit of the vCenter tree code (and related model types) that could be shared. Refactored to `base` packages in both model and web layers.  Types moved to `base` (packages):
- Ref
- Tree
- TreeNode
- BranchNavigator
- ParentNavigator
- NodeBuilder (_new_)

The responsibility of fetching models while building the tree was shifted from the `Tree` to the the _navigator_.  This was necessary/better for 2 reasons:
1. For ovirt, the children need to be queried by parent ID.  Thus, the navigator already has the (child) models.  Returning `[]Ref` just to fetch 1-by-1 would be unnecessarily (very) inefficient.
2. The consolidation of concerns just makes since it's already navigating the model anyway.  This keeps knowledge of the model hierarchy in one place.

The `NodeBuilder` needed to be separated out of the `Tree` and delegated to a new provider type specific object.

Also, replaced the base `parent` in the oVirt model with specific _parent_ fields.  This is necessary to support query to build trees.