### PR TITLE
Fix Plan.TargetNamespace() nil pointer dereference

### DIFF
--- a/config/crds/forklift.konveyor.io_plans.yaml
+++ b/config/crds/forklift.konveyor.io_plans.yaml
@@ -252,6 +252,7 @@ spec:
             required:
             - map
             - provider
+            - targetNamespace
             - vms
             type: object
           status:

--- a/config/forklift.konveyor.io_plans.yaml
+++ b/config/forklift.konveyor.io_plans.yaml
@@ -252,6 +252,7 @@ spec:
             required:
             - map
             - provider
+            - targetNamespace
             - vms
             type: object
           status:

--- a/pkg/apis/forklift/v1beta1/plan.go
+++ b/pkg/apis/forklift/v1beta1/plan.go
@@ -31,7 +31,7 @@ type PlanSpec struct {
 	// Description
 	Description string `json:"description,omitempty"`
 	// Target namespace.
-	TargetNamespace string `json:"targetNamespace,omitempty"`
+	TargetNamespace string `json:"targetNamespace"`
 	// Providers.
 	Provider provider.Pair `json:"provider"`
 	// Resource mapping.
@@ -88,19 +88,6 @@ type Plan struct {
 	// Referenced resources populated
 	// during validation.
 	Referenced `json:"-"`
-}
-
-//
-// Get the target namespace.
-// Default to `plan` namespace when not specified
-// in the plan spec.
-func (r *Plan) TargetNamespace() (ns string) {
-	ns = r.Spec.TargetNamespace
-	if ns == "" {
-		ns = r.Namespace
-	}
-
-	return
 }
 
 //

--- a/pkg/apis/forklift/v1beta1/plan.go
+++ b/pkg/apis/forklift/v1beta1/plan.go
@@ -97,7 +97,7 @@ type Plan struct {
 func (r *Plan) TargetNamespace() (ns string) {
 	ns = r.Spec.TargetNamespace
 	if ns == "" {
-		ns = r.Plan.Namespace
+		ns = r.Namespace
 	}
 
 	return

--- a/pkg/controller/plan/handler/ocp/handler.go
+++ b/pkg/controller/plan/handler/ocp/handler.go
@@ -84,7 +84,7 @@ func (r *Handler) changed(vm *ocp.VM) {
 		if !r.MatchProvider(ref) {
 			continue
 		}
-		if plan.TargetNamespace() == vm.Namespace {
+		if plan.Spec.TargetNamespace == vm.Namespace {
 			log.V(3).Info(
 				"Queue reconcile event.",
 				"plan",

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -78,7 +78,7 @@ func (r *KubeVirt) ListImports() ([]VmImport, error) {
 		vList,
 		&client.ListOptions{
 			LabelSelector: labels.SelectorFromSet(r.planLabels()),
-			Namespace:     r.Plan.TargetNamespace(),
+			Namespace:     r.Plan.Spec.TargetNamespace,
 		},
 	)
 	if err != nil {
@@ -98,7 +98,7 @@ func (r *KubeVirt) ListImports() ([]VmImport, error) {
 		context.TODO(),
 		dvList,
 		&client.ListOptions{
-			Namespace: r.Plan.TargetNamespace(),
+			Namespace: r.Plan.Spec.TargetNamespace,
 		},
 	)
 	if err != nil {
@@ -138,7 +138,7 @@ func (r *KubeVirt) EnsureImport(vm *plan.VMStatus) (err error) {
 		list,
 		&client.ListOptions{
 			LabelSelector: labels.SelectorFromSet(r.vmLabels(vm.Ref)),
-			Namespace:     r.Plan.TargetNamespace(),
+			Namespace:     r.Plan.Spec.TargetNamespace,
 		},
 	)
 	if err != nil {
@@ -205,7 +205,7 @@ func (r *KubeVirt) DeleteImport(vm *plan.VMStatus) (err error) {
 		list,
 		&client.ListOptions{
 			LabelSelector: labels.SelectorFromSet(r.vmLabels(vm.Ref)),
-			Namespace:     r.Plan.TargetNamespace(),
+			Namespace:     r.Plan.Spec.TargetNamespace,
 		},
 	)
 	if err != nil {
@@ -240,7 +240,7 @@ func (r *KubeVirt) DeleteImport(vm *plan.VMStatus) (err error) {
 func (r *KubeVirt) EnsureNamespace() (err error) {
 	ns := &core.Namespace{
 		ObjectMeta: meta.ObjectMeta{
-			Name: r.Plan.TargetNamespace(),
+			Name: r.Plan.Spec.TargetNamespace,
 		},
 	}
 	err = r.Destination.Client.Create(context.TODO(), ns)
@@ -274,7 +274,7 @@ func (r *KubeVirt) ensureSecret(vmRef ref.Ref) (secret *core.Secret, err error) 
 		list,
 		&client.ListOptions{
 			LabelSelector: labels.SelectorFromSet(r.vmLabels(vmRef)),
-			Namespace:     r.Plan.TargetNamespace(),
+			Namespace:     r.Plan.Spec.TargetNamespace,
 		},
 	)
 	if err != nil {
@@ -333,7 +333,7 @@ func (r *KubeVirt) vmImport(
 	}
 	object = &vmio.VirtualMachineImport{
 		ObjectMeta: meta.ObjectMeta{
-			Namespace:   r.Plan.TargetNamespace(),
+			Namespace:   r.Plan.Spec.TargetNamespace,
 			Labels:      r.vmLabels(vm.Ref),
 			Annotations: annotations,
 			GenerateName: strings.Join(
@@ -372,7 +372,7 @@ func (r *KubeVirt) secret(vmRef ref.Ref) (object *core.Secret, err error) {
 	object = &core.Secret{
 		ObjectMeta: meta.ObjectMeta{
 			Labels:    r.vmLabels(vmRef),
-			Namespace: r.Plan.TargetNamespace(),
+			Namespace: r.Plan.Spec.TargetNamespace,
 			GenerateName: strings.Join(
 				[]string{
 					r.Plan.Name,


### PR DESCRIPTION
Plan.TargetNamespace() was falling back to the `Referenced` Plan's `Namespace` field. The `Referenced` Plan field is not populated for Plans, so this fails.