### PR TITLE
Link() refactor in web layer.

### DIFF
--- a/pkg/controller/provider/container/vsphere/watch.go
+++ b/pkg/controller/provider/container/vsphere/watch.go
@@ -352,40 +352,20 @@ func (r *VMEventHandler) validated(batch []*policy.Task) {
 // Build the workload.
 func (r *VMEventHandler) workload(vmID string) (object interface{}, err error) {
 	vm := &model.VM{
-		Base: model.Base{
-			ID: vmID,
-		},
+		Base: model.Base{ID: vmID},
 	}
 	err = r.DB.Get(vm)
 	if err != nil {
 		return
 	}
 	workload := web.Workload{}
-	host := &model.Host{
-		Base: model.Base{
-			ID: vm.Host,
-		},
-	}
-	workload.VM = &web.VM{}
-	workload.VM.With(vm)
-	err = r.DB.Get(host)
+	workload.With(vm)
+	err = workload.Expand(r.DB)
 	if err != nil {
 		return
 	}
-	workload.Host.Host = &web.Host{}
-	workload.Host.Host.With(host)
-	cluster := &model.Cluster{
-		Base: model.Base{
-			ID: host.Cluster,
-		},
-	}
-	err = r.DB.Get(cluster)
-	if err != nil {
-		return
-	}
-	workload.Host.Cluster.Cluster = &web.Cluster{}
-	workload.Host.Cluster.Cluster.With(cluster)
 
+	workload.Link(r.Provider)
 	object = workload
 
 	return

--- a/pkg/controller/provider/web/base/handler.go
+++ b/pkg/controller/provider/web/base/handler.go
@@ -113,6 +113,8 @@ func (h *Handler) setProvider(ctx *gin.Context) (status int) {
 		ctx.Header(ProviderHeader, uid)
 		h.Provider = h.Reconciler.Owner().(*api.Provider)
 		status = h.EnsureParity(h.Reconciler, time.Second*30)
+	} else {
+		status = http.StatusOK
 	}
 
 	return

--- a/pkg/controller/provider/web/ocp/client.go
+++ b/pkg/controller/provider/web/ocp/client.go
@@ -3,7 +3,6 @@ package ocp
 import (
 	liberr "github.com/konveyor/controller/pkg/error"
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
-	model "github.com/konveyor/forklift-controller/pkg/controller/provider/model/ocp"
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/web/base"
 	"path"
 	"strings"
@@ -24,40 +23,33 @@ type Resolver struct {
 //
 // Resolve the URL path.
 func (r *Resolver) Path(object interface{}, id string) (path string, err error) {
+	provider := r.Provider
 	switch object.(type) {
 	case *Provider:
-		h := ProviderHandler{}
-		path = h.Link(&model.Provider{
-			Base: model.Base{UID: id},
-		})
+		r := Provider{}
+		r.UID = id
+		r.Link()
+		path = r.SelfLink
 	case *Namespace:
-		h := NamespaceHandler{}
-		path = h.Link(
-			r.Provider,
-			&model.Namespace{
-				Base: model.Base{PK: id},
-			})
+		r := Namespace{}
+		r.UID = id
+		r.Link(provider)
+		path = r.SelfLink
 	case *StorageClass:
-		h := StorageClassHandler{}
-		path = h.Link(
-			r.Provider,
-			&model.StorageClass{
-				Base: model.Base{PK: id},
-			})
+		r := StorageClass{}
+		r.UID = id
+		r.Link(provider)
+		path = r.SelfLink
 	case *NetworkAttachmentDefinition:
-		h := NadHandler{}
-		path = h.Link(
-			r.Provider,
-			&model.NetworkAttachmentDefinition{
-				Base: model.Base{PK: id},
-			})
+		r := NetworkAttachmentDefinition{}
+		r.UID = id
+		r.Link(provider)
+		path = r.SelfLink
 	case *VM:
-		h := VMHandler{}
-		path = h.Link(
-			r.Provider,
-			&model.VM{
-				Base: model.Base{PK: id},
-			})
+		r := VM{}
+		r.UID = id
+		r.Link(provider)
+		path = r.SelfLink
 	default:
 		err = liberr.Wrap(
 			ResourceNotResolvedError{

--- a/pkg/controller/provider/web/ocp/namespace.go
+++ b/pkg/controller/provider/web/ocp/namespace.go
@@ -62,7 +62,7 @@ func (h NamespaceHandler) List(ctx *gin.Context) {
 	for _, m := range list {
 		r := &Namespace{}
 		r.With(&m)
-		r.SelfLink = h.Link(h.Provider, &m)
+		r.Link(h.Provider)
 		content = append(content, r.Content(h.Detail))
 	}
 
@@ -98,21 +98,10 @@ func (h NamespaceHandler) Get(ctx *gin.Context) {
 	}
 	r := &Namespace{}
 	r.With(m)
-	r.SelfLink = h.Link(h.Provider, m)
+	r.Link(h.Provider)
 	content := r.Content(true)
 
 	ctx.JSON(http.StatusOK, content)
-}
-
-//
-// Build self link (URI).
-func (h NamespaceHandler) Link(p *api.Provider, m *model.Namespace) string {
-	return h.Handler.Link(
-		NamespaceRoot,
-		base.Params{
-			base.ProviderParam: string(p.UID),
-			NsParam:            m.PK,
-		})
 }
 
 //
@@ -127,7 +116,7 @@ func (h NamespaceHandler) watch(ctx *gin.Context) {
 			m := in.(*model.Namespace)
 			vm := &Namespace{}
 			vm.With(m)
-			vm.SelfLink = h.Link(h.Provider, m)
+			vm.Link(h.Provider)
 			r = vm
 			return
 		})
@@ -152,6 +141,17 @@ type Namespace struct {
 func (r *Namespace) With(m *model.Namespace) {
 	r.Resource.With(&m.Base)
 	r.Object = m.Object
+}
+
+//
+// Build self link (URI).
+func (r *Namespace) Link(p *api.Provider) {
+	r.SelfLink = base.Link(
+		NamespaceRoot,
+		base.Params{
+			base.ProviderParam: string(p.UID),
+			NsParam:            r.UID,
+		})
 }
 
 //

--- a/pkg/controller/provider/web/ocp/netattachdefinition.go
+++ b/pkg/controller/provider/web/ocp/netattachdefinition.go
@@ -63,7 +63,7 @@ func (h NadHandler) List(ctx *gin.Context) {
 	for _, m := range list {
 		r := &NetworkAttachmentDefinition{}
 		r.With(&m)
-		r.SelfLink = h.Link(h.Provider, &m)
+		r.Link(h.Provider)
 		content = append(content, r.Content(h.Detail))
 	}
 
@@ -99,21 +99,10 @@ func (h NadHandler) Get(ctx *gin.Context) {
 	}
 	r := &NetworkAttachmentDefinition{}
 	r.With(m)
-	r.SelfLink = h.Link(h.Provider, m)
+	r.Link(h.Provider)
 	content := r.Content(true)
 
 	ctx.JSON(http.StatusOK, content)
-}
-
-//
-// Build self link (URI).
-func (h NadHandler) Link(p *api.Provider, m *model.NetworkAttachmentDefinition) string {
-	return h.Handler.Link(
-		NadRoot,
-		base.Params{
-			base.ProviderParam: string(p.UID),
-			NadParam:           m.PK,
-		})
 }
 
 //
@@ -128,7 +117,7 @@ func (h NadHandler) watch(ctx *gin.Context) {
 			m := in.(*model.NetworkAttachmentDefinition)
 			nad := &NetworkAttachmentDefinition{}
 			nad.With(m)
-			nad.SelfLink = h.Link(h.Provider, m)
+			nad.Link(h.Provider)
 			r = nad
 			return
 		})
@@ -153,6 +142,17 @@ type NetworkAttachmentDefinition struct {
 func (r *NetworkAttachmentDefinition) With(m *model.NetworkAttachmentDefinition) {
 	r.Resource.With(&m.Base)
 	r.Object = m.Object
+}
+
+//
+// Build self link (URI).
+func (r *NetworkAttachmentDefinition) Link(p *api.Provider) {
+	r.SelfLink = base.Link(
+		NadRoot,
+		base.Params{
+			base.ProviderParam: string(p.UID),
+			NadParam:           r.UID,
+		})
 }
 
 //

--- a/pkg/controller/provider/web/ocp/provider.go
+++ b/pkg/controller/provider/web/ocp/provider.go
@@ -78,7 +78,7 @@ func (h ProviderHandler) Get(ctx *gin.Context) {
 		ctx.Status(http.StatusInternalServerError)
 		return
 	}
-	r.SelfLink = h.Link(m)
+	r.Link()
 	content := r.Content(true)
 
 	ctx.JSON(http.StatusOK, content)
@@ -112,7 +112,7 @@ func (h *ProviderHandler) ListContent(ctx *gin.Context) (content []interface{}, 
 				err = aErr
 				return
 			}
-			r.SelfLink = h.Link(m)
+			r.Link()
 			content = append(content, r.Content(h.Detail))
 		}
 	}
@@ -152,16 +152,6 @@ func (h ProviderHandler) AddCount(r *Provider) (err error) {
 }
 
 //
-// Build self link (URI).
-func (h ProviderHandler) Link(m *model.Provider) string {
-	return h.Handler.Link(
-		ProviderRoot,
-		base.Params{
-			ProviderParam: m.UID,
-		})
-}
-
-//
 // REST Resource.
 type Provider struct {
 	Resource
@@ -178,6 +168,16 @@ func (r *Provider) With(m *model.Provider) {
 	r.Resource.With(&m.Base)
 	r.Type = m.Type
 	r.Object = m.Object
+}
+
+//
+// Build self link (URI).
+func (r *Provider) Link() {
+	r.SelfLink = base.Link(
+		ProviderRoot,
+		base.Params{
+			ProviderParam: r.UID,
+		})
 }
 
 //

--- a/pkg/controller/provider/web/ocp/storageclass.go
+++ b/pkg/controller/provider/web/ocp/storageclass.go
@@ -63,7 +63,7 @@ func (h StorageClassHandler) List(ctx *gin.Context) {
 	for _, m := range list {
 		r := &StorageClass{}
 		r.With(&m)
-		r.SelfLink = h.Link(h.Provider, &m)
+		r.Link(h.Provider)
 		content = append(content, r.Content(h.Detail))
 	}
 
@@ -99,21 +99,10 @@ func (h StorageClassHandler) Get(ctx *gin.Context) {
 	}
 	r := &StorageClass{}
 	r.With(m)
-	r.SelfLink = h.Link(h.Provider, m)
+	r.Link(h.Provider)
 	content := r.Content(true)
 
 	ctx.JSON(http.StatusOK, content)
-}
-
-//
-// Build self link (URI).
-func (h StorageClassHandler) Link(p *api.Provider, m *model.StorageClass) string {
-	return h.Handler.Link(
-		StorageClassRoot,
-		base.Params{
-			base.ProviderParam: string(p.UID),
-			StorageClassParam:  m.PK,
-		})
 }
 
 //
@@ -128,7 +117,7 @@ func (h StorageClassHandler) watch(ctx *gin.Context) {
 			m := in.(*model.StorageClass)
 			sc := &StorageClass{}
 			sc.With(m)
-			sc.SelfLink = h.Link(h.Provider, m)
+			sc.Link(h.Provider)
 			r = sc
 			return
 		})
@@ -153,6 +142,17 @@ type StorageClass struct {
 func (r *StorageClass) With(m *model.StorageClass) {
 	r.Resource.With(&m.Base)
 	r.Object = m.Object
+}
+
+//
+// Build self link (URI).
+func (r *StorageClass) Link(p *api.Provider) {
+	r.SelfLink = base.Link(
+		StorageClassRoot,
+		base.Params{
+			base.ProviderParam: string(p.UID),
+			StorageClassParam:  r.UID,
+		})
 }
 
 //

--- a/pkg/controller/provider/web/ocp/vm.go
+++ b/pkg/controller/provider/web/ocp/vm.go
@@ -63,7 +63,7 @@ func (h VMHandler) List(ctx *gin.Context) {
 	for _, m := range list {
 		r := &VM{}
 		r.With(&m)
-		r.SelfLink = h.Link(h.Provider, &m)
+		r.Link(h.Provider)
 		content = append(content, r.Content(h.Detail))
 	}
 
@@ -99,21 +99,10 @@ func (h VMHandler) Get(ctx *gin.Context) {
 	}
 	r := &VM{}
 	r.With(m)
-	r.SelfLink = h.Link(h.Provider, m)
+	r.Link(h.Provider)
 	content := r.Content(true)
 
 	ctx.JSON(http.StatusOK, content)
-}
-
-//
-// Build self link (URI).
-func (h VMHandler) Link(p *api.Provider, m *model.VM) string {
-	return h.Handler.Link(
-		VMRoot,
-		base.Params{
-			base.ProviderParam: string(p.UID),
-			VmParam:            m.PK,
-		})
 }
 
 //
@@ -128,7 +117,7 @@ func (h VMHandler) watch(ctx *gin.Context) {
 			m := in.(*model.VM)
 			vm := &VM{}
 			vm.With(m)
-			vm.SelfLink = h.Link(h.Provider, m)
+			vm.Link(h.Provider)
 			r = vm
 			return
 		})
@@ -153,6 +142,17 @@ type VM struct {
 func (r *VM) With(m *model.VM) {
 	r.Resource.With(&m.Base)
 	r.Object = m.Object
+}
+
+//
+// Build self link (URI).
+func (r *VM) Link(p *api.Provider) {
+	r.SelfLink = base.Link(
+		VMRoot,
+		base.Params{
+			base.ProviderParam: string(p.UID),
+			VmParam:            r.UID,
+		})
 }
 
 //

--- a/pkg/controller/provider/web/vsphere/client.go
+++ b/pkg/controller/provider/web/vsphere/client.go
@@ -3,8 +3,6 @@ package vsphere
 import (
 	liberr "github.com/konveyor/controller/pkg/error"
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
-	ocpmodel "github.com/konveyor/forklift-controller/pkg/controller/provider/model/ocp"
-	model "github.com/konveyor/forklift-controller/pkg/controller/provider/model/vsphere"
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/web/base"
 	"strings"
 )
@@ -24,69 +22,53 @@ type Resolver struct {
 //
 // Build the URL path.
 func (r *Resolver) Path(resource interface{}, id string) (path string, err error) {
+	provider := r.Provider
 	switch resource.(type) {
 	case *Provider:
-		h := ProviderHandler{}
-		path = h.Link(
-			&ocpmodel.Provider{
-				Base: ocpmodel.Base{UID: id},
-			})
+		r := Provider{}
+		r.UID = id
+		r.Link()
+		path = r.SelfLink
 	case *Folder:
-		h := FolderHandler{}
-		path = h.Link(
-			r.Provider,
-			&model.Folder{
-				Base: model.Base{ID: id},
-			})
+		r := Folder{}
+		r.ID = id
+		r.Link(provider)
+		path = r.SelfLink
 	case *Datacenter:
-		h := DatacenterHandler{}
-		path = h.Link(
-			r.Provider,
-			&model.Datacenter{
-				Base: model.Base{ID: id},
-			})
+		r := Datacenter{}
+		r.ID = id
+		r.Link(provider)
+		path = r.SelfLink
 	case *Cluster:
-		h := ClusterHandler{}
-		path = h.Link(
-			r.Provider,
-			&model.Cluster{
-				Base: model.Base{ID: id},
-			})
+		r := Cluster{}
+		r.ID = id
+		r.Link(provider)
+		path = r.SelfLink
 	case *Host:
-		h := HostHandler{}
-		path = h.Link(
-			r.Provider,
-			&model.Host{
-				Base: model.Base{ID: id},
-			})
+		r := Host{}
+		r.ID = id
+		r.Link(provider)
+		path = r.SelfLink
 	case *Network:
-		h := NetworkHandler{}
-		path = h.Link(
-			r.Provider,
-			&model.Network{
-				Base: model.Base{ID: id},
-			})
+		r := Network{}
+		r.ID = id
+		r.Link(provider)
+		path = r.SelfLink
 	case *Datastore:
-		h := DatastoreHandler{}
-		path = h.Link(
-			r.Provider,
-			&model.Datastore{
-				Base: model.Base{ID: id},
-			})
+		r := Datastore{}
+		r.ID = id
+		r.Link(provider)
+		path = r.SelfLink
 	case *VM:
-		h := VMHandler{}
-		path = h.Link(
-			r.Provider,
-			&model.VM{
-				Base: model.Base{ID: id},
-			})
+		r := VM{}
+		r.ID = id
+		r.Link(provider)
+		path = r.SelfLink
 	case *Workload:
-		h := WorkloadHandler{}
-		path = h.Link(
-			r.Provider,
-			&model.VM{
-				Base: model.Base{ID: id},
-			})
+		r := Workload{}
+		r.ID = id
+		r.Link(provider)
+		path = r.SelfLink
 	default:
 		err = liberr.Wrap(
 			base.ResourceNotResolvedError{

--- a/pkg/controller/provider/web/vsphere/cluster.go
+++ b/pkg/controller/provider/web/vsphere/cluster.go
@@ -65,7 +65,7 @@ func (h ClusterHandler) List(ctx *gin.Context) {
 	for _, m := range list {
 		r := &Cluster{}
 		r.With(&m)
-		r.SelfLink = h.Link(h.Provider, &m)
+		r.Link(h.Provider)
 		content = append(content, r.Content(h.Detail))
 	}
 
@@ -109,21 +109,10 @@ func (h ClusterHandler) Get(ctx *gin.Context) {
 			ctx.Request.URL)
 		return
 	}
-	r.SelfLink = h.Link(h.Provider, m)
+	r.Link(h.Provider)
 	content := r.Content(true)
 
 	ctx.JSON(http.StatusOK, content)
-}
-
-//
-// Build self link (URI).
-func (h ClusterHandler) Link(p *api.Provider, m *model.Cluster) string {
-	return h.Handler.Link(
-		ClusterRoot,
-		base.Params{
-			base.ProviderParam: string(p.UID),
-			ClusterParam:       m.ID,
-		})
 }
 
 //
@@ -138,7 +127,7 @@ func (h ClusterHandler) watch(ctx *gin.Context) {
 			m := in.(*model.Cluster)
 			cluster := &Cluster{}
 			cluster.With(m)
-			cluster.SelfLink = h.Link(h.Provider, m)
+			cluster.Link(h.Provider)
 			cluster.Path, _ = m.Path(db)
 			r = cluster
 			return
@@ -180,6 +169,17 @@ func (r *Cluster) With(m *model.Cluster) {
 	r.Hosts = m.Hosts
 	r.DasVms = m.DasVms
 	r.DrsVms = m.DasVms
+}
+
+//
+// Build self link (URI).
+func (r *Cluster) Link(p *api.Provider) {
+	r.SelfLink = base.Link(
+		ClusterRoot,
+		base.Params{
+			base.ProviderParam: string(p.UID),
+			ClusterParam:       r.ID,
+		})
 }
 
 //

--- a/pkg/controller/provider/web/vsphere/datacenter.go
+++ b/pkg/controller/provider/web/vsphere/datacenter.go
@@ -65,7 +65,7 @@ func (h DatacenterHandler) List(ctx *gin.Context) {
 	for _, m := range list {
 		r := &Datacenter{}
 		r.With(&m)
-		r.SelfLink = h.Link(h.Provider, &m)
+		r.Link(h.Provider)
 		content = append(content, r.Content(h.Detail))
 	}
 
@@ -110,21 +110,10 @@ func (h DatacenterHandler) Get(ctx *gin.Context) {
 		ctx.Status(http.StatusInternalServerError)
 		return
 	}
-	r.SelfLink = h.Link(h.Provider, m)
+	r.Link(h.Provider)
 	content := r.Content(true)
 
 	ctx.JSON(http.StatusOK, content)
-}
-
-//
-// Build self link (URI).
-func (h DatacenterHandler) Link(p *api.Provider, m *model.Datacenter) string {
-	return h.Handler.Link(
-		DatacenterRoot,
-		base.Params{
-			base.ProviderParam: string(p.UID),
-			DatacenterParam:    m.ID,
-		})
 }
 
 //
@@ -139,7 +128,7 @@ func (h DatacenterHandler) watch(ctx *gin.Context) {
 			m := in.(*model.Datacenter)
 			dc := &Datacenter{}
 			dc.With(m)
-			dc.SelfLink = h.Link(h.Provider, m)
+			dc.Link(h.Provider)
 			dc.Path, _ = m.Path(db)
 			r = dc
 			return
@@ -171,6 +160,17 @@ func (r *Datacenter) With(m *model.Datacenter) {
 	r.Networks = m.Networks
 	r.Clusters = m.Clusters
 	r.VMs = m.Vms
+}
+
+//
+// Build self link (URI).
+func (r *Datacenter) Link(p *api.Provider) {
+	r.SelfLink = base.Link(
+		DatacenterRoot,
+		base.Params{
+			base.ProviderParam: string(p.UID),
+			DatacenterParam:    r.ID,
+		})
 }
 
 //

--- a/pkg/controller/provider/web/vsphere/datastore.go
+++ b/pkg/controller/provider/web/vsphere/datastore.go
@@ -73,7 +73,7 @@ func (h DatastoreHandler) List(ctx *gin.Context) {
 	for _, m := range list {
 		r := &Datastore{}
 		r.With(&m)
-		r.SelfLink = h.Link(h.Provider, &m)
+		r.Link(h.Provider)
 		content = append(content, r.Content(h.Detail))
 	}
 
@@ -118,21 +118,10 @@ func (h DatastoreHandler) Get(ctx *gin.Context) {
 		ctx.Status(http.StatusInternalServerError)
 		return
 	}
-	r.SelfLink = h.Link(h.Provider, m)
+	r.Link(h.Provider)
 	content := r.Content(true)
 
 	ctx.JSON(http.StatusOK, content)
-}
-
-//
-// Build self link (URI).
-func (h DatastoreHandler) Link(p *api.Provider, m *model.Datastore) string {
-	return h.Handler.Link(
-		DatastoreRoot,
-		base.Params{
-			base.ProviderParam: string(p.UID),
-			DatastoreParam:     m.ID,
-		})
 }
 
 //
@@ -147,7 +136,7 @@ func (h DatastoreHandler) watch(ctx *gin.Context) {
 			m := in.(*model.Datastore)
 			ds := &Datastore{}
 			ds.With(m)
-			ds.SelfLink = h.Link(h.Provider, m)
+			ds.Link(h.Provider)
 			ds.Path, _ = m.Path(db)
 			r = ds
 			return
@@ -212,6 +201,17 @@ func (r *Datastore) With(m *model.Datastore) {
 	r.Capacity = m.Capacity
 	r.Free = m.Free
 	r.MaintenanceMode = m.MaintenanceMode
+}
+
+//
+// Build self link (URI).
+func (r *Datastore) Link(p *api.Provider) {
+	r.SelfLink = base.Link(
+		DatastoreRoot,
+		base.Params{
+			base.ProviderParam: string(p.UID),
+			DatastoreParam:     r.ID,
+		})
 }
 
 //

--- a/pkg/controller/provider/web/vsphere/folder.go
+++ b/pkg/controller/provider/web/vsphere/folder.go
@@ -65,7 +65,7 @@ func (h FolderHandler) List(ctx *gin.Context) {
 	for _, m := range list {
 		r := &Folder{}
 		r.With(&m)
-		r.SelfLink = h.Link(h.Provider, &m)
+		r.Link(h.Provider)
 		content = append(content, r.Content(h.Detail))
 	}
 
@@ -110,21 +110,10 @@ func (h FolderHandler) Get(ctx *gin.Context) {
 		ctx.Status(http.StatusInternalServerError)
 		return
 	}
-	r.SelfLink = h.Link(h.Provider, m)
+	r.Link(h.Provider)
 	content := r.Content(true)
 
 	ctx.JSON(http.StatusOK, content)
-}
-
-//
-// Build self link (URI).
-func (h FolderHandler) Link(p *api.Provider, m *model.Folder) string {
-	return h.Handler.Link(
-		FolderRoot,
-		base.Params{
-			base.ProviderParam: string(p.UID),
-			FolderParam:        m.ID,
-		})
 }
 
 //
@@ -139,7 +128,7 @@ func (h FolderHandler) watch(ctx *gin.Context) {
 			m := in.(*model.Folder)
 			folder := &Folder{}
 			folder.With(m)
-			folder.SelfLink = h.Link(h.Provider, m)
+			folder.Link(h.Provider)
 			folder.Path, _ = m.Path(db)
 			r = folder
 			return
@@ -169,6 +158,17 @@ func (r *Folder) With(m *model.Folder) {
 	r.Folder = m.Folder
 	r.Datacenter = m.Datacenter
 	r.Children = m.Children
+}
+
+//
+// Build self link (URI).
+func (r *Folder) Link(p *api.Provider) {
+	r.SelfLink = base.Link(
+		FolderRoot,
+		base.Params{
+			base.ProviderParam: string(p.UID),
+			FolderParam:        r.ID,
+		})
 }
 
 //

--- a/pkg/controller/provider/web/vsphere/host.go
+++ b/pkg/controller/provider/web/vsphere/host.go
@@ -83,7 +83,7 @@ func (h HostHandler) List(ctx *gin.Context) {
 			ctx.Status(http.StatusInternalServerError)
 			return
 		}
-		r.SelfLink = h.Link(h.Provider, &m)
+		r.Link(h.Provider)
 		content = append(content, r.Content(h.Detail))
 	}
 
@@ -138,21 +138,10 @@ func (h HostHandler) Get(ctx *gin.Context) {
 		ctx.Status(http.StatusInternalServerError)
 		return
 	}
-	r.SelfLink = h.Link(h.Provider, m)
+	r.Link(h.Provider)
 	content := r.Content(true)
 
 	ctx.JSON(http.StatusOK, content)
-}
-
-//
-// Build self link (URI).
-func (h HostHandler) Link(p *api.Provider, m *model.Host) string {
-	return h.Handler.Link(
-		HostRoot,
-		base.Params{
-			base.ProviderParam: string(p.UID),
-			HostParam:          m.ID,
-		})
 }
 
 //
@@ -167,7 +156,7 @@ func (h HostHandler) watch(ctx *gin.Context) {
 			m := in.(*model.Host)
 			host := &Host{}
 			host.With(m)
-			host.SelfLink = h.Link(h.Provider, m)
+			host.Link(h.Provider)
 			host.Path, _ = m.Path(db)
 			r = host
 			return
@@ -265,6 +254,17 @@ func (r *Host) With(m *model.Host) {
 	r.Datastores = m.Datastores
 	r.VMs = m.Vms
 	r.NetworkAdapters = []NetworkAdapter{}
+}
+
+//
+// Build self link (URI).
+func (r *Host) Link(p *api.Provider) {
+	r.SelfLink = base.Link(
+		HostRoot,
+		base.Params{
+			base.ProviderParam: string(p.UID),
+			HostParam:          r.ID,
+		})
 }
 
 //

--- a/pkg/controller/provider/web/vsphere/network.go
+++ b/pkg/controller/provider/web/vsphere/network.go
@@ -73,7 +73,7 @@ func (h NetworkHandler) List(ctx *gin.Context) {
 	for _, m := range list {
 		r := &Network{}
 		r.With(&m)
-		r.SelfLink = h.Link(h.Provider, &m)
+		r.Link(h.Provider)
 		content = append(content, r.Content(h.Detail))
 	}
 
@@ -118,21 +118,10 @@ func (h NetworkHandler) Get(ctx *gin.Context) {
 		ctx.Status(http.StatusInternalServerError)
 		return
 	}
-	r.SelfLink = h.Link(h.Provider, m)
+	r.Link(h.Provider)
 	content := r.Content(true)
 
 	ctx.JSON(http.StatusOK, content)
-}
-
-//
-// Build self link (URI).
-func (h NetworkHandler) Link(p *api.Provider, m *model.Network) string {
-	return h.Handler.Link(
-		NetworkRoot,
-		base.Params{
-			base.ProviderParam: string(p.UID),
-			NetworkParam:       m.ID,
-		})
 }
 
 //
@@ -147,7 +136,7 @@ func (h NetworkHandler) watch(ctx *gin.Context) {
 			m := in.(*model.Network)
 			network := &Network{}
 			network.With(m)
-			network.SelfLink = h.Link(h.Provider, m)
+			network.Link(h.Provider)
 			network.Path, _ = m.Path(db)
 			r = network
 			return
@@ -217,6 +206,17 @@ func (r *Network) With(m *model.Network) {
 	case model.NetDvSwitch:
 		r.Host = m.Host
 	}
+}
+
+//
+// Build self link (URI).
+func (r *Network) Link(p *api.Provider) {
+	r.SelfLink = base.Link(
+		NetworkRoot,
+		base.Params{
+			base.ProviderParam: string(p.UID),
+			NetworkParam:       r.ID,
+		})
 }
 
 //

--- a/pkg/controller/provider/web/vsphere/provider.go
+++ b/pkg/controller/provider/web/vsphere/provider.go
@@ -83,7 +83,7 @@ func (h ProviderHandler) Get(ctx *gin.Context) {
 		ctx.Status(http.StatusInternalServerError)
 		return
 	}
-	r.SelfLink = h.Link(m)
+	r.Link()
 	content := r.Content(true)
 
 	ctx.JSON(http.StatusOK, content)
@@ -117,7 +117,7 @@ func (h *ProviderHandler) ListContent(ctx *gin.Context) (content []interface{}, 
 				err = aErr
 				return
 			}
-			r.SelfLink = h.Link(m)
+			r.Link()
 			content = append(content, r.Content(h.Detail))
 		}
 	}
@@ -184,16 +184,6 @@ func (h ProviderHandler) AddDerived(r *Provider) (err error) {
 }
 
 //
-// Build self link (URI).
-func (h ProviderHandler) Link(m *model.Provider) string {
-	return h.Handler.Link(
-		ProviderRoot,
-		base.Params{
-			base.ProviderParam: m.UID,
-		})
-}
-
-//
 // REST Resource.
 type Provider struct {
 	ocp.Resource
@@ -215,6 +205,16 @@ func (r *Provider) With(m *model.Provider) {
 	r.Resource.With(&m.Base)
 	r.Type = m.Type
 	r.Object = m.Object
+}
+
+//
+// Build self link (URI).
+func (r *Provider) Link() {
+	r.SelfLink = base.Link(
+		ProviderRoot,
+		base.Params{
+			base.ProviderParam: r.UID,
+		})
 }
 
 //

--- a/pkg/controller/provider/web/vsphere/tree.go
+++ b/pkg/controller/provider/web/vsphere/tree.go
@@ -129,7 +129,7 @@ func (h TreeHandler) VmTree(ctx *gin.Context) {
 		}
 		r := Datacenter{}
 		r.With(&dc)
-		r.SelfLink = DatacenterHandler{}.Link(h.Provider, &dc)
+		r.Link(h.Provider)
 		branch.Kind = model.DatacenterKind
 		branch.Object = r
 		content.Children = append(content.Children, branch)
@@ -192,7 +192,7 @@ func (h TreeHandler) HostTree(ctx *gin.Context) {
 		}
 		r := Datacenter{}
 		r.With(&dc)
-		r.SelfLink = DatacenterHandler{}.Link(h.Provider, &dc)
+		r.Link(h.Provider)
 		branch.Kind = model.DatacenterKind
 		branch.Object = r
 		content.Children = append(content.Children, branch)
@@ -373,8 +373,7 @@ func (r *NodeBuilder) Node(parent *TreeNode, m model.Model) *TreeNode {
 	case model.FolderKind:
 		resource := &Folder{}
 		resource.With(m.(*model.Folder))
-		resource.SelfLink =
-			FolderHandler{}.Link(r.provider, m.(*model.Folder))
+		resource.Link(r.provider)
 		object := resource.Content(r.withDetail(kind))
 		node = &TreeNode{
 			Parent: parent,
@@ -384,8 +383,7 @@ func (r *NodeBuilder) Node(parent *TreeNode, m model.Model) *TreeNode {
 	case model.DatacenterKind:
 		resource := &Datacenter{}
 		resource.With(m.(*model.Datacenter))
-		resource.SelfLink =
-			DatacenterHandler{}.Link(r.provider, m.(*model.Datacenter))
+		resource.Link(r.provider)
 		object := resource.Content(r.withDetail(kind))
 		node = &TreeNode{
 			Parent: parent,
@@ -395,8 +393,7 @@ func (r *NodeBuilder) Node(parent *TreeNode, m model.Model) *TreeNode {
 	case model.ClusterKind:
 		resource := &Cluster{}
 		resource.With(m.(*model.Cluster))
-		resource.SelfLink =
-			ClusterHandler{}.Link(r.provider, m.(*model.Cluster))
+		resource.Link(r.provider)
 		object := resource.Content(r.withDetail(kind))
 		node = &TreeNode{
 			Parent: parent,
@@ -406,8 +403,7 @@ func (r *NodeBuilder) Node(parent *TreeNode, m model.Model) *TreeNode {
 	case model.HostKind:
 		resource := &Host{}
 		resource.With(m.(*model.Host))
-		resource.SelfLink =
-			HostHandler{}.Link(r.provider, m.(*model.Host))
+		resource.Link(r.provider)
 		object := resource.Content(r.withDetail(kind))
 		node = &TreeNode{
 			Parent: parent,
@@ -417,8 +413,7 @@ func (r *NodeBuilder) Node(parent *TreeNode, m model.Model) *TreeNode {
 	case model.VmKind:
 		resource := &VM{}
 		resource.With(m.(*model.VM))
-		resource.SelfLink =
-			VMHandler{}.Link(r.provider, m.(*model.VM))
+		resource.Link(r.provider)
 		object := resource.Content(r.withDetail(kind))
 		node = &TreeNode{
 			Parent: parent,
@@ -428,8 +423,7 @@ func (r *NodeBuilder) Node(parent *TreeNode, m model.Model) *TreeNode {
 	case model.NetKind:
 		resource := &Network{}
 		resource.With(m.(*model.Network))
-		resource.SelfLink =
-			NetworkHandler{}.Link(r.provider, m.(*model.Network))
+		resource.Link(r.provider)
 		object := resource.Content(r.withDetail(kind))
 		node = &TreeNode{
 			Parent: parent,
@@ -439,8 +433,7 @@ func (r *NodeBuilder) Node(parent *TreeNode, m model.Model) *TreeNode {
 	case model.DsKind:
 		resource := &Datastore{}
 		resource.With(m.(*model.Datastore))
-		resource.SelfLink =
-			DatastoreHandler{}.Link(r.provider, m.(*model.Datastore))
+		resource.Link(r.provider)
 		object := resource.Content(r.withDetail(kind))
 		node = &TreeNode{
 			Parent: parent,

--- a/pkg/controller/provider/web/vsphere/vm.go
+++ b/pkg/controller/provider/web/vsphere/vm.go
@@ -74,7 +74,7 @@ func (h VMHandler) List(ctx *gin.Context) {
 	for _, m := range list {
 		r := &VM{}
 		r.With(&m)
-		r.SelfLink = h.Link(h.Provider, &m)
+		r.Link(h.Provider)
 		content = append(content, r.Content(h.Detail))
 	}
 
@@ -119,21 +119,10 @@ func (h VMHandler) Get(ctx *gin.Context) {
 		ctx.Status(http.StatusInternalServerError)
 		return
 	}
-	r.SelfLink = h.Link(h.Provider, m)
+	r.Link(h.Provider)
 	content := r.Content(true)
 
 	ctx.JSON(http.StatusOK, content)
-}
-
-//
-// Build self link (URI).
-func (h VMHandler) Link(p *api.Provider, m *model.VM) string {
-	return h.Handler.Link(
-		VMRoot,
-		base.Params{
-			base.ProviderParam: string(p.UID),
-			VMParam:            m.ID,
-		})
 }
 
 //
@@ -148,7 +137,7 @@ func (h VMHandler) watch(ctx *gin.Context) {
 			m := in.(*model.VM)
 			vm := &VM{}
 			vm.With(m)
-			vm.SelfLink = h.Link(h.Provider, m)
+			vm.Link(h.Provider)
 			vm.Path, _ = m.Path(db)
 			r = vm
 			return
@@ -261,6 +250,17 @@ func (r *VM) With(m *model.VM) {
 	r.Networks = m.Networks
 	r.Disks = m.Disks
 	r.Concerns = m.Concerns
+}
+
+//
+// Build self link (URI).
+func (r *VM) Link(p *api.Provider) {
+	r.SelfLink = base.Link(
+		VMRoot,
+		base.Params{
+			base.ProviderParam: string(p.UID),
+			VMParam:            r.ID,
+		})
 }
 
 //


### PR DESCRIPTION
The web `Handler`.Link() moved to _Resource_.Link() for both consistency and resource use outside of the web layer.
The `Workload` is used outside the web package for validation.  Deduplicated.

Fixes listing /providers endpoints broken in https://github.com/konveyor/forklift-controller/pull/274