### PR TITLE
Refactor Handler.Link() for better separation of responsibility and re-use outside the web layer.

### DIFF
--- a/pkg/controller/provider/web/base/handler.go
+++ b/pkg/controller/provider/web/base/handler.go
@@ -34,6 +34,18 @@ const (
 type Params = map[string]string
 
 //
+// Build link.
+func Link(path string, params Params) string {
+	for k, v := range params {
+		if len(v) > 0 {
+			path = strings.Replace(path, ":"+k, v, 1)
+		}
+	}
+
+	return path
+}
+
+//
 // Base handler.
 type Handler struct {
 	libweb.Parity
@@ -79,13 +91,7 @@ func (h *Handler) Prepare(ctx *gin.Context) int {
 //
 // Build link.
 func (h *Handler) Link(path string, params Params) string {
-	for k, v := range params {
-		if len(v) > 0 {
-			path = strings.Replace(path, ":"+k, v, 1)
-		}
-	}
-
-	return path
+	return Link(path, params)
 }
 
 //

--- a/pkg/controller/provider/web/ovirt/client.go
+++ b/pkg/controller/provider/web/ovirt/client.go
@@ -3,8 +3,6 @@ package ovirt
 import (
 	liberr "github.com/konveyor/controller/pkg/error"
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
-	ocpmodel "github.com/konveyor/forklift-controller/pkg/controller/provider/model/ocp"
-	model "github.com/konveyor/forklift-controller/pkg/controller/provider/model/ovirt"
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/web/base"
 	"strings"
 )
@@ -24,55 +22,43 @@ type Resolver struct {
 //
 // Build the URL path.
 func (r *Resolver) Path(resource interface{}, id string) (path string, err error) {
+	provider := r.Provider
 	switch resource.(type) {
 	case *Provider:
-		h := ProviderHandler{}
-		path = h.Link(
-			&ocpmodel.Provider{
-				Base: ocpmodel.Base{UID: id},
-			})
+		r := Provider{}
+		r.UID = id
+		r.Link()
+		path = r.SelfLink
 	case *DataCenter:
-		h := DataCenterHandler{}
-		path = h.Link(
-			r.Provider,
-			&model.DataCenter{
-				Base: model.Base{ID: id},
-			})
+		r := DataCenter{}
+		r.ID = id
+		r.Link(provider)
+		path = r.SelfLink
 	case *Cluster:
-		h := ClusterHandler{}
-		path = h.Link(
-			r.Provider,
-			&model.Cluster{
-				Base: model.Base{ID: id},
-			})
+		r := Cluster{}
+		r.ID = id
+		r.Link(provider)
+		path = r.SelfLink
 	case *Host:
-		h := HostHandler{}
-		path = h.Link(
-			r.Provider,
-			&model.Host{
-				Base: model.Base{ID: id},
-			})
+		r := Host{}
+		r.ID = id
+		r.Link(provider)
+		path = r.SelfLink
 	case *Network:
-		h := NetworkHandler{}
-		path = h.Link(
-			r.Provider,
-			&model.Network{
-				Base: model.Base{ID: id},
-			})
+		r := Network{}
+		r.ID = id
+		r.Link(provider)
+		path = r.SelfLink
 	case *StorageDomain:
-		h := StorageDomainHandler{}
-		path = h.Link(
-			r.Provider,
-			&model.StorageDomain{
-				Base: model.Base{ID: id},
-			})
+		r := StorageDomain{}
+		r.ID = id
+		r.Link(provider)
+		path = r.SelfLink
 	case *VM:
-		h := VMHandler{}
-		path = h.Link(
-			r.Provider,
-			&model.VM{
-				Base: model.Base{ID: id},
-			})
+		r := VM{}
+		r.ID = id
+		r.Link(provider)
+		path = r.SelfLink
 	default:
 		err = liberr.Wrap(
 			base.ResourceNotResolvedError{

--- a/pkg/controller/provider/web/ovirt/cluster.go
+++ b/pkg/controller/provider/web/ovirt/cluster.go
@@ -65,7 +65,7 @@ func (h ClusterHandler) List(ctx *gin.Context) {
 	for _, m := range list {
 		r := &Cluster{}
 		r.With(&m)
-		r.SelfLink = h.Link(h.Provider, &m)
+		r.Link(h.Provider)
 		content = append(content, r.Content(h.Detail))
 	}
 
@@ -101,21 +101,10 @@ func (h ClusterHandler) Get(ctx *gin.Context) {
 	}
 	r := &Cluster{}
 	r.With(m)
-	r.SelfLink = h.Link(h.Provider, m)
+	r.Link(h.Provider)
 	content := r.Content(true)
 
 	ctx.JSON(http.StatusOK, content)
-}
-
-//
-// Build self link (URI).
-func (h ClusterHandler) Link(p *api.Provider, m *model.Cluster) string {
-	return h.Handler.Link(
-		ClusterRoot,
-		base.Params{
-			base.ProviderParam: string(p.UID),
-			ClusterParam:       m.ID,
-		})
 }
 
 //
@@ -130,7 +119,7 @@ func (h ClusterHandler) watch(ctx *gin.Context) {
 			m := in.(*model.Cluster)
 			cluster := &Cluster{}
 			cluster.With(m)
-			cluster.SelfLink = h.Link(h.Provider, m)
+			cluster.Link(h.Provider)
 			r = cluster
 			return
 		})
@@ -159,6 +148,17 @@ func (r *Cluster) With(m *model.Cluster) {
 	r.DataCenter = m.DataCenter
 	r.HaReservation = m.HaReservation
 	r.KsmEnabled = m.KsmEnabled
+}
+
+//
+// Build self link (URI).
+func (r *Cluster) Link(p *api.Provider) {
+	r.SelfLink = base.Link(
+		ClusterRoot,
+		base.Params{
+			base.ProviderParam: string(p.UID),
+			ClusterParam:       r.ID,
+		})
 }
 
 //

--- a/pkg/controller/provider/web/ovirt/datacenter.go
+++ b/pkg/controller/provider/web/ovirt/datacenter.go
@@ -65,7 +65,7 @@ func (h DataCenterHandler) List(ctx *gin.Context) {
 	for _, m := range list {
 		r := &DataCenter{}
 		r.With(&m)
-		r.SelfLink = h.Link(h.Provider, &m)
+		r.Link(h.Provider)
 		content = append(content, r.Content(h.Detail))
 	}
 
@@ -101,21 +101,10 @@ func (h DataCenterHandler) Get(ctx *gin.Context) {
 	}
 	r := &DataCenter{}
 	r.With(m)
-	r.SelfLink = h.Link(h.Provider, m)
+	r.Link(h.Provider)
 	content := r.Content(true)
 
 	ctx.JSON(http.StatusOK, content)
-}
-
-//
-// Build self link (URI).
-func (h DataCenterHandler) Link(p *api.Provider, m *model.DataCenter) string {
-	return h.Handler.Link(
-		DataCenterRoot,
-		base.Params{
-			base.ProviderParam: string(p.UID),
-			DataCenterParam:    m.ID,
-		})
 }
 
 //
@@ -130,7 +119,7 @@ func (h DataCenterHandler) watch(ctx *gin.Context) {
 			m := in.(*model.DataCenter)
 			dc := &DataCenter{}
 			dc.With(m)
-			dc.SelfLink = h.Link(h.Provider, m)
+			dc.Link(h.Provider)
 			r = dc
 			return
 		})
@@ -153,6 +142,17 @@ type DataCenter struct {
 // Build the resource using the model.
 func (r *DataCenter) With(m *model.DataCenter) {
 	r.Resource.With(&m.Base)
+}
+
+//
+// Build self link (URI).
+func (r *DataCenter) Link(p *api.Provider) {
+	r.SelfLink = base.Link(
+		DataCenterRoot,
+		base.Params{
+			base.ProviderParam: string(p.UID),
+			DataCenterParam:    r.ID,
+		})
 }
 
 //

--- a/pkg/controller/provider/web/ovirt/diskprofile.go
+++ b/pkg/controller/provider/web/ovirt/diskprofile.go
@@ -63,7 +63,7 @@ func (h DiskProfileHandler) List(ctx *gin.Context) {
 	for _, m := range list {
 		r := &DiskProfile{}
 		r.With(&m)
-		r.SelfLink = h.Link(h.Provider, &m)
+		r.Link(h.Provider)
 		content = append(content, r.Content(h.Detail))
 	}
 
@@ -99,21 +99,10 @@ func (h DiskProfileHandler) Get(ctx *gin.Context) {
 	}
 	r := &DiskProfile{}
 	r.With(m)
-	r.SelfLink = h.Link(h.Provider, m)
+	r.Link(h.Provider)
 	content := r.Content(true)
 
 	ctx.JSON(http.StatusOK, content)
-}
-
-//
-// Build self link (URI).
-func (h DiskProfileHandler) Link(p *api.Provider, m *model.DiskProfile) string {
-	return h.Handler.Link(
-		DiskProfileRoot,
-		base.Params{
-			base.ProviderParam: string(p.UID),
-			DiskProfileParam:   m.ID,
-		})
 }
 
 //
@@ -128,7 +117,7 @@ func (h DiskProfileHandler) watch(ctx *gin.Context) {
 			m := in.(*model.DiskProfile)
 			profile := &DiskProfile{}
 			profile.With(m)
-			profile.SelfLink = h.Link(h.Provider, m)
+			profile.Link(h.Provider)
 			r = profile
 			return
 		})
@@ -155,6 +144,17 @@ func (r *DiskProfile) With(m *model.DiskProfile) {
 	r.Resource.With(&m.Base)
 	r.StorageDomain = m.StorageDomain
 	r.QoS = m.QoS
+}
+
+//
+// Build self link (URI).
+func (r *DiskProfile) Link(p *api.Provider) {
+	r.SelfLink = base.Link(
+		DiskProfileRoot,
+		base.Params{
+			base.ProviderParam: string(p.UID),
+			DiskProfileParam:   r.ID,
+		})
 }
 
 //

--- a/pkg/controller/provider/web/ovirt/host.go
+++ b/pkg/controller/provider/web/ovirt/host.go
@@ -63,7 +63,7 @@ func (h HostHandler) List(ctx *gin.Context) {
 	for _, m := range list {
 		r := &Host{}
 		r.With(&m)
-		r.SelfLink = h.Link(h.Provider, &m)
+		r.Link(h.Provider)
 		content = append(content, r.Content(h.Detail))
 	}
 
@@ -100,21 +100,10 @@ func (h HostHandler) Get(ctx *gin.Context) {
 	}
 	r := &Host{}
 	r.With(m)
-	r.SelfLink = h.Link(h.Provider, m)
+	r.Link(h.Provider)
 	content := r.Content(true)
 
 	ctx.JSON(http.StatusOK, content)
-}
-
-//
-// Build self link (URI).
-func (h HostHandler) Link(p *api.Provider, m *model.Host) string {
-	return h.Handler.Link(
-		HostRoot,
-		base.Params{
-			base.ProviderParam: string(p.UID),
-			HostParam:          m.ID,
-		})
 }
 
 //
@@ -129,7 +118,7 @@ func (h HostHandler) watch(ctx *gin.Context) {
 			m := in.(*model.Host)
 			host := &Host{}
 			host.With(m)
-			host.SelfLink = h.Link(h.Provider, m)
+			host.Link(h.Provider)
 			r = host
 			return
 		})
@@ -171,6 +160,17 @@ func (r *Host) With(m *model.Host) {
 	r.CpuCores = m.CpuCores
 	r.NetworkAttachments = m.NetworkAttachments
 	r.NICs = m.NICs
+}
+
+//
+// Build self link (URI).
+func (r *Host) Link(p *api.Provider) {
+	r.SelfLink = base.Link(
+		HostRoot,
+		base.Params{
+			base.ProviderParam: string(p.UID),
+			HostParam:          r.ID,
+		})
 }
 
 //

--- a/pkg/controller/provider/web/ovirt/network.go
+++ b/pkg/controller/provider/web/ovirt/network.go
@@ -63,7 +63,7 @@ func (h NetworkHandler) List(ctx *gin.Context) {
 	for _, m := range list {
 		r := &Network{}
 		r.With(&m)
-		r.SelfLink = h.Link(h.Provider, &m)
+		r.Link(h.Provider)
 		content = append(content, r.Content(h.Detail))
 	}
 
@@ -99,21 +99,10 @@ func (h NetworkHandler) Get(ctx *gin.Context) {
 	}
 	r := &Network{}
 	r.With(m)
-	r.SelfLink = h.Link(h.Provider, m)
+	r.Link(h.Provider)
 	content := r.Content(true)
 
 	ctx.JSON(http.StatusOK, content)
-}
-
-//
-// Build self link (URI).
-func (h NetworkHandler) Link(p *api.Provider, m *model.Network) string {
-	return h.Handler.Link(
-		NetworkRoot,
-		base.Params{
-			base.ProviderParam: string(p.UID),
-			NetworkParam:       m.ID,
-		})
 }
 
 //
@@ -128,7 +117,7 @@ func (h NetworkHandler) watch(ctx *gin.Context) {
 			m := in.(*model.Network)
 			network := &Network{}
 			network.With(m)
-			network.SelfLink = h.Link(h.Provider, m)
+			network.Link(h.Provider)
 			r = network
 			return
 		})
@@ -159,6 +148,17 @@ func (r *Network) With(m *model.Network) {
 	r.VLan = m.VLan
 	r.Usages = m.Usages
 	r.Profiles = m.Profiles
+}
+
+//
+// Build self link (URI).
+func (r *Network) Link(p *api.Provider) {
+	r.SelfLink = base.Link(
+		NetworkRoot,
+		base.Params{
+			base.ProviderParam: string(p.UID),
+			NetworkParam:       r.ID,
+		})
 }
 
 //

--- a/pkg/controller/provider/web/ovirt/nicprofile.go
+++ b/pkg/controller/provider/web/ovirt/nicprofile.go
@@ -63,7 +63,7 @@ func (h NICProfileHandler) List(ctx *gin.Context) {
 	for _, m := range list {
 		r := &NICProfile{}
 		r.With(&m)
-		r.SelfLink = h.Link(h.Provider, &m)
+		r.Link(h.Provider)
 		content = append(content, r.Content(h.Detail))
 	}
 
@@ -99,21 +99,10 @@ func (h NICProfileHandler) Get(ctx *gin.Context) {
 	}
 	r := &NICProfile{}
 	r.With(m)
-	r.SelfLink = h.Link(h.Provider, m)
+	r.Link(h.Provider)
 	content := r.Content(true)
 
 	ctx.JSON(http.StatusOK, content)
-}
-
-//
-// Build self link (URI).
-func (h NICProfileHandler) Link(p *api.Provider, m *model.NICProfile) string {
-	return h.Handler.Link(
-		NICProfileRoot,
-		base.Params{
-			base.ProviderParam: string(p.UID),
-			NICProfileParam:    m.ID,
-		})
 }
 
 //
@@ -128,7 +117,7 @@ func (h NICProfileHandler) watch(ctx *gin.Context) {
 			m := in.(*model.NICProfile)
 			profile := &NICProfile{}
 			profile.With(m)
-			profile.SelfLink = h.Link(h.Provider, m)
+			profile.Link(h.Provider)
 			r = profile
 			return
 		})
@@ -159,6 +148,17 @@ func (r *NICProfile) With(m *model.NICProfile) {
 	r.NetworkFilter = m.NetworkFilter
 	r.PortMirroring = m.PortMirroring
 	r.QoS = m.QoS
+}
+
+//
+// Build self link (URI).
+func (r *NICProfile) Link(p *api.Provider) {
+	r.SelfLink = base.Link(
+		NICProfileRoot,
+		base.Params{
+			base.ProviderParam: string(p.UID),
+			NICProfileParam:    r.ID,
+		})
 }
 
 //

--- a/pkg/controller/provider/web/ovirt/provider.go
+++ b/pkg/controller/provider/web/ovirt/provider.go
@@ -83,7 +83,7 @@ func (h ProviderHandler) Get(ctx *gin.Context) {
 		ctx.Status(http.StatusInternalServerError)
 		return
 	}
-	r.SelfLink = h.Link(m)
+	r.Link()
 	content := r.Content(true)
 
 	ctx.JSON(http.StatusOK, content)
@@ -117,7 +117,7 @@ func (h *ProviderHandler) ListContent(ctx *gin.Context) (content []interface{}, 
 				err = aErr
 				return
 			}
-			r.SelfLink = h.Link(m)
+			r.Link()
 			content = append(content, r.Content(h.Detail))
 		}
 	}
@@ -176,16 +176,6 @@ func (h ProviderHandler) AddDerived(r *Provider) (err error) {
 }
 
 //
-// Build self link (URI).
-func (h ProviderHandler) Link(m *model.Provider) string {
-	return h.Handler.Link(
-		ProviderRoot,
-		base.Params{
-			base.ProviderParam: m.UID,
-		})
-}
-
-//
 // REST Resource.
 type Provider struct {
 	ocp.Resource
@@ -205,6 +195,16 @@ func (r *Provider) With(m *model.Provider) {
 	r.Resource.With(&m.Base)
 	r.Type = m.Type
 	r.Object = m.Object
+}
+
+//
+// Build self link (URI).
+func (r *Provider) Link() {
+	r.SelfLink = base.Link(
+		ProviderRoot,
+		base.Params{
+			base.ProviderParam: r.UID,
+		})
 }
 
 //

--- a/pkg/controller/provider/web/ovirt/storage.go
+++ b/pkg/controller/provider/web/ovirt/storage.go
@@ -63,7 +63,7 @@ func (h StorageDomainHandler) List(ctx *gin.Context) {
 	for _, m := range list {
 		r := &StorageDomain{}
 		r.With(&m)
-		r.SelfLink = h.Link(h.Provider, &m)
+		r.Link(h.Provider)
 		content = append(content, r.Content(h.Detail))
 	}
 
@@ -99,21 +99,10 @@ func (h StorageDomainHandler) Get(ctx *gin.Context) {
 	}
 	r := &StorageDomain{}
 	r.With(m)
-	r.SelfLink = h.Link(h.Provider, m)
+	r.Link(h.Provider)
 	content := r.Content(true)
 
 	ctx.JSON(http.StatusOK, content)
-}
-
-//
-// Build self link (URI).
-func (h StorageDomainHandler) Link(p *api.Provider, m *model.StorageDomain) string {
-	return h.Handler.Link(
-		StorageDomainRoot,
-		base.Params{
-			base.ProviderParam: string(p.UID),
-			StorageDomainParam: m.ID,
-		})
 }
 
 //
@@ -128,7 +117,7 @@ func (h StorageDomainHandler) watch(ctx *gin.Context) {
 			m := in.(*model.StorageDomain)
 			ds := &StorageDomain{}
 			ds.With(m)
-			ds.SelfLink = h.Link(h.Provider, m)
+			ds.Link(h.Provider)
 			r = ds
 			return
 		})
@@ -163,6 +152,17 @@ func (r *StorageDomain) With(m *model.StorageDomain) {
 	r.Capacity = m.Available
 	r.Free = m.Available - m.Used
 	r.Storage.Type = m.Storage.Type
+}
+
+//
+// Build self link (URI).
+func (r *StorageDomain) Link(p *api.Provider) {
+	r.SelfLink = base.Link(
+		StorageDomainRoot,
+		base.Params{
+			base.ProviderParam: string(p.UID),
+			StorageDomainParam: r.ID,
+		})
 }
 
 //

--- a/pkg/controller/provider/web/ovirt/tree.go
+++ b/pkg/controller/provider/web/ovirt/tree.go
@@ -111,7 +111,7 @@ func (h TreeHandler) Tree(ctx *gin.Context) {
 		}
 		r := DataCenter{}
 		r.With(&dc)
-		r.SelfLink = DataCenterHandler{}.Link(h.Provider, &dc)
+		r.Link(h.Provider)
 		branch.Kind = model.DataCenterKind
 		branch.Object = r
 		content.Children = append(content.Children, branch)
@@ -218,10 +218,9 @@ func (r *NodeBuilder) Node(parent *TreeNode, m model.Model) *TreeNode {
 	node := &TreeNode{}
 	switch kind {
 	case model.DataCenterKind:
-		h := DataCenterHandler{}
 		resource := &DataCenter{}
 		resource.With(m.(*model.DataCenter))
-		resource.SelfLink = h.Link(provider, m.(*model.DataCenter))
+		resource.Link(provider)
 		object := resource.Content(r.withDetail(kind))
 		node = &TreeNode{
 			Parent: parent,
@@ -229,10 +228,9 @@ func (r *NodeBuilder) Node(parent *TreeNode, m model.Model) *TreeNode {
 			Object: object,
 		}
 	case model.ClusterKind:
-		h := ClusterHandler{}
 		resource := &Cluster{}
 		resource.With(m.(*model.Cluster))
-		resource.SelfLink = h.Link(provider, m.(*model.Cluster))
+		resource.Link(provider)
 		object := resource.Content(r.withDetail(kind))
 		node = &TreeNode{
 			Parent: parent,
@@ -240,10 +238,9 @@ func (r *NodeBuilder) Node(parent *TreeNode, m model.Model) *TreeNode {
 			Object: object,
 		}
 	case model.HostKind:
-		h := HostHandler{}
 		resource := &Host{}
 		resource.With(m.(*model.Host))
-		resource.SelfLink = h.Link(provider, m.(*model.Host))
+		resource.Link(provider)
 		object := resource.Content(r.withDetail(kind))
 		node = &TreeNode{
 			Parent: parent,
@@ -251,23 +248,19 @@ func (r *NodeBuilder) Node(parent *TreeNode, m model.Model) *TreeNode {
 			Object: object,
 		}
 	case model.VmKind:
-		h := VMHandler{
-			Handler: r.handler,
-		}
 		resource := &VM{}
-		h.Detail = r.withDetail(kind)
-		_ = h.Build(m.(*model.VM), resource)
-		object := resource.Content(h.Detail)
+		resource.With(m.(*model.VM))
+		resource.Link(provider)
+		object := resource.Content(r.withDetail(kind))
 		node = &TreeNode{
 			Parent: parent,
 			Kind:   kind,
 			Object: object,
 		}
 	case model.NetKind:
-		h := NetworkHandler{}
 		resource := &Network{}
 		resource.With(m.(*model.Network))
-		resource.SelfLink = h.Link(provider, m.(*model.Network))
+		resource.Link(provider)
 		object := resource.Content(r.withDetail(kind))
 		node = &TreeNode{
 			Parent: parent,
@@ -275,10 +268,9 @@ func (r *NodeBuilder) Node(parent *TreeNode, m model.Model) *TreeNode {
 			Object: object,
 		}
 	case model.StorageKind:
-		h := StorageDomainHandler{}
 		resource := &StorageDomain{}
 		resource.With(m.(*model.StorageDomain))
-		resource.SelfLink = h.Link(provider, m.(*model.StorageDomain))
+		resource.Link(provider)
 		object := resource.Content(r.withDetail(kind))
 		node = &TreeNode{
 			Parent: parent,


### PR DESCRIPTION
Refactor Handler.Link() for better separation of responsibility and re-use both inside and outside the web layer.
It's useful to Link and Expand REST resources outside the web layer.  It's complex and potentially dangerous to artificially build and use the _Handler_ because of unknown Handler state needs.

The main driver is to support the VM validation building the workload which needs to be a REST resource.

Essentially, functionality moved from endpoint _Handler_ to REST resources.

Summary:
- Removed Handler.Link().
- Added _Resource_.Link().
- Removed Handler.Build().
- Added _Resource_.Expand() to resources as necessary.  Here the term _expand_ refers to de-referencing foreign keys.

For consistency, we'll want to do the same refactor for vSphere.