### PR TITLE
Fix pointer issue w/ Plan VM ref resolution

### DIFF
--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -279,8 +279,8 @@ func (r *Reconciler) validateVM(plan *api.Plan) error {
 	setOf := map[string]bool{}
 	//
 	// Referenced VMs.
-	for _, vm := range plan.Spec.VMs {
-		ref := &vm.Ref
+	for i := range plan.Spec.VMs {
+		ref := &plan.Spec.VMs[i].Ref
 		if ref.NotSet() {
 			plan.Status.SetCondition(libcnd.Condition{
 				Type:     VMRefNotValid,


### PR DESCRIPTION
The refs in the Plan spec's `vms` field weren't being resolved properly due to the ref being a loop copy of the one on the plan, rather than the ref itself. This was causing VMs to not match the list of VMs in the Plan's copy of the migration status, which resulted in completed VMs being restarted.