### PR TITLE
Better handling of provider inventory not-ready.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/gin-gonic/gin v1.6.3
 	github.com/go-logr/logr v0.3.0
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.1.0
-	github.com/konveyor/controller v0.4.1
+	github.com/konveyor/controller v0.4.2
 	github.com/onsi/gomega v1.10.3
 	github.com/pkg/profile v1.3.0
 	github.com/prometheus/client_golang v1.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -723,6 +723,8 @@ github.com/konveyor/controller v0.4.0 h1:Bz9WVys5yw/TDir5nAEgFhfd8wGI45t4aLAOYK+
 github.com/konveyor/controller v0.4.0/go.mod h1:j0DSNesS0XHmqOLcJEuwB+qIRkdJ3mSIEJFA2byC12c=
 github.com/konveyor/controller v0.4.1 h1:0LiBaAIrXScOqb6OoIGOIqpK9dxBAQotPWEhP4JX4qk=
 github.com/konveyor/controller v0.4.1/go.mod h1:j0DSNesS0XHmqOLcJEuwB+qIRkdJ3mSIEJFA2byC12c=
+github.com/konveyor/controller v0.4.2 h1:xP+vDP+c2eWJMERjfx2UeaoJHYJRavOnA6wnKMivTxw=
+github.com/konveyor/controller v0.4.2/go.mod h1:j0DSNesS0XHmqOLcJEuwB+qIRkdJ3mSIEJFA2byC12c=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=

--- a/pkg/controller/host/handler/vsphere/handler.go
+++ b/pkg/controller/host/handler/vsphere/handler.go
@@ -49,9 +49,6 @@ func (r *Handler) Watch(watch *handler.WatchManager) (err error) {
 //
 // Resource created.
 func (r *Handler) Created(e libweb.Event) {
-	if !r.HasParity() {
-		return
-	}
 	if host, cast := e.Resource.(*vsphere.Host); cast {
 		r.changed(host)
 	}
@@ -60,9 +57,6 @@ func (r *Handler) Created(e libweb.Event) {
 //
 // Resource created.
 func (r *Handler) Updated(e libweb.Event) {
-	if !r.HasParity() {
-		return
-	}
 	if host, cast := e.Resource.(*vsphere.Host); cast {
 		updated := e.Updated.(*vsphere.Host)
 		if updated.Path != host.Path {
@@ -74,9 +68,6 @@ func (r *Handler) Updated(e libweb.Event) {
 //
 // Resource deleted.
 func (r *Handler) Deleted(e libweb.Event) {
-	if !r.HasParity() {
-		return
-	}
 	if host, cast := e.Resource.(*vsphere.Host); cast {
 		r.changed(host)
 	}

--- a/pkg/controller/map/network/handler/ocp/handler.go
+++ b/pkg/controller/map/network/handler/ocp/handler.go
@@ -48,9 +48,6 @@ func (r *Handler) Watch(watch *handler.WatchManager) (err error) {
 //
 // Resource created.
 func (r *Handler) Created(e libweb.Event) {
-	if !r.HasParity() {
-		return
-	}
 	if network, cast := e.Resource.(*ocp.NetworkAttachmentDefinition); cast {
 		r.changed(network)
 	}
@@ -59,9 +56,6 @@ func (r *Handler) Created(e libweb.Event) {
 //
 // Resource deleted.
 func (r *Handler) Deleted(e libweb.Event) {
-	if !r.HasParity() {
-		return
-	}
 	if network, cast := e.Resource.(*ocp.NetworkAttachmentDefinition); cast {
 		r.changed(network)
 	}

--- a/pkg/controller/map/network/handler/ovirt/handler.go
+++ b/pkg/controller/map/network/handler/ovirt/handler.go
@@ -49,9 +49,6 @@ func (r *Handler) Watch(watch *handler.WatchManager) (err error) {
 //
 // Resource created.
 func (r *Handler) Created(e libweb.Event) {
-	if !r.HasParity() {
-		return
-	}
 	if network, cast := e.Resource.(*ovirt.Network); cast {
 		r.changed(network)
 	}
@@ -60,9 +57,6 @@ func (r *Handler) Created(e libweb.Event) {
 //
 // Resource created.
 func (r *Handler) Updated(e libweb.Event) {
-	if !r.HasParity() {
-		return
-	}
 	if network, cast := e.Resource.(*ovirt.Network); cast {
 		updated := e.Updated.(*ovirt.Network)
 		if updated.Path != network.Path {
@@ -74,9 +68,6 @@ func (r *Handler) Updated(e libweb.Event) {
 //
 // Resource deleted.
 func (r *Handler) Deleted(e libweb.Event) {
-	if !r.HasParity() {
-		return
-	}
 	if network, cast := e.Resource.(*ovirt.Network); cast {
 		r.changed(network)
 	}

--- a/pkg/controller/map/network/handler/vsphere/handler.go
+++ b/pkg/controller/map/network/handler/vsphere/handler.go
@@ -49,9 +49,6 @@ func (r *Handler) Watch(watch *handler.WatchManager) (err error) {
 //
 // Resource created.
 func (r *Handler) Created(e libweb.Event) {
-	if !r.HasParity() {
-		return
-	}
 	if network, cast := e.Resource.(*vsphere.Network); cast {
 		r.changed(network)
 	}
@@ -60,9 +57,6 @@ func (r *Handler) Created(e libweb.Event) {
 //
 // Resource created.
 func (r *Handler) Updated(e libweb.Event) {
-	if !r.HasParity() {
-		return
-	}
 	if network, cast := e.Resource.(*vsphere.Network); cast {
 		updated := e.Updated.(*vsphere.Network)
 		if updated.Path != network.Path {
@@ -74,9 +68,6 @@ func (r *Handler) Updated(e libweb.Event) {
 //
 // Resource deleted.
 func (r *Handler) Deleted(e libweb.Event) {
-	if !r.HasParity() {
-		return
-	}
 	if network, cast := e.Resource.(*vsphere.Network); cast {
 		r.changed(network)
 	}

--- a/pkg/controller/map/storage/handler/ocp/handler.go
+++ b/pkg/controller/map/storage/handler/ocp/handler.go
@@ -48,9 +48,6 @@ func (r *Handler) Watch(watch *handler.WatchManager) (err error) {
 //
 // Resource created.
 func (r *Handler) Created(e libweb.Event) {
-	if !r.HasParity() {
-		return
-	}
 	if storageClass, cast := e.Resource.(*ocp.StorageClass); cast {
 		r.changed(storageClass)
 	}
@@ -59,9 +56,6 @@ func (r *Handler) Created(e libweb.Event) {
 //
 // Resource deleted.
 func (r *Handler) Deleted(e libweb.Event) {
-	if !r.HasParity() {
-		return
-	}
 	if storageClass, cast := e.Resource.(*ocp.StorageClass); cast {
 		r.changed(storageClass)
 	}

--- a/pkg/controller/map/storage/handler/ovirt/handler.go
+++ b/pkg/controller/map/storage/handler/ovirt/handler.go
@@ -49,9 +49,6 @@ func (r *Handler) Watch(watch *handler.WatchManager) (err error) {
 //
 // Resource created.
 func (r *Handler) Created(e libweb.Event) {
-	if !r.HasParity() {
-		return
-	}
 	if ds, cast := e.Resource.(*ovirt.StorageDomain); cast {
 		r.changed(ds)
 	}
@@ -60,9 +57,6 @@ func (r *Handler) Created(e libweb.Event) {
 //
 // Resource created.
 func (r *Handler) Updated(e libweb.Event) {
-	if !r.HasParity() {
-		return
-	}
 	if ds, cast := e.Resource.(*ovirt.StorageDomain); cast {
 		updated := e.Updated.(*ovirt.StorageDomain)
 		if updated.Path != ds.Path {
@@ -74,9 +68,6 @@ func (r *Handler) Updated(e libweb.Event) {
 //
 // Resource deleted.
 func (r *Handler) Deleted(e libweb.Event) {
-	if !r.HasParity() {
-		return
-	}
 	if ds, cast := e.Resource.(*ovirt.StorageDomain); cast {
 		r.changed(ds)
 	}

--- a/pkg/controller/map/storage/handler/vsphere/handler.go
+++ b/pkg/controller/map/storage/handler/vsphere/handler.go
@@ -49,9 +49,6 @@ func (r *Handler) Watch(watch *handler.WatchManager) (err error) {
 //
 // Resource created.
 func (r *Handler) Created(e libweb.Event) {
-	if !r.HasParity() {
-		return
-	}
 	if ds, cast := e.Resource.(*vsphere.Datastore); cast {
 		r.changed(ds)
 	}
@@ -60,9 +57,6 @@ func (r *Handler) Created(e libweb.Event) {
 //
 // Resource created.
 func (r *Handler) Updated(e libweb.Event) {
-	if !r.HasParity() {
-		return
-	}
 	if ds, cast := e.Resource.(*vsphere.Datastore); cast {
 		updated := e.Updated.(*vsphere.Datastore)
 		if updated.Path != ds.Path {
@@ -74,9 +68,6 @@ func (r *Handler) Updated(e libweb.Event) {
 //
 // Resource deleted.
 func (r *Handler) Deleted(e libweb.Event) {
-	if !r.HasParity() {
-		return
-	}
 	if ds, cast := e.Resource.(*vsphere.Datastore); cast {
 		r.changed(ds)
 	}

--- a/pkg/controller/plan/handler/ocp/handler.go
+++ b/pkg/controller/plan/handler/ocp/handler.go
@@ -48,9 +48,6 @@ func (r *Handler) Watch(watch *handler.WatchManager) (err error) {
 //
 // Resource created.
 func (r *Handler) Created(e libweb.Event) {
-	if !r.HasParity() {
-		return
-	}
 	if vm, cast := e.Resource.(*ocp.VM); cast {
 		r.changed(vm)
 	}
@@ -59,9 +56,6 @@ func (r *Handler) Created(e libweb.Event) {
 //
 // Resource deleted.
 func (r *Handler) Deleted(e libweb.Event) {
-	if !r.HasParity() {
-		return
-	}
 	if vm, cast := e.Resource.(*ocp.VM); cast {
 		r.changed(vm)
 	}

--- a/pkg/controller/plan/handler/ovirt/handler.go
+++ b/pkg/controller/plan/handler/ovirt/handler.go
@@ -49,9 +49,6 @@ func (r *Handler) Watch(watch *handler.WatchManager) (err error) {
 //
 // Resource created.
 func (r *Handler) Created(e libweb.Event) {
-	if !r.HasParity() {
-		return
-	}
 	if vm, cast := e.Resource.(*ovirt.VM); cast {
 		r.changed(vm)
 	}
@@ -60,9 +57,6 @@ func (r *Handler) Created(e libweb.Event) {
 //
 // Resource created.
 func (r *Handler) Updated(e libweb.Event) {
-	if !r.HasParity() {
-		return
-	}
 	if vm, cast := e.Resource.(*ovirt.VM); cast {
 		updated := e.Updated.(*ovirt.VM)
 		if updated.Path != vm.Path {
@@ -74,9 +68,6 @@ func (r *Handler) Updated(e libweb.Event) {
 //
 // Resource deleted.
 func (r *Handler) Deleted(e libweb.Event) {
-	if !r.HasParity() {
-		return
-	}
 	if vm, cast := e.Resource.(*ovirt.VM); cast {
 		r.changed(vm)
 	}

--- a/pkg/controller/plan/handler/vsphere/handler.go
+++ b/pkg/controller/plan/handler/vsphere/handler.go
@@ -49,9 +49,6 @@ func (r *Handler) Watch(watch *handler.WatchManager) (err error) {
 //
 // Resource created.
 func (r *Handler) Created(e libweb.Event) {
-	if !r.HasParity() {
-		return
-	}
 	if vm, cast := e.Resource.(*vsphere.VM); cast {
 		r.changed(vm)
 	}
@@ -60,9 +57,6 @@ func (r *Handler) Created(e libweb.Event) {
 //
 // Resource created.
 func (r *Handler) Updated(e libweb.Event) {
-	if !r.HasParity() {
-		return
-	}
 	if vm, cast := e.Resource.(*vsphere.VM); cast {
 		updated := e.Updated.(*vsphere.VM)
 		if updated.Path != vm.Path {
@@ -74,9 +68,6 @@ func (r *Handler) Updated(e libweb.Event) {
 //
 // Resource deleted.
 func (r *Handler) Deleted(e libweb.Event) {
-	if !r.HasParity() {
-		return
-	}
 	if vm, cast := e.Resource.(*vsphere.VM); cast {
 		r.changed(vm)
 	}

--- a/pkg/controller/provider/container/vsphere/watch.go
+++ b/pkg/controller/provider/container/vsphere/watch.go
@@ -101,6 +101,9 @@ func (r *VMEventHandler) Started(uint64) {
 // This is best-effort.  If the validate() fails, it wil be
 // picked up in the next search().
 func (r *VMEventHandler) Created(event libmodel.Event) {
+	if r.canceled() {
+		return
+	}
 	if vm, cast := event.Model.(*model.VM); cast {
 		if !vm.Validated() {
 			if r.validate(vm) == nil {
@@ -116,6 +119,9 @@ func (r *VMEventHandler) Created(event libmodel.Event) {
 // This is best-effort.  If the validate() fails, it wil be
 // picked up in the next search().
 func (r *VMEventHandler) Updated(event libmodel.Event) {
+	if r.canceled() {
+		return
+	}
 	if vm, cast := event.Updated.(*model.VM); cast {
 		if !vm.Validated() {
 			if r.validate(vm) == nil {
@@ -225,10 +231,8 @@ func (r *VMEventHandler) list() {
 		r.log.Error(err, err.Error())
 		return
 	}
-	select {
-	case <-r.context.Done():
+	if r.canceled() {
 		return
-	default:
 	}
 	itr, err := r.DB.Iter(
 		&model.VM{},
@@ -248,7 +252,7 @@ func (r *VMEventHandler) list() {
 			r.log.Error(err, "VM iterator failed.")
 			break
 		}
-		if !hasNext {
+		if !hasNext || r.canceled() {
 			break
 		}
 		if revision, found := r.reported[vm.ID]; found {
@@ -257,6 +261,17 @@ func (r *VMEventHandler) list() {
 			}
 		}
 		_ = r.validate(vm)
+	}
+}
+
+//
+// Handler canceled.
+func (r *VMEventHandler) canceled() bool {
+	select {
+	case <-r.context.Done():
+		return true
+	default:
+		return false
 	}
 }
 

--- a/pkg/controller/provider/container/vsphere/watch.go
+++ b/pkg/controller/provider/container/vsphere/watch.go
@@ -22,7 +22,6 @@ package vsphere
 
 import (
 	"context"
-	"errors"
 	"github.com/go-logr/logr"
 	liberr "github.com/konveyor/controller/pkg/error"
 	libmodel "github.com/konveyor/controller/pkg/inventory/model"
@@ -161,6 +160,7 @@ func (r *VMEventHandler) run() {
 	defer r.log.Info("Run stopped.")
 	interval := time.Second * time.Duration(
 		Settings.PolicyAgent.SearchInterval)
+	r.list()
 	r.reset()
 	for {
 		select {
@@ -274,11 +274,7 @@ func (r *VMEventHandler) validate(vm *model.VM) (err error) {
 	}
 	err = policy.Agent.Submit(task)
 	if err != nil {
-		if errors.As(err, &policy.BacklogExceededError{}) {
-			r.log.Info(err.Error())
-		} else {
-			r.log.Error(err, "VM task (submit) failed.")
-		}
+		r.log.Error(err, "VM task (submit) failed.")
 	}
 
 	return

--- a/pkg/controller/watch/handler/handler.go
+++ b/pkg/controller/watch/handler/handler.go
@@ -33,8 +33,6 @@ type Handler struct {
 	id uint64
 	// Watch ended by peer.
 	ended bool
-	// Parity marker.
-	parity bool
 }
 
 //
@@ -73,13 +71,6 @@ func (r *Handler) Match(object meta.Object, ref core.ObjectReference) bool {
 
 //
 // Inventory watch has parity.
-func (r *Handler) HasParity() bool {
-	return r.parity
-
-}
-
-//
-// Inventory watch has parity.
 func (r *Handler) Started(id uint64) {
 	r.id = id
 	log.V(1).Info(
@@ -89,20 +80,9 @@ func (r *Handler) Started(id uint64) {
 }
 
 //
-// Inventory watch has parity.
-func (r *Handler) Parity() {
-	r.parity = true
-	log.V(1).Info(
-		"event: parity.",
-		"id",
-		r.id)
-}
-
-//
 // Watch ended by peer.
 // The database has been closed.
 func (r *Handler) End() {
-	r.parity = false
 	r.ended = true
 	log.V(1).Info(
 		"event: ended.",

--- a/pkg/settings/policy.go
+++ b/pkg/settings/policy.go
@@ -11,7 +11,6 @@ const (
 	PolicyTLSEnabled          = "POLICY_TLS_ENABLED"
 	PolicyAgentCA             = "POLICY_AGENT_CA"
 	PolicyAgentWorkerLimit    = "POLICY_AGENT_WORKER_LIMIT"
-	PolicyAgentBacklogLimit   = "POLICY_AGENT_BACKLOG_LIMIT"
 	PolicyAgentSearchInterval = "POLICY_AGENT_SEARCH_INTERVAL"
 )
 
@@ -33,8 +32,6 @@ type PolicyAgent struct {
 	Limit struct {
 		// Number of workers.
 		Worker int
-		// Backlog depth.
-		Backlog int
 	}
 }
 
@@ -52,10 +49,6 @@ func (r *PolicyAgent) Load() (err error) {
 		r.TLS.CA = ServiceCAFile
 	}
 	r.Limit.Worker, err = getEnvLimit(PolicyAgentWorkerLimit, 10)
-	if err != nil {
-		return err
-	}
-	r.Limit.Backlog, err = getEnvLimit(PolicyAgentBacklogLimit, 10000)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Better handling of provider inventory not-ready.
To distinguish between 404 because the provider has not yet been added to the container vs. the resource is not in the inventory, the client will:
- **Currently**: The client fetches the provider on every request.
- **This PR**: The web handler (server) sets the `X-Provider` header when the requested _provider_ is found in the container. If the header is not set, the client determines that the 404 is because the provider has not yet been loaded and returns a `ProviderNotReady` error.  Else, the provider is in the container but the resource is not found.

This enhancement will cut the number of GET requests to the API (from the controller) in half.

Also, noticed the `PartialContent` (206) was not being handled.

**Note**: Requires: https://github.com/konveyor/controller/pull/77