### PR TITLE
controller 0.4.3 compat.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/gin-gonic/gin v1.6.3
 	github.com/go-logr/logr v0.3.0
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.1.0
-	github.com/konveyor/controller v0.4.2
+	github.com/konveyor/controller v0.4.3
 	github.com/onsi/gomega v1.10.3
 	github.com/pkg/profile v1.3.0
 	github.com/prometheus/client_golang v1.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -725,6 +725,8 @@ github.com/konveyor/controller v0.4.1 h1:0LiBaAIrXScOqb6OoIGOIqpK9dxBAQotPWEhP4J
 github.com/konveyor/controller v0.4.1/go.mod h1:j0DSNesS0XHmqOLcJEuwB+qIRkdJ3mSIEJFA2byC12c=
 github.com/konveyor/controller v0.4.2 h1:xP+vDP+c2eWJMERjfx2UeaoJHYJRavOnA6wnKMivTxw=
 github.com/konveyor/controller v0.4.2/go.mod h1:j0DSNesS0XHmqOLcJEuwB+qIRkdJ3mSIEJFA2byC12c=
+github.com/konveyor/controller v0.4.3 h1:Yr7DNLnTWcHPvl/07xQJgRer6ZkyyoHIOsqbeXCnlL8=
+github.com/konveyor/controller v0.4.3/go.mod h1:j0DSNesS0XHmqOLcJEuwB+qIRkdJ3mSIEJFA2byC12c=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=

--- a/pkg/controller/provider/container/ovirt/model.go
+++ b/pkg/controller/provider/container/ovirt/model.go
@@ -81,7 +81,6 @@ func (r *DataCenterAdapter) List(client *Client) (itr fb.Iterator, err error) {
 		m := &model.DataCenter{
 			Base: model.Base{ID: object.ID},
 		}
-		m.Created()
 		object.ApplyTo(m)
 		err = list.Append(m)
 		if err != nil {
@@ -135,7 +134,6 @@ func (r *NetworkAdapter) List(client *Client) (itr fb.Iterator, err error) {
 		m := &model.Network{
 			Base: model.Base{ID: object.ID},
 		}
-		m.Created()
 		object.ApplyTo(m)
 		err = list.Append(m)
 		if err != nil {
@@ -194,7 +192,6 @@ func (r *NICProfileAdapter) List(client *Client) (itr fb.Iterator, err error) {
 		m := &model.NICProfile{
 			Base: model.Base{ID: object.ID},
 		}
-		m.Created()
 		object.ApplyTo(m)
 		err = list.Append(m)
 		if err != nil {
@@ -242,7 +239,6 @@ func (r *DiskProfileAdapter) List(client *Client) (itr fb.Iterator, err error) {
 		m := &model.DiskProfile{
 			Base: model.Base{ID: object.ID},
 		}
-		m.Created()
 		object.ApplyTo(m)
 		err = list.Append(m)
 		if err != nil {
@@ -290,7 +286,6 @@ func (r *StorageDomainAdapter) List(client *Client) (itr fb.Iterator, err error)
 		m := &model.StorageDomain{
 			Base: model.Base{ID: object.ID},
 		}
-		m.Created()
 		object.ApplyTo(m)
 		err = list.Append(m)
 		if err != nil {
@@ -342,7 +337,6 @@ func (r *ClusterAdapter) List(client *Client) (itr fb.Iterator, err error) {
 		m := &model.Cluster{
 			Base: model.Base{ID: object.ID},
 		}
-		m.Created()
 		object.ApplyTo(m)
 		err = list.Append(m)
 		if err != nil {
@@ -368,7 +362,6 @@ func (r *ClusterAdapter) Apply(client *Client, tx *libmodel.Tx, event *Event) (e
 		m := &model.Cluster{
 			Base: model.Base{ID: object.ID},
 		}
-		m.Created()
 		object.ApplyTo(m)
 		err = tx.Insert(m)
 		if err != nil {
@@ -383,7 +376,6 @@ func (r *ClusterAdapter) Apply(client *Client, tx *libmodel.Tx, event *Event) (e
 		m := &model.Cluster{
 			Base: model.Base{ID: object.ID},
 		}
-		m.Updated()
 		object.ApplyTo(m)
 		err = tx.Update(m)
 		if err != nil {
@@ -432,7 +424,6 @@ func (r *HostAdapter) List(client *Client) (itr fb.Iterator, err error) {
 		m := &model.Host{
 			Base: model.Base{ID: object.ID},
 		}
-		m.Created()
 		object.ApplyTo(m)
 		err = list.Append(m)
 		if err != nil {
@@ -458,7 +449,6 @@ func (r *HostAdapter) Apply(client *Client, tx *libmodel.Tx, event *Event) (err 
 		m := &model.Host{
 			Base: model.Base{ID: object.ID},
 		}
-		m.Created()
 		object.ApplyTo(m)
 		err = tx.Insert(m)
 		if err != nil {
@@ -473,7 +463,6 @@ func (r *HostAdapter) Apply(client *Client, tx *libmodel.Tx, event *Event) (err 
 		m := &model.Host{
 			Base: model.Base{ID: object.ID},
 		}
-		m.Updated()
 		object.ApplyTo(m)
 		err = tx.Update(m)
 		if err != nil {
@@ -534,7 +523,6 @@ func (r *VMAdapter) List(client *Client) (itr fb.Iterator, err error) {
 		m := &model.VM{
 			Base: model.Base{ID: object.ID},
 		}
-		m.Created()
 		object.ApplyTo(m)
 		err = list.Append(m)
 		if err != nil {
@@ -560,7 +548,6 @@ func (r *VMAdapter) Apply(client *Client, tx *libmodel.Tx, event *Event) (err er
 		m := &model.VM{
 			Base: model.Base{ID: object.ID},
 		}
-		m.Created()
 		object.ApplyTo(m)
 		err = tx.Insert(m)
 		if err != nil {
@@ -575,7 +562,6 @@ func (r *VMAdapter) Apply(client *Client, tx *libmodel.Tx, event *Event) (err er
 		m := &model.VM{
 			Base: model.Base{ID: object.ID},
 		}
-		m.Updated()
 		object.ApplyTo(m)
 		err = tx.Update(m)
 		if err != nil {
@@ -636,7 +622,6 @@ func (r *DiskAdapter) List(client *Client) (itr fb.Iterator, err error) {
 		m := &model.Disk{
 			Base: model.Base{ID: object.ID},
 		}
-		m.Created()
 		object.ApplyTo(m)
 		err = list.Append(m)
 		if err != nil {

--- a/pkg/controller/provider/model/base/model.go
+++ b/pkg/controller/provider/model/base/model.go
@@ -8,6 +8,10 @@ import (
 type Model = libmodel.Model
 type ListOptions = libmodel.ListOptions
 
+const (
+	MaxDetail = libmodel.MaxDetail
+)
+
 //
 // An object reference.
 type Ref struct {

--- a/pkg/controller/provider/model/ocp/model.go
+++ b/pkg/controller/provider/model/ocp/model.go
@@ -20,6 +20,10 @@ var NotFound = libmodel.NotFound
 
 type InvalidRefError = base.InvalidRefError
 
+const (
+	MaxDetail = base.MaxDetail
+)
+
 //
 // Types
 type Model = base.Model
@@ -36,10 +40,8 @@ type Resource interface {
 //
 // Base k8s model.
 type Base struct {
-	// PK
-	PK string `sql:"pk"`
 	// Object UID.
-	UID string `sql:"d0"`
+	UID string `sql:"pk"`
 	// Resource version.
 	Version string `sql:"d0"`
 	// Namespace.
@@ -68,20 +70,11 @@ func (m *Base) ResourceVersion() uint64 {
 }
 
 func (m *Base) Pk() string {
-	return m.PK
+	return m.UID
 }
 
 func (m *Base) String() string {
 	return path.Join(m.Namespace, m.Name)
-}
-
-func (m *Base) Equals(other Model) bool {
-	if b, cast := other.(*Base); cast {
-		return m.Namespace == b.Namespace &&
-			m.Name == b.Name
-	}
-
-	return false
 }
 
 func (m *Base) Labels() libmodel.Labels {

--- a/pkg/controller/provider/model/ovirt/model.go
+++ b/pkg/controller/provider/model/ovirt/model.go
@@ -11,6 +11,10 @@ var NotFound = libmodel.NotFound
 
 type InvalidRefError = base.InvalidRefError
 
+const (
+	MaxDetail = base.MaxDetail
+)
+
 //
 // Types
 type Model = base.Model
@@ -28,7 +32,7 @@ type Base struct {
 	// Revision
 	Description string `sql:"d0"`
 	// Revision
-	Revision int64 `sql:"d0,index(revision)"`
+	Revision int64 `sql:"incremented,d0,index(revision)"`
 }
 
 //
@@ -41,34 +45,6 @@ func (m *Base) Pk() string {
 // String representation.
 func (m *Base) String() string {
 	return m.ID
-}
-
-//
-// Get labels.
-func (m *Base) Labels() libmodel.Labels {
-	return nil
-}
-
-func (m *Base) Equals(other libmodel.Model) bool {
-	if vm, cast := other.(*Base); cast {
-		return m.ID == vm.ID
-	}
-
-	return false
-}
-
-//
-// Created.
-func (m *Base) Created() {
-	m.Revision = 1
-}
-
-//
-// Updated.
-// Increment revision. Should ONLY be called by
-// the reconciler.
-func (m *Base) Updated() {
-	m.Revision++
 }
 
 type DataCenter struct {

--- a/pkg/controller/provider/model/vsphere/model.go
+++ b/pkg/controller/provider/model/vsphere/model.go
@@ -20,6 +20,10 @@ var NotFound = libmodel.NotFound
 
 type InvalidRefError = base.InvalidRefError
 
+const (
+	MaxDetail = base.MaxDetail
+)
+
 //
 // Types
 type Model = base.Model
@@ -37,7 +41,7 @@ type Base struct {
 	// Parent
 	Parent Ref `sql:"d0,index(parent)"`
 	// Revision
-	Revision int64 `sql:"d0,index(revision)"`
+	Revision int64 `sql:"incremented,d0,index(revision)"`
 }
 
 //

--- a/pkg/controller/provider/web/ocp/namespace.go
+++ b/pkg/controller/provider/web/ocp/namespace.go
@@ -79,7 +79,7 @@ func (h NamespaceHandler) Get(ctx *gin.Context) {
 	}
 	m := &model.Namespace{
 		Base: model.Base{
-			PK: ctx.Param(NsParam),
+			UID: ctx.Param(NsParam),
 		},
 	}
 	db := h.Reconciler.DB()

--- a/pkg/controller/provider/web/ocp/netattachdefinition.go
+++ b/pkg/controller/provider/web/ocp/netattachdefinition.go
@@ -80,7 +80,7 @@ func (h NadHandler) Get(ctx *gin.Context) {
 	}
 	m := &model.NetworkAttachmentDefinition{
 		Base: model.Base{
-			PK: ctx.Param(NadParam),
+			UID: ctx.Param(NadParam),
 		},
 	}
 	db := h.Reconciler.DB()

--- a/pkg/controller/provider/web/ocp/storageclass.go
+++ b/pkg/controller/provider/web/ocp/storageclass.go
@@ -80,7 +80,7 @@ func (h StorageClassHandler) Get(ctx *gin.Context) {
 	}
 	m := &model.StorageClass{
 		Base: model.Base{
-			PK: ctx.Param(StorageClassParam),
+			UID: ctx.Param(StorageClassParam),
 		},
 	}
 	db := h.Reconciler.DB()

--- a/pkg/controller/provider/web/ocp/vm.go
+++ b/pkg/controller/provider/web/ocp/vm.go
@@ -80,7 +80,7 @@ func (h VMHandler) Get(ctx *gin.Context) {
 	}
 	m := &model.VM{
 		Base: model.Base{
-			PK: ctx.Param(VmParam),
+			UID: ctx.Param(VmParam),
 		},
 	}
 	db := h.Reconciler.DB()

--- a/pkg/controller/provider/web/ovirt/tree.go
+++ b/pkg/controller/provider/web/ovirt/tree.go
@@ -47,7 +47,7 @@ func (h *TreeHandler) Prepare(ctx *gin.Context) int {
 	err := db.List(
 		&h.datacenters,
 		model.ListOptions{
-			Detail: 1,
+			Detail: model.MaxDetail,
 		})
 	if err != nil {
 		log.Trace(

--- a/pkg/controller/provider/web/vsphere/tree.go
+++ b/pkg/controller/provider/web/vsphere/tree.go
@@ -50,7 +50,7 @@ func (h *TreeHandler) Prepare(ctx *gin.Context) int {
 	err := db.List(
 		&h.datacenters,
 		model.ListOptions{
-			Detail: 1,
+			Detail: model.MaxDetail,
 		})
 	if err != nil {
 		log.Trace(


### PR DESCRIPTION
The `Model` interface related.  String(), Equals() and Labels() now optional.
Using `sql:incremented` instead of Created() and Updated() methods on the models.
Detail level=1 no longer means ALL.
The PK no longer blindly derived when not set.  As a result, the OCP primary key is the UID which is more straight forward anyway.

**Requires**: https://github.com/konveyor/controller/pull/82 expected to be released as 0.4.3.  Will update the PR when it's released.