### PR TITLE
Fix VM validation tracking by defeating the auto-incremented Revision…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/gin-gonic/gin v1.6.3
 	github.com/go-logr/logr v0.3.0
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.1.0
-	github.com/konveyor/controller v0.4.4
+	github.com/konveyor/controller v0.4.5
 	github.com/onsi/gomega v1.10.3
 	github.com/pkg/profile v1.3.0
 	github.com/prometheus/client_golang v1.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -729,6 +729,8 @@ github.com/konveyor/controller v0.4.3 h1:Yr7DNLnTWcHPvl/07xQJgRer6ZkyyoHIOsqbeXC
 github.com/konveyor/controller v0.4.3/go.mod h1:j0DSNesS0XHmqOLcJEuwB+qIRkdJ3mSIEJFA2byC12c=
 github.com/konveyor/controller v0.4.4 h1:0hWDCahnQU7h90WM0eBECxATD2wyiOOPzUomQ4MzUec=
 github.com/konveyor/controller v0.4.4/go.mod h1:j0DSNesS0XHmqOLcJEuwB+qIRkdJ3mSIEJFA2byC12c=
+github.com/konveyor/controller v0.4.5 h1:21/DrEm8GbjgOlGec+pjJNot3IMOyBHzWT1ZP8bkKq8=
+github.com/konveyor/controller v0.4.5/go.mod h1:j0DSNesS0XHmqOLcJEuwB+qIRkdJ3mSIEJFA2byC12c=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=

--- a/pkg/controller/provider/container/ovirt/watch.go
+++ b/pkg/controller/provider/container/ovirt/watch.go
@@ -324,6 +324,7 @@ func (r *VMEventHandler) validated(batch []*policy.Task) {
 		latest.PolicyVersion = task.Version
 		latest.RevisionValidated = latest.Revision
 		latest.Concerns = task.Concerns
+		latest.Revision--
 		err = tx.Update(latest)
 		if err != nil {
 			r.log.Error(err, "VM update failed.")

--- a/pkg/controller/provider/container/vsphere/watch.go
+++ b/pkg/controller/provider/container/vsphere/watch.go
@@ -324,6 +324,7 @@ func (r *VMEventHandler) validated(batch []*policy.Task) {
 		latest.PolicyVersion = task.Version
 		latest.RevisionValidated = latest.Revision
 		latest.Concerns = task.Concerns
+		latest.Revision--
 		err = tx.Update(latest)
 		if err != nil {
 			r.log.Error(err, "VM update failed.")


### PR DESCRIPTION
Fix VM validation tracking by defeating the auto-incremented `Revision` when updating the `RevisionValidated`.  Else, the `ValidatedRevision` will always be 1 behind and the VM will never be considered as validated.

Requires: https://github.com/konveyor/controller/pull/84