### PR TITLE
Load() the oVirt builder while constructing it

### DIFF
--- a/pkg/controller/plan/adapter/ovirt/adapter.go
+++ b/pkg/controller/plan/adapter/ovirt/adapter.go
@@ -13,7 +13,12 @@ type Adapter struct{}
 //
 // Constructs a oVirt builder.
 func (r *Adapter) Builder(ctx *plancontext.Context) (builder base.Builder, err error) {
-	builder = &Builder{Context: ctx}
+	b := &Builder{Context: ctx}
+	err = b.Load()
+	if err != nil {
+		return
+	}
+	builder = b
 	return
 }
 


### PR DESCRIPTION
The oVirt Builder wasn't having `Load()` called on it before, which meant the provisioner map was unpopulated and the destination storage would not have the correct volume and access modes set.