### PR TITLE
oVirt Builder and Scheduler

### DIFF
--- a/pkg/controller/plan/adapter/ovirt/builder.go
+++ b/pkg/controller/plan/adapter/ovirt/builder.go
@@ -204,8 +204,7 @@ func (r *Builder) Tasks(vmRef ref.Ref) (list []*plan.Task, err error) {
 		return
 	}
 	for _, da := range vm.DiskAttachments {
-		//mB := da.Disk.Capacity / 0x100000
-		mB := int64(0)
+		mB := da.Disk.ProvisionedSize / 0x100000
 		list = append(
 			list,
 			&plan.Task{

--- a/pkg/controller/plan/adapter/ovirt/builder.go
+++ b/pkg/controller/plan/adapter/ovirt/builder.go
@@ -1,13 +1,20 @@
 package ovirt
 
 import (
+	"context"
+	"fmt"
+	liberr "github.com/konveyor/controller/pkg/error"
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/plan"
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/ref"
 	plancontext "github.com/konveyor/forklift-controller/pkg/controller/plan/context"
+	"github.com/konveyor/forklift-controller/pkg/controller/provider/web/ocp"
+	model "github.com/konveyor/forklift-controller/pkg/controller/provider/web/ovirt"
+	"gopkg.in/yaml.v2"
 	core "k8s.io/api/core/v1"
 	cdi "kubevirt.io/containerized-data-importer/pkg/apis/core/v1beta1"
 	vmio "kubevirt.io/vm-import-operator/pkg/apis/v2v/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 //
@@ -16,30 +23,232 @@ type Builder struct {
 	*plancontext.Context
 	// Provisioner CRs.
 	provisioners map[string]*api.Provisioner
-	// Host CRs.
-	hosts map[string]*api.Host
 }
 
 //
 // Build the VMIO secret.
 func (r *Builder) Secret(vmRef ref.Ref, in, object *core.Secret) (err error) {
+	url := r.Source.Provider.Spec.URL
+
+	content, mErr := yaml.Marshal(
+		map[string]string{
+			"apiUrl":   url,
+			"username": string(in.Data["user"]),
+			"password": string(in.Data["password"]),
+			"ca.cert":  string(in.Data["cacert"]),
+		})
+	if mErr != nil {
+		err = liberr.Wrap(mErr)
+		return
+	}
+	object.StringData = map[string]string{
+		"ovirt": string(content),
+	}
+
 	return
 }
 
 //
 // Build the VMIO VM Import Spec.
 func (r *Builder) Import(vmRef ref.Ref, object *vmio.VirtualMachineImportSpec) (err error) {
+	vm := &model.VM{}
+	pErr := r.Source.Inventory.Find(vm, vmRef)
+	if pErr != nil {
+		err = liberr.New(
+			fmt.Sprintf(
+				"VM %s lookup failed: %s",
+				vmRef.String(),
+				pErr.Error()))
+		return
+	}
+
+	object.TargetVMName = &vm.Name
+	object.Source.Ovirt = &vmio.VirtualMachineImportOvirtSourceSpec{
+		VM: vmio.VirtualMachineImportOvirtSourceVMSpec{
+			ID: &vm.ID,
+		},
+	}
+	object.Source.Ovirt.Mappings, err = r.mapping(vm)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+func (r *Builder) mapping(vm *model.VM) (out *vmio.OvirtMappings, err error) {
+	netMap := []vmio.NetworkResourceMappingItem{}
+	storageMap := []vmio.StorageResourceMappingItem{}
+	netMapIn := r.Context.Map.Network.Spec.Map
+	for i := range netMapIn {
+		mapped := &netMapIn[i]
+		ref := mapped.Source
+		network := &model.Network{}
+		fErr := r.Source.Inventory.Find(network, ref)
+		if err != nil {
+			err = fErr
+			return
+		}
+		needed := false
+		//for _, net := range vm.Networks {
+		//	if net.ID == network.ID {
+		//		needed = true
+		//		break
+		//	}
+		//}
+		if !needed {
+			continue
+		}
+		netMap = append(
+			netMap,
+			vmio.NetworkResourceMappingItem{
+				Source: vmio.Source{
+					ID: &network.ID,
+				},
+				Target: vmio.ObjectIdentifier{
+					Namespace: &mapped.Destination.Namespace,
+					Name:      mapped.Destination.Name,
+				},
+				Type: &mapped.Destination.Type,
+			})
+	}
+	storageMapIn := r.Context.Map.Storage.Spec.Map
+	for i := range storageMapIn {
+		mapped := &storageMapIn[i]
+		ref := mapped.Source
+		domain := &model.StorageDomain{}
+		fErr := r.Source.Inventory.Find(domain, ref)
+		if fErr != nil {
+			err = fErr
+			return
+		}
+		needed := false
+		//for _, disk := range vm.Disks {
+		//	if disk.StorageDomain.ID == domain.ID {
+		//		needed = true
+		//		break
+		//	}
+		//}
+		if !needed {
+			continue
+		}
+		mErr := r.defaultModes(&mapped.Destination)
+		if mErr != nil {
+			err = mErr
+			return
+		}
+		item := vmio.StorageResourceMappingItem{
+			Source: vmio.Source{
+				ID: &domain.ID,
+			},
+			Target: vmio.ObjectIdentifier{
+				Name: mapped.Destination.StorageClass,
+			},
+		}
+		if mapped.Destination.VolumeMode != "" {
+			item.VolumeMode = &mapped.Destination.VolumeMode
+		}
+		if mapped.Destination.AccessMode != "" {
+			item.AccessMode = &mapped.Destination.AccessMode
+		}
+		storageMap = append(storageMap, item)
+	}
+	out = &vmio.OvirtMappings{
+		NetworkMappings: &netMap,
+		StorageMappings: &storageMap,
+	}
+
+	return
+}
+
+
+//
+// Set volume and access modes.
+func (r *Builder) defaultModes(dm *api.DestinationStorage) (err error) {
+	model := &ocp.StorageClass{}
+	ref := ref.Ref{Name: dm.StorageClass}
+	err = r.Destination.Inventory.Find(model, ref)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	if dm.VolumeMode == "" || dm.AccessMode == "" {
+		if provisioner, found := r.provisioners[model.Object.Provisioner]; found {
+			volumeMode := provisioner.VolumeMode(dm.VolumeMode)
+			accessMode := volumeMode.AccessMode(dm.AccessMode)
+			if dm.VolumeMode == "" {
+				dm.VolumeMode = volumeMode.Name
+			}
+			if dm.AccessMode == "" {
+				dm.AccessMode = accessMode.Name
+			}
+		}
+	}
+
 	return
 }
 
 //
 // Build tasks.
 func (r *Builder) Tasks(vmRef ref.Ref) (list []*plan.Task, err error) {
+	vm := &model.VM{}
+	pErr := r.Source.Inventory.Find(vm, vmRef)
+	if pErr != nil {
+		err = liberr.New(
+			fmt.Sprintf(
+				"VM %s lookup failed: %s",
+				vmRef.String(),
+				pErr.Error()))
+		return
+	}
+	//for _, disk := range vm.Disks {
+	//	mB := disk.Capacity / 0x100000
+	//	list = append(
+	//		list,
+	//		&plan.Task{
+	//			Name: disk.ID,
+	//			Progress: libitr.Progress{
+	//				Total: mB,
+	//			},
+	//			Annotations: map[string]string{
+	//				"unit": "MB",
+	//			},
+	//		})
+	//}
+
 	return
 }
 
 //
 // Return a stable identifier for a DataVolume.
 func (r *Builder) ResolveDataVolumeIdentifier(dv *cdi.DataVolume) string {
-	return ""
+	return dv.Spec.Source.Imageio.DiskID
+}
+
+func (r *Builder) Load() (err error) {
+	return r.loadProvisioners()
+}
+
+//
+// Load provisioner CRs.
+func (r *Builder) loadProvisioners() (err error) {
+	list := &api.ProvisionerList{}
+	err = r.List(
+		context.TODO(),
+		list,
+		&client.ListOptions{
+			Namespace: r.Source.Provider.Namespace,
+		},
+	)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	r.provisioners = map[string]*api.Provisioner{}
+	for i := range list.Items {
+		p := &list.Items[i]
+		r.provisioners[p.Spec.Name] = p
+	}
+
+	return
 }

--- a/pkg/controller/plan/adapter/ovirt/validator.go
+++ b/pkg/controller/plan/adapter/ovirt/validator.go
@@ -38,13 +38,12 @@ func (r *Validator) NetworksMapped(vmRef ref.Ref) (ok bool, err error) {
 			vmRef.String())
 		return
 	}
-	/*  TODO: Implement when inventory is complete.
-	for _, net := range vm.Networks {
-		if !r.plan.Referenced.Map.Network.Status.Refs.Find(ref.Ref{ID: net.ID}) {
+
+	for _, nic := range vm.NICs {
+		if !r.plan.Referenced.Map.Network.Status.Refs.Find(ref.Ref{ID: nic.Profile.Network}) {
 			return
 		}
 	}
-	*/
 	ok = true
 	return
 }
@@ -65,13 +64,11 @@ func (r *Validator) StorageMapped(vmRef ref.Ref) (ok bool, err error) {
 			vmRef.String())
 		return
 	}
-	/*  TODO: Implement when inventory is complete.
-	for _, disk := range vm.Disks {
-		if !r.plan.Referenced.Map.Storage.Status.Refs.Find(ref.Ref{ID: disk.Datastore.ID}) {
+	for _, da := range vm.DiskAttachments {
+		if !r.plan.Referenced.Map.Storage.Status.Refs.Find(ref.Ref{ID: da.Disk.StorageDomain}) {
 			return
 		}
 	}
-	*/
 	ok = true
 	return
 }

--- a/pkg/controller/plan/scheduler/doc.go
+++ b/pkg/controller/plan/scheduler/doc.go
@@ -5,6 +5,7 @@ import (
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/plan"
 	plancontext "github.com/konveyor/forklift-controller/pkg/controller/plan/context"
+	"github.com/konveyor/forklift-controller/pkg/controller/plan/scheduler/ovirt"
 	"github.com/konveyor/forklift-controller/pkg/controller/plan/scheduler/vsphere"
 	"github.com/konveyor/forklift-controller/pkg/settings"
 )
@@ -22,6 +23,11 @@ func New(ctx *plancontext.Context) (scheduler Scheduler, err error) {
 	switch ctx.Source.Provider.Type() {
 	case api.VSphere:
 		scheduler = &vsphere.Scheduler{
+			Context:     ctx,
+			MaxInFlight: settings.Settings.MaxInFlight,
+		}
+	case api.OVirt:
+		scheduler = &ovirt.Scheduler{
 			Context:     ctx,
 			MaxInFlight: settings.Settings.MaxInFlight,
 		}

--- a/pkg/controller/plan/scheduler/ovirt/scheduler.go
+++ b/pkg/controller/plan/scheduler/ovirt/scheduler.go
@@ -1,0 +1,29 @@
+package ovirt
+
+import (
+	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/plan"
+	plancontext "github.com/konveyor/forklift-controller/pkg/controller/plan/context"
+	"sync"
+)
+
+//
+// Package level mutex to ensure that
+// multiple concurrent reconciles don't
+// attempt to schedule VMs into the same
+// slots.
+var mutex sync.Mutex
+
+// Scheduler for migrations from oVirt.
+type Scheduler struct {
+	*plancontext.Context
+	// Maximum number of VMs that can be
+	// migrated at once per provider.
+	MaxInFlight int
+}
+
+func (r *Scheduler) Next() (vm *plan.VMStatus, hasNext bool, err error) {
+	mutex.Lock()
+	defer mutex.Unlock()
+	hasNext = false
+	return
+}

--- a/pkg/controller/plan/scheduler/ovirt/scheduler.go
+++ b/pkg/controller/plan/scheduler/ovirt/scheduler.go
@@ -24,6 +24,14 @@ type Scheduler struct {
 func (r *Scheduler) Next() (vm *plan.VMStatus, hasNext bool, err error) {
 	mutex.Lock()
 	defer mutex.Unlock()
-	hasNext = false
+
+	for _, vmStatus := range r.Plan.Status.Migration.VMs {
+		if !vmStatus.MarkedStarted() && !vmStatus.MarkedCompleted() {
+			vm = vmStatus
+			hasNext = true
+			return
+		}
+	}
+
 	return
 }

--- a/pkg/controller/provider/container/ovirt/resource.go
+++ b/pkg/controller/provider/container/ovirt/resource.go
@@ -594,9 +594,10 @@ type DiskProfileList struct {
 // Disk.
 type Disk struct {
 	Base
-	Sharable       string `json:"sharable"`
-	Profile        Ref    `json:"disk_profile"`
-	StorageDomains struct {
+	Sharable        string `json:"sharable"`
+	Profile         Ref    `json:"disk_profile"`
+	ProvisionedSize string `json:"provisioned_size"`
+	StorageDomains  struct {
 		List []Ref `json:"storage_domain"`
 	} `json:"storage_domains"`
 	Status      string `json:"status"`
@@ -616,6 +617,7 @@ func (r *Disk) ApplyTo(m *model.Disk) {
 	m.StorageUsed = r.int64(r.StorageUsed)
 	m.Backup = r.Backup
 	m.StorageType = r.StorageType
+	m.ProvisionedSize = r.int64(r.ProvisionedSize)
 	r.setStorageDomain(m)
 }
 

--- a/pkg/controller/provider/model/ovirt/model.go
+++ b/pkg/controller/provider/model/ovirt/model.go
@@ -233,11 +233,12 @@ type Property struct {
 
 type Disk struct {
 	Base
-	Shared        bool   `sql:""`
-	Profile       string `sql:"index(profile)"`
-	StorageDomain string `sql:"index(storageDomain)"`
-	Status        string `sql:""`
-	StorageUsed   int64  `sql:""`
-	Backup        string `sql:""`
-	StorageType   string `sql:""`
+	Shared          bool   `sql:""`
+	Profile         string `sql:"index(profile)"`
+	StorageDomain   string `sql:"index(storageDomain)"`
+	Status          string `sql:""`
+	StorageUsed     int64  `sql:""`
+	Backup          string `sql:""`
+	StorageType     string `sql:""`
+	ProvisionedSize int64  `sql:""`
 }

--- a/pkg/controller/provider/validation.go
+++ b/pkg/controller/provider/validation.go
@@ -204,6 +204,7 @@ func (r *Reconciler) validateSecret(provider *api.Provider) (secret *core.Secret
 		keyList = []string{
 			"user",
 			"password",
+			"cacert",
 		}
 	}
 	for _, key := range keyList {

--- a/pkg/controller/provider/web/ovirt/disk.go
+++ b/pkg/controller/provider/web/ovirt/disk.go
@@ -163,15 +163,17 @@ func (h DiskHandler) watch(ctx *gin.Context) {
 // REST Resource.
 type Disk struct {
 	Resource
-	Shared  bool        `json:"shared"`
-	StorageDomain string `json:"storageDomain"`
-	Profile DiskProfile `json:"profile"`
+	Shared          bool        `json:"shared"`
+	StorageDomain   string      `json:"storageDomain"`
+	Profile         DiskProfile `json:"profile"`
+	ProvisionedSize int64       `json:"provisionedSize"`
 }
 
 //
 // Build the resource using the model.
 func (r *Disk) With(m *model.Disk) {
 	r.Resource.With(&m.Base)
+	r.ProvisionedSize = m.ProvisionedSize
 	r.Shared = m.Shared
 	r.StorageDomain = m.StorageDomain
 	r.Profile = DiskProfile{


### PR DESCRIPTION
* Adds ProvisionedSize field to the Disk
* Implements the oVirt builder. The secret requires a `cacert` field containing a b64 encoded root CA.
* Implements the oVirt scheduler. The scheduler will allow up to MaxInFlight VMs per provider to be running at once. We should probably have vSphere and oVirt have their own settings for the maximum number of transfers in flight, since vSphere is disks not VMs, and in any case limitations will be different per provider. This can be done in a follow up.