### PR TITLE
Optimized vSphere tree building.

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -270,7 +270,7 @@ func (r *Builder) hostID(vmRef ref.Ref) (hostID string, err error) {
 		return
 	}
 
-	hostID = vm.Host.ID
+	hostID = vm.Host
 
 	return
 }
@@ -456,7 +456,7 @@ func (r *Builder) datastoreID(vm *model.VM, ds *model.Datastore) (id string, err
 // Find may matching a `Host` CR.
 func (r *Builder) esxHost(vm *model.VM) (esxHost *EsxHost, found bool, err error) {
 	url := r.Source.Provider.Spec.URL
-	hostDef, found := r.hosts[vm.Host.ID]
+	hostDef, found := r.hosts[vm.Host]
 	if !found {
 		return
 	}
@@ -471,7 +471,7 @@ func (r *Builder) esxHost(vm *model.VM) (esxHost *EsxHost, found bool, err error
 		err = liberr.Wrap(err)
 		return
 	}
-	hostModel, nErr := r.host(vm.Host.ID)
+	hostModel, nErr := r.host(vm.Host)
 	if nErr != nil {
 		err = nErr
 		return

--- a/pkg/controller/plan/scheduler/vsphere/scheduler.go
+++ b/pkg/controller/plan/scheduler/vsphere/scheduler.go
@@ -112,7 +112,7 @@ func (r *Scheduler) buildInFlight() (err error) {
 			return
 		}
 		if vmStatus.Running() {
-			r.inFlight[vm.Host.ID] += len(vm.Disks)
+			r.inFlight[vm.Host] += len(vm.Disks)
 		}
 	}
 
@@ -153,7 +153,7 @@ func (r *Scheduler) buildInFlight() (err error) {
 				}
 				return err
 			}
-			r.inFlight[vm.Host.ID] += len(vm.Disks)
+			r.inFlight[vm.Host] += len(vm.Disks)
 		}
 	}
 
@@ -177,7 +177,7 @@ func (r *Scheduler) buildPending() (err error) {
 				status: vmStatus,
 				cost:   len(vm.Disks),
 			}
-			r.pending[vm.Host.ID] = append(r.pending[vm.Host.ID], pending)
+			r.pending[vm.Host] = append(r.pending[vm.Host], pending)
 		}
 	}
 	return

--- a/pkg/controller/provider/container/vsphere/model.go
+++ b/pkg/controller/provider/container/vsphere/model.go
@@ -99,6 +99,14 @@ func (v *FolderAdapter) Apply(u types.ObjectUpdate) {
 		switch p.Op {
 		case Assign:
 			switch p.Name {
+			case fParent:
+				ref := v.Ref(p.Val)
+				switch ref.Kind {
+				case model.DatacenterKind:
+					v.model.Datacenter = ref.ID
+				case model.FolderKind:
+					v.model.Folder = ref.ID
+				}
 			case fChildEntity:
 				v.model.Children = v.RefList(p.Val)
 			}
@@ -167,6 +175,8 @@ func (v *ClusterAdapter) Apply(u types.ObjectUpdate) {
 		switch p.Op {
 		case Assign:
 			switch p.Name {
+			case fParent:
+				v.model.Folder = v.Ref(p.Val).ID
 			case fHost:
 				v.model.Hosts = v.RefList(p.Val)
 			case fNetwork:
@@ -226,6 +236,8 @@ func (v *HostAdapter) Apply(u types.ObjectUpdate) {
 		switch p.Op {
 		case Assign:
 			switch p.Name {
+			case fParent:
+				v.model.Cluster = v.Ref(p.Val).ID
 			case fInMaintMode:
 				if b, cast := p.Val.(bool); cast {
 					v.model.InMaintenanceMode = b
@@ -492,6 +504,8 @@ func (v *VmAdapter) Apply(u types.ObjectUpdate) {
 		switch p.Op {
 		case Assign:
 			switch p.Name {
+			case fParent:
+				v.model.Folder = v.Ref(p.Val).ID
 			case fUUID:
 				if s, cast := p.Val.(string); cast {
 					v.model.UUID = s
@@ -564,7 +578,7 @@ func (v *VmAdapter) Apply(u types.ObjectUpdate) {
 					v.model.BalloonedMemory = n
 				}
 			case fRuntimeHost:
-				v.model.Host = v.Ref(p.Val)
+				v.model.Host = v.Ref(p.Val).ID
 			case fVmIpAddress:
 				if s, cast := p.Val.(string); cast {
 					v.model.IpAddress = s

--- a/pkg/controller/provider/model/vsphere/model.go
+++ b/pkg/controller/provider/model/vsphere/model.go
@@ -171,7 +171,9 @@ type About struct {
 
 type Folder struct {
 	Base
-	Children []Ref `sql:""`
+	Datacenter string `sql:"d0,index(datacenter)"`
+	Folder     string `sql:"d0,index(folder)"`
+	Children   []Ref  `sql:""`
 }
 
 type Datacenter struct {
@@ -184,6 +186,7 @@ type Datacenter struct {
 
 type Cluster struct {
 	Base
+	Folder      string `sql:"d0,index(folder)"`
 	Hosts       []Ref  `sql:""`
 	Networks    []Ref  `sql:""`
 	Datastores  []Ref  `sql:""`
@@ -196,6 +199,7 @@ type Cluster struct {
 
 type Host struct {
 	Base
+	Cluster            string      `sql:"d0,index(cluster)"`
 	InMaintenanceMode  bool        `sql:""`
 	ManagementServerIp string      `sql:""`
 	Thumbprint         string      `sql:""`
@@ -301,6 +305,8 @@ type Datastore struct {
 
 type VM struct {
 	Base
+	Folder                string    `sql:"d0,index(folder)"`
+	Host                  string    `sql:"d0,index(host)"`
 	RevisionValidated     int64     `sql:"d0,index(revisionValidated)"`
 	PolicyVersion         int       `sql:"d0,index(policyVersion)"`
 	UUID                  string    `sql:""`
@@ -326,7 +332,6 @@ type VM struct {
 	Devices               []Device  `sql:""`
 	Disks                 []Disk    `sql:""`
 	Networks              []Ref     `sql:""`
-	Host                  Ref       `sql:""`
 	Concerns              []Concern `sql:""`
 }
 

--- a/pkg/controller/provider/web/base/tree.go
+++ b/pkg/controller/provider/web/base/tree.go
@@ -2,8 +2,12 @@ package base
 
 import (
 	libmodel "github.com/konveyor/controller/pkg/inventory/model"
+	"github.com/konveyor/controller/pkg/logging"
 	model "github.com/konveyor/forklift-controller/pkg/controller/provider/model/base"
+	"time"
 )
+
+var log = logging.WithName("web|tree")
 
 //
 // Node builder.
@@ -39,6 +43,7 @@ func (r *Tree) Build(m model.Model, navigator model.BranchNavigator) (*TreeNode,
 	tree := model.Tree{
 		Depth: r.Depth,
 	}
+	mark := time.Now()
 	modelRoot, err := tree.Build(m, navigator)
 	if err != nil {
 		return nil, err
@@ -46,6 +51,8 @@ func (r *Tree) Build(m model.Model, navigator model.BranchNavigator) (*TreeNode,
 	for _, child := range modelRoot.Children {
 		walk(child)
 	}
+
+	log.V(1).Info("Tree built.", "duration", time.Since(mark))
 
 	return root, nil
 }

--- a/pkg/controller/provider/web/vsphere/cluster.go
+++ b/pkg/controller/provider/web/vsphere/cluster.go
@@ -156,6 +156,7 @@ func (h ClusterHandler) watch(ctx *gin.Context) {
 // REST Resource.
 type Cluster struct {
 	Resource
+	Folder      string      `json:"folder"`
 	Networks    []model.Ref `json:"networks"`
 	Datastores  []model.Ref `json:"datastores"`
 	Hosts       []model.Ref `json:"hosts"`
@@ -169,6 +170,7 @@ type Cluster struct {
 //
 // Build the resource using the model.
 func (r *Cluster) With(m *model.Cluster) {
+	r.Folder = m.Folder
 	r.Resource.With(&m.Base)
 	r.DasEnabled = m.DasEnabled
 	r.DrsEnabled = m.DrsEnabled

--- a/pkg/controller/provider/web/vsphere/folder.go
+++ b/pkg/controller/provider/web/vsphere/folder.go
@@ -157,13 +157,17 @@ func (h FolderHandler) watch(ctx *gin.Context) {
 // REST Resource.
 type Folder struct {
 	Resource
-	Children []model.Ref `json:"children"`
+	Folder     string      `json:"folder"`
+	Datacenter string      `json:"datacenter"`
+	Children   []model.Ref `json:"children"`
 }
 
 //
 // Build the resource using the model.
 func (r *Folder) With(m *model.Folder) {
 	r.Resource.With(&m.Base)
+	r.Folder = m.Folder
+	r.Datacenter = m.Datacenter
 	r.Children = m.Children
 }
 

--- a/pkg/controller/provider/web/vsphere/host.go
+++ b/pkg/controller/provider/web/vsphere/host.go
@@ -233,6 +233,7 @@ func (h *HostHandler) buildAdapters(host *Host) (err error) {
 // REST Resource.
 type Host struct {
 	Resource
+	Cluster            string            `json:"cluster"`
 	InMaintenanceMode  bool              `json:"inMaintenance"`
 	ManagementServerIp string            `json:"managementServerIp"`
 	Thumbprint         string            `json:"thumbprint"`
@@ -251,6 +252,7 @@ type Host struct {
 // Build the resource using the model.
 func (r *Host) With(m *model.Host) {
 	r.Resource.With(&m.Base)
+	r.Cluster = m.Cluster
 	r.InMaintenanceMode = m.InMaintenanceMode
 	r.ManagementServerIp = m.ManagementServerIp
 	r.Thumbprint = m.Thumbprint

--- a/pkg/controller/provider/web/vsphere/vm.go
+++ b/pkg/controller/provider/web/vsphere/vm.go
@@ -199,6 +199,8 @@ func (h VMHandler) filter(ctx *gin.Context, list *[]model.VM) (err error) {
 // REST Resource.
 type VM struct {
 	Resource
+	Folder                string          `json:"folder"`
+	Host                  string          `json:"host"`
 	PolicyVersion         int             `json:"policyVersion"`
 	RevisionValidated     int64           `json:"revisionValidated"`
 	UUID                  string          `json:"uuid"`
@@ -224,7 +226,6 @@ type VM struct {
 	Devices               []model.Device  `json:"devices"`
 	Networks              []model.Ref     `json:"networks"`
 	Disks                 []model.Disk    `json:"disks"`
-	Host                  model.Ref       `json:"host"`
 	Concerns              []model.Concern `json:"concerns"`
 }
 
@@ -232,6 +233,8 @@ type VM struct {
 // Build the resource using the model.
 func (r *VM) With(m *model.VM) {
 	r.Resource.With(&m.Base)
+	r.Host = m.Host
+	r.Folder = m.Folder
 	r.PolicyVersion = m.PolicyVersion
 	r.RevisionValidated = m.RevisionValidated
 	r.UUID = m.UUID
@@ -257,7 +260,6 @@ func (r *VM) With(m *model.VM) {
 	r.NumaNodeAffinity = m.NumaNodeAffinity
 	r.Networks = m.Networks
 	r.Disks = m.Disks
-	r.Host = m.Host
 	r.Concerns = m.Concerns
 }
 

--- a/pkg/controller/provider/web/vsphere/workload.go
+++ b/pkg/controller/provider/web/vsphere/workload.go
@@ -109,16 +109,27 @@ type WorkloadNavigator struct {
 //
 // Next parent.
 func (n *WorkloadNavigator) Next(m model.Model) (r model.Model, err error) {
-	bn := BranchNavigator{db: n.db}
 	switch m.(type) {
-	case *model.Folder:
-		r, err = bn.get(m.(*model.Folder).Parent)
-	case *model.Cluster:
-		r, err = bn.get(m.(*model.Cluster).Parent)
 	case *model.Host:
-		r, err = bn.get(m.(*model.Host).Parent)
+		m := &model.Cluster{
+			Base: model.Base{
+				ID: m.(*model.Host).Parent.ID,
+			},
+		}
+		err = n.db.Get(m)
+		if err == nil {
+			r = m
+		}
 	case *model.VM:
-		r, err = bn.get(m.(*model.VM).Host)
+		m := &model.Host{
+			Base: model.Base{
+				ID: m.(*model.VM).Host,
+			},
+		}
+		err = n.db.Get(m)
+		if err == nil {
+			r = m
+		}
 	}
 
 	return


### PR DESCRIPTION
Update the algorithm for building the vSphere trees.  Results in a **5x** improvement in performance and (likely) reduced CPU usage.

**Instead of** traversing each node: following child refs and Get() each child by ref.  The number of queries is a multiple of the number of children of each node.  So 4k VMs results in 4k+ queries.

**The optimization** traverse each node: List() children by parent=_node_.  The number of queries is a multiple of the tree depth.

To achieve this:
- The vSphere `Model` objects needed a few _new_ _natural_ FK to parents.
- The tree _navigators_ needed to be rewritten (they are simple).
- The web resources updated to reflect the new FK fields (mainly to make visual testing easier).
- The existing` VM.Host` needed to be changed from type `Ref` to `string` to support DB query.  The ref is stored has json.
- The vSphere `Builder` and `Scheduler` needed to be updated for the VM.Host field change.