### PR TITLE
Fix vsphere validation search.

### DIFF
--- a/pkg/settings/policy.go
+++ b/pkg/settings/policy.go
@@ -8,6 +8,7 @@ import (
 // Environment variables.
 const (
 	PolicyAgentURL            = "POLICY_AGENT_URL"
+	PolicyTLSEnabled          = "POLICY_TLS_ENABLED"
 	PolicyAgentCA             = "POLICY_AGENT_CA"
 	PolicyAgentWorkerLimit    = "POLICY_AGENT_WORKER_LIMIT"
 	PolicyAgentBacklogLimit   = "POLICY_AGENT_BACKLOG_LIMIT"
@@ -19,8 +20,13 @@ const (
 type PolicyAgent struct {
 	// URL.
 	URL string
-	// CA path
-	CA string
+	// TLS
+	TLS struct {
+		// Enabled.
+		Enabled bool
+		// CA path
+		CA string
+	}
 	// Search interval (seconds).
 	SearchInterval int
 	// Limits.
@@ -38,10 +44,12 @@ func (r *PolicyAgent) Load() (err error) {
 	if s, found := os.LookupEnv(PolicyAgentURL); found {
 		r.URL = s
 	}
+	// TLS
+	r.TLS.Enabled = getEnvBool(TLSEnabled, false)
 	if s, found := os.LookupEnv(PolicyAgentCA); found {
-		r.CA = s
+		r.TLS.CA = s
 	} else {
-		r.CA = ServiceCAFile
+		r.TLS.CA = ServiceCAFile
 	}
 	r.Limit.Worker, err = getEnvLimit(PolicyAgentWorkerLimit, 10)
 	if err != nil {


### PR DESCRIPTION
Fix (runaway) vsphere validation search.
The search lists VM that need to be validated in pages. However, the page was never incremented.  As a result, the loop would run _hot_ for a bit but would exit eventually when all of the VMs were validated.
However, the input queue to the validation worker queue has limited capacity and Pool.Submit() can return a `BacklogExceededError`.  This is anticipated and logged.  It's designed to be _best effort_ and relies on the next scheduled search to validate the VM.

However, there is a flaw that results in an infinite, _hot_ loop in the goroutine.

The _runaway_ scenario:

1. The VM created/updated event received.
2. The handler reports that it has scheduled the validation.
3. The Submit() fails and is logged.
4. The search lists VMs and finds the VM but ignores it because it was reported as already scheduled.
5. The search runs in a tight loop forever.

The fix.
1. Use DB.Iter() instead of pagination when listing VM in the search.
2. Report the VM as _scheduled_ for validation only if validate() does not return an error.
3. Abort the search (loop) if the context is canceled.