### PR TITLE
Fix updating VMs with batched validation result.

### DIFF
--- a/pkg/controller/provider/container/ovirt/watch.go
+++ b/pkg/controller/provider/container/ovirt/watch.go
@@ -310,16 +310,16 @@ func (r *VMEventHandler) validated(batch []*policy.Task) {
 	for _, task := range batch {
 		if task.Error != nil {
 			r.log.Info(task.Error.Error())
-			return
+			continue
 		}
 		latest := &model.VM{Base: model.Base{ID: task.Ref.ID}}
 		err = tx.Get(latest)
 		if err != nil {
 			r.log.Error(err, "VM (get) failed.")
-			return
+			continue
 		}
 		if task.Revision != latest.Revision {
-			return
+			continue
 		}
 		latest.PolicyVersion = task.Version
 		latest.RevisionValidated = latest.Revision
@@ -328,7 +328,7 @@ func (r *VMEventHandler) validated(batch []*policy.Task) {
 		err = tx.Update(latest)
 		if err != nil {
 			r.log.Error(err, "VM update failed.")
-			return
+			continue
 		}
 		r.log.V(3).Info(
 			"VM validated.",

--- a/pkg/controller/provider/container/vsphere/watch.go
+++ b/pkg/controller/provider/container/vsphere/watch.go
@@ -310,16 +310,16 @@ func (r *VMEventHandler) validated(batch []*policy.Task) {
 	for _, task := range batch {
 		if task.Error != nil {
 			r.log.Info(task.Error.Error())
-			return
+			continue
 		}
 		latest := &model.VM{Base: model.Base{ID: task.Ref.ID}}
 		err = tx.Get(latest)
 		if err != nil {
 			r.log.Error(err, "VM (get) failed.")
-			return
+			continue
 		}
 		if task.Revision != latest.Revision {
-			return
+			continue
 		}
 		latest.PolicyVersion = task.Version
 		latest.RevisionValidated = latest.Revision
@@ -328,7 +328,7 @@ func (r *VMEventHandler) validated(batch []*policy.Task) {
 		err = tx.Update(latest)
 		if err != nil {
 			r.log.Error(err, "VM update failed.")
-			return
+			continue
 		}
 		r.log.V(3).Info(
 			"VM validated.",


### PR DESCRIPTION
Fix updating VMs with batched validation result.  When something failed or the revision of the validated VM no longer matched the _latest_ VM, we needed to continue processing other task results instead of returning.  As a result, subsequent task results were not updating their VMs and VMs would remain un-validated (in the DB) until the next schedule validation or an update triggered (re)validation of the VM.

This is a regression introduced late in 2.0.0 performance/scale fixes that also affects vSphere.