### PR TITLE
Revert "Don't reconcile successful plans"

### DIFF
--- a/pkg/controller/plan/controller.go
+++ b/pkg/controller/plan/controller.go
@@ -196,12 +196,6 @@ func (r Reconciler) Reconcile(request reconcile.Request) (result reconcile.Resul
 		}
 		return
 	}
-
-	if plan.Status.HasCondition(Succeeded) {
-		r.Log.V(1).Info("Ignoring successfully completed plan.")
-		return
-	}
-
 	defer func() {
 		r.Log.V(2).Info("Conditions.", "all", plan.Status.Conditions)
 	}()


### PR DESCRIPTION
Since we are always permitting retries in 2.1, this can be reverted.

Reverts konveyor/forklift-controller#259