### PR TITLE
Improved oVirt (change) detection and event handling.

### DIFF
--- a/pkg/controller/provider/container/ovirt/reconciler.go
+++ b/pkg/controller/provider/container/ovirt/reconciler.go
@@ -309,6 +309,20 @@ func (r *Reconciler) watch() (list []*libmodel.Watch) {
 	} else {
 		list = append(list, w)
 	}
+	// NICProfile
+	w, err = r.db.Watch(
+		&model.NICProfile{},
+		&NICProfileHandler{
+			DB:  r.db,
+			log: r.log,
+		})
+	if err != nil {
+		r.log.Error(
+			err,
+			"create (NICProfile) watch failed.")
+	} else {
+		list = append(list, w)
+	}
 
 	return
 }

--- a/pkg/controller/provider/container/ovirt/resource.go
+++ b/pkg/controller/provider/container/ovirt/resource.go
@@ -601,7 +601,7 @@ type Disk struct {
 		List []Ref `json:"storage_domain"`
 	} `json:"storage_domains"`
 	Status      string `json:"status"`
-	StorageUsed string `json:"actual_size"`
+	ActualSize  string `json:"actual_size"`
 	Backup      string `json:"backup"`
 	StorageType string `json:"storage_type"`
 }
@@ -614,7 +614,7 @@ func (r *Disk) ApplyTo(m *model.Disk) {
 	m.Shared = r.bool(r.Sharable)
 	m.Profile = r.Profile.ID
 	m.Status = r.Status
-	m.StorageUsed = r.int64(r.StorageUsed)
+	m.ActualSize = r.int64(r.ActualSize)
 	m.Backup = r.Backup
 	m.StorageType = r.StorageType
 	m.ProvisionedSize = r.int64(r.ProvisionedSize)

--- a/pkg/controller/provider/model/ovirt/model.go
+++ b/pkg/controller/provider/model/ovirt/model.go
@@ -214,7 +214,7 @@ type Disk struct {
 	Profile         string `sql:"index(profile)"`
 	StorageDomain   string `sql:"index(storageDomain)"`
 	Status          string `sql:""`
-	StorageUsed     int64  `sql:""`
+	ActualSize      int64  `sql:""`
 	Backup          string `sql:""`
 	StorageType     string `sql:""`
 	ProvisionedSize int64  `sql:""`

--- a/pkg/controller/provider/web/ovirt/disk.go
+++ b/pkg/controller/provider/web/ovirt/disk.go
@@ -167,6 +167,7 @@ type Disk struct {
 	StorageDomain   string      `json:"storageDomain"`
 	Profile         DiskProfile `json:"profile"`
 	ProvisionedSize int64       `json:"provisionedSize"`
+	ActualSize      int64       `json:"actualSize"`
 }
 
 //
@@ -174,6 +175,7 @@ type Disk struct {
 func (r *Disk) With(m *model.Disk) {
 	r.Resource.With(&m.Base)
 	r.ProvisionedSize = m.ProvisionedSize
+	r.ActualSize = m.ActualSize
 	r.Shared = m.Shared
 	r.StorageDomain = m.StorageDomain
 	r.Profile = DiskProfile{


### PR DESCRIPTION
Add additional _const_ for event codes.

Disk.StorageUsed renamed: `ActualSize` per RHV native naming.

A support for DataCenter events though don't know how to test it.  Not sure how to add/update/delete a DC.

Add support for vNICProfile events.  This uses the new container.Collection since these events do not indicate which profile changed.  A watch is added that will determine which VMs are affected and _tag_ them for re-validation.

This PR established this pattern.