### PR TITLE
Let VMIO manage VM start during warm migration

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -123,8 +123,11 @@ func (r *Builder) Import(vmRef ref.Ref, object *vmio.VirtualMachineImportSpec) (
 	}
 	uuid := vm.UUID
 	object.TargetVMName = &vm.Name
-	start := vm.PowerState == string(types.VirtualMachinePowerStatePoweredOn)
-	object.StartVM = &start
+	if !r.Plan.Spec.Warm {
+		// object.StartVM left nil during a warm migration so that VMIO can manage it.
+		start := vm.PowerState == string(types.VirtualMachinePowerStatePoweredOn)
+		object.StartVM = &start
+	}
 	object.Source.Vmware = &vmio.VirtualMachineImportVmwareSourceSpec{
 		VM: vmio.VirtualMachineImportVmwareSourceVMSpec{
 			ID: &uuid,


### PR DESCRIPTION
Lets VMIO handle whether or not to start a VM during a warm migration. This permits it to use the VM's powerstate immediately before cutover to determine whether or not to start the destination VM. 

https://bugzilla.redhat.com/show_bug.cgi?id=1957791