### PR TITLE
oVirt part 7

### DIFF
--- a/pkg/controller/provider/container/ovirt/model.go
+++ b/pkg/controller/provider/container/ovirt/model.go
@@ -11,22 +11,16 @@ import (
 
 //
 // Event codes.
-// NICProfileAdded   = 1122
-// NICProfileUpdated = 1124
-// NICProfileDeleted = 1126
 const (
-	DataCenterAdded   = 950
-	DataCenterUpdated = 952
-	DataCenterDeleted = 954
-	ClusterAdded      = 809
-	ClusterUpdated    = 811
-	ClusterDeleted    = 813
-	HostAdded         = 42
-	HostUpdated       = 43
-	HostDeleted       = 44
-	VmAdded           = 34
-	VmUpdated         = 35
-	VmDeleted         = 113
+	USER_ADD_CLUSTER    = 809
+	USER_UPDATE_CLUSTER = 811
+	USER_REMOVE_CLUSTER = 813
+	USER_ADD_HOST       = 42
+	USER_UPDATE_HOST    = 43
+	USER_REMOVE_HOST    = 44
+	USER_ADD_VM         = 34
+	USER_UPDATE_VM      = 35
+	USER_REMOVE_VM      = 113
 )
 
 //
@@ -103,60 +97,13 @@ func (r *DataCenterAdapter) List(client *Client) (itr fb.Iterator, err error) {
 //
 // Handled events.
 func (r *DataCenterAdapter) Event() []int {
-	return []int{
-		DataCenterAdded,
-		DataCenterUpdated,
-		DataCenterDeleted,
-	}
+	return []int{}
 }
 
 //
 // Apply events to the inventory model.
 func (r *DataCenterAdapter) Apply(client *Client, tx *libmodel.Tx, event *Event) (err error) {
 	switch event.code() {
-	case DataCenterAdded:
-		object := &DataCenter{}
-		err = client.get(event.DataCenter.Ref, object)
-		if err != nil {
-			break
-		}
-		m := &model.DataCenter{
-			Base: model.Base{ID: object.ID},
-		}
-		m.Created()
-		object.ApplyTo(m)
-		err = tx.Insert(m)
-		if err != nil {
-			break
-		}
-	case DataCenterUpdated:
-		object := &DataCenter{}
-		err = client.get(event.DataCenter.Ref, object)
-		if err != nil {
-			break
-		}
-		m := &model.DataCenter{
-			Base: model.Base{ID: object.ID},
-		}
-		m.Updated()
-		object.ApplyTo(m)
-		err = tx.Update(m)
-		if err != nil {
-			break
-		}
-	case DataCenterDeleted:
-		object := &DataCenter{}
-		err = client.get(event.DataCenter.Ref, object)
-		if err != nil {
-			break
-		}
-		m := &model.DataCenter{
-			Base: model.Base{ID: object.ID},
-		}
-		err = tx.Delete(m)
-		if err != nil {
-			break
-		}
 	default:
 		err = liberr.New("unknown event", "event", event)
 	}
@@ -376,9 +323,9 @@ type ClusterAdapter struct {
 // Handled events.
 func (r *ClusterAdapter) Event() []int {
 	return []int{
-		ClusterAdded,
-		ClusterUpdated,
-		ClusterDeleted,
+		USER_ADD_CLUSTER,
+		USER_UPDATE_CLUSTER,
+		USER_REMOVE_CLUSTER,
 	}
 }
 
@@ -412,7 +359,7 @@ func (r *ClusterAdapter) List(client *Client) (itr fb.Iterator, err error) {
 // Apply and event tot the inventory model.
 func (r *ClusterAdapter) Apply(client *Client, tx *libmodel.Tx, event *Event) (err error) {
 	switch event.code() {
-	case ClusterAdded:
+	case USER_ADD_CLUSTER:
 		object := &Cluster{}
 		err = client.get(event.Cluster.Ref, object)
 		if err != nil {
@@ -427,7 +374,7 @@ func (r *ClusterAdapter) Apply(client *Client, tx *libmodel.Tx, event *Event) (e
 		if err != nil {
 			break
 		}
-	case ClusterUpdated:
+	case USER_UPDATE_CLUSTER:
 		object := &Cluster{}
 		err = client.get(event.Cluster.Ref, object)
 		if err != nil {
@@ -442,7 +389,7 @@ func (r *ClusterAdapter) Apply(client *Client, tx *libmodel.Tx, event *Event) (e
 		if err != nil {
 			break
 		}
-	case ClusterDeleted:
+	case USER_REMOVE_CLUSTER:
 		m := &model.Cluster{
 			Base: model.Base{ID: event.Cluster.Ref},
 		}
@@ -466,9 +413,9 @@ type HostAdapter struct {
 // Handled events.
 func (r *HostAdapter) Event() []int {
 	return []int{
-		HostAdded,
-		HostUpdated,
-		HostDeleted,
+		USER_ADD_HOST,
+		USER_UPDATE_HOST,
+		USER_REMOVE_HOST,
 	}
 }
 
@@ -502,7 +449,7 @@ func (r *HostAdapter) List(client *Client) (itr fb.Iterator, err error) {
 // Apply and event tot the inventory model.
 func (r *HostAdapter) Apply(client *Client, tx *libmodel.Tx, event *Event) (err error) {
 	switch event.code() {
-	case HostAdded:
+	case USER_ADD_HOST:
 		object := &Host{}
 		err = client.get(event.Host.Ref, object, r.follow())
 		if err != nil {
@@ -517,7 +464,7 @@ func (r *HostAdapter) Apply(client *Client, tx *libmodel.Tx, event *Event) (err 
 		if err != nil {
 			break
 		}
-	case HostUpdated:
+	case USER_UPDATE_HOST:
 		object := &Host{}
 		err = client.get(event.Host.Ref, object, r.follow())
 		if err != nil {
@@ -532,7 +479,7 @@ func (r *HostAdapter) Apply(client *Client, tx *libmodel.Tx, event *Event) (err 
 		if err != nil {
 			break
 		}
-	case HostDeleted:
+	case USER_REMOVE_HOST:
 		m := &model.Host{
 			Base: model.Base{ID: event.Host.Ref},
 		}
@@ -568,9 +515,9 @@ type VMAdapter struct {
 // Handled events.
 func (r *VMAdapter) Event() []int {
 	return []int{
-		VmAdded,
-		VmUpdated,
-		VmDeleted,
+		USER_ADD_VM,
+		USER_UPDATE_VM,
+		USER_REMOVE_VM,
 	}
 }
 
@@ -604,7 +551,7 @@ func (r *VMAdapter) List(client *Client) (itr fb.Iterator, err error) {
 // Apply and event tot the inventory model.
 func (r *VMAdapter) Apply(client *Client, tx *libmodel.Tx, event *Event) (err error) {
 	switch event.code() {
-	case VmAdded:
+	case USER_ADD_VM:
 		object := &VM{}
 		err = client.get(event.VM.Ref, object, r.follow())
 		if err != nil {
@@ -619,7 +566,7 @@ func (r *VMAdapter) Apply(client *Client, tx *libmodel.Tx, event *Event) (err er
 		if err != nil {
 			break
 		}
-	case VmUpdated:
+	case USER_UPDATE_VM:
 		object := &VM{}
 		err = client.get(event.VM.Ref, object, r.follow())
 		if err != nil {
@@ -634,7 +581,7 @@ func (r *VMAdapter) Apply(client *Client, tx *libmodel.Tx, event *Event) (err er
 		if err != nil {
 			break
 		}
-	case VmDeleted:
+	case USER_REMOVE_VM:
 		m := &model.VM{
 			Base: model.Base{ID: event.VM.Ref},
 		}

--- a/pkg/controller/provider/container/ovirt/reconciler.go
+++ b/pkg/controller/provider/container/ovirt/reconciler.go
@@ -38,6 +38,8 @@ type Reconciler struct {
 	log logr.Logger
 	// has parity.
 	parity bool
+	// load() completed.
+	loaded bool
 	// REST client.
 	client *Client
 	// cancel function.
@@ -126,10 +128,13 @@ func (r *Reconciler) Start() error {
 			case <-ctx.Done():
 				break try
 			default:
-				if r.parity {
+				if r.loaded {
 					err := r.refresh()
 					if err != nil {
 						r.log.Error(err, "Refresh failed.")
+						r.parity = false
+					} else {
+						r.parity = true
 					}
 				} else {
 					err := r.drainEvent()
@@ -236,6 +241,7 @@ func (r *Reconciler) load() (err error) {
 	err = tx.Commit()
 	if err == nil {
 		r.parity = true
+		r.loaded = true
 	} else {
 		return
 	}

--- a/pkg/controller/provider/web/ovirt/tree.go
+++ b/pkg/controller/provider/web/ovirt/tree.go
@@ -12,8 +12,8 @@ import (
 //
 // Routes.
 const (
-	TreeRoot   = ProviderRoot + "/tree"
-	TreeVmRoot = TreeRoot + "/host"
+	TreeRoot        = ProviderRoot + "/tree"
+	TreeClusterRoot = TreeRoot + "/cluster"
 )
 
 //
@@ -32,7 +32,7 @@ type TreeHandler struct {
 //
 // Add routes to the `gin` router.
 func (h *TreeHandler) AddRoutes(e *gin.Engine) {
-	e.GET(TreeVmRoot, h.Tree)
+	e.GET(TreeClusterRoot, h.Tree)
 }
 
 //
@@ -142,20 +142,21 @@ func (n *BranchNavigator) Next(p libmodel.Model) (r []model.Model, err error) {
 			err = nErr
 		}
 	case *model.Cluster:
-		list, nErr := n.listHost(p.(*model.Cluster))
+		m := p.(*model.Cluster)
+		hostList, nErr := n.listHost(m)
 		if nErr == nil {
-			for i := range list {
-				m := &list[i]
+			for i := range hostList {
+				m := &hostList[i]
 				r = append(r, m)
 			}
 		} else {
 			err = nErr
+			return
 		}
-	case *model.Host:
-		list, nErr := n.listVM(p.(*model.Host))
+		vmList, nErr := n.listVM(m)
 		if nErr == nil {
-			for i := range list {
-				m := &list[i]
+			for i := range vmList {
+				m := &vmList[i]
 				r = append(r, m)
 			}
 		} else {
@@ -186,7 +187,7 @@ func (n *BranchNavigator) listHost(p *model.Cluster) (list []model.Host, err err
 	return
 }
 
-func (n *BranchNavigator) listVM(p *model.Host) (list []model.VM, err error) {
+func (n *BranchNavigator) listVM(p *model.Cluster) (list []model.VM, err error) {
 	detail := 0
 	if n.detail {
 		detail = 1
@@ -195,7 +196,7 @@ func (n *BranchNavigator) listVM(p *model.Host) (list []model.VM, err error) {
 	err = n.db.List(
 		&list,
 		model.ListOptions{
-			Predicate: libmodel.Eq("Host", p.ID),
+			Predicate: libmodel.Eq("Cluster", p.ID),
 			Detail:    detail,
 		})
 	return


### PR DESCRIPTION
oVirt part 7.

Renamed const to match [Event Documentation](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/technical_reference/appe-event_codes).  A lot more event to follow in future PR.

Improved handling of the oVirt data reconciler lifecycle.

Updated oVirt trees.
Renamed the /tree/host to /tree/cluster since the tree really needs to be focused on the cluster.  Putting the VM under the host reflects an untrue containment relationship.

Tree:
- DataCenter
  - Cluster
  - VM

The `workload` has been flattened to match.

Workload:
- ID
- Name
- ...
- Host
- Cluster
- DataCenter
