### PR TITLE
Fix logic error w/ kept VMs in Migration.begin()

### DIFF
--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -363,8 +363,8 @@ func (r *Migration) begin() (err error) {
 	}
 	//
 	// Delete
+	kept := []*plan.VMStatus{}
 	for _, status := range r.Plan.Status.Migration.VMs {
-		kept := []*plan.VMStatus{}
 
 		// resolve the VM ref
 		_, err = r.Source.Inventory.VM(&status.Ref)
@@ -376,8 +376,8 @@ func (r *Migration) begin() (err error) {
 		if _, found := r.Plan.Spec.FindVM(status.Ref); found {
 			kept = append(kept, status)
 		}
-		r.Plan.Status.Migration.VMs = kept
 	}
+	r.Plan.Status.Migration.VMs = kept
 	//
 	// Add/Update.
 	list := []*plan.VMStatus{}


### PR DESCRIPTION
Slice creation and assignment for kept VMs was happening inside of the for loop, so the slice of kept VMs would only ever have a single VM in it. Moved the creation and assignment outside of the loop to fix this.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1953145
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1959731