### PR TITLE
Fix oVirt event refresh.

### DIFF
--- a/pkg/controller/provider/container/ovirt/resource.go
+++ b/pkg/controller/provider/container/ovirt/resource.go
@@ -2,6 +2,7 @@ package ovirt
 
 import (
 	model "github.com/konveyor/forklift-controller/pkg/controller/provider/model/ovirt"
+	"sort"
 	"strconv"
 )
 
@@ -706,4 +707,14 @@ func (r *Event) code() (n int) {
 // EVent (list).
 type EventList struct {
 	Items []Event `json:"event"`
+}
+
+//
+// Sort by ID ascending.
+func (r *EventList) sort() {
+	sort.Slice(
+		r.Items,
+		func(i, j int) bool {
+			return r.Items[i].id() < r.Items[j].id()
+		})
 }


### PR DESCRIPTION
Fix oVirt event refresh.
The algorithm of listing events sorted by date having noted the highest event ID is unnecessarily complex and flawed.
As a result - the reconciler was not determining the _latest_ event properly and processing _old_ events which caused a lot of NotFound errors applying the event.  The flaw was to sort by date.

Instead:
1. List events which are naturally sorted by `ID` descending.  This means a max=1 (limit) can be used to easily determine the latest event ID.
2. Note the `lastEvent` ID.
2. List events using the `from=lastEvent` parameter.
3. Sort (reverse) the list of events by ID ascending so they are applied in order created.

---

Example of failure.
```
{"level":"info","ts":1625083396.44058,"logger":"reconciler|ovirt","msg":"Event received.","provider":"konveyor-forklift/rhv","event":{"id":"1200914","code":"2016","description":"Disk fdupont-test_Disk1 was successfully attached to VM fdupont-test by admin@internal-authz.","data_center":{"href":"/ovirt-engine/api/datacenters/30528e0a-23eb-11e8-805f-00163e18b6f7","id":"30528e0a-23eb-11e8-805f-00163e18b6f7"},"cluster":{"href":"/ovirt-engine/api/clusters/0edb53fa-232e-4145-8184-946a3736b251","id":"0edb53fa-232e-4145-8184-946a3736b251"},"host":{"href":"","id":""},"vm":{"href":"/ovirt-engine/api/vms/0c4873b6-2546-48ba-9b90-e5de0006e74b","id":"0c4873b6-2546-48ba-9b90-e5de0006e74b"}}}
{"level":"info","ts":1625083396.5225081,"logger":"reconciler|ovirt","msg":"Apply event failed.","provider":"konveyor-forklift/rhv","event":{"id":"1200914","code":"2016","description":"Disk fdupont-test_Disk1 was successfully attached to VM fdupont-test by admin@internal-authz.","data_center":{"href":"/ovirt-engine/api/datacenters/30528e0a-23eb-11e8-805f-00163e18b6f7","id":"30528e0a-23eb-11e8-805f-00163e18b6f7"},"cluster":{"href":"/ovirt-engine/api/clusters/0edb53fa-232e-4145-8184-946a3736b251","id":"0edb53fa-232e-4145-8184-946a3736b251"},"host":{"href":"","id":""},"vm":{"href":"/ovirt-engine/api/vms/0c4873b6-2546-48ba-9b90-e5de0006e74b","id":"0c4873b6-2546-48ba-9b90-e5de0006e74b"}},"error":"Not Found","stacktrace":"\ngithub.com/konveyor/controller/pkg/error.New()\n\t/opt/app-root/pkg/mod/github.com/konveyor/controller@v0.4.6/pkg/error/wrap.go:14\ngithub.com/konveyor/forklift-controller/pkg/controller/provider/container/ovirt.(*Client).get()\n\t/opt/app-root/src/pkg/controller/provider/container/ovirt/client.go:106\ngithub.com/konveyor/forklift-controller/pkg/controller/provider/container/ovirt.(*VMAdapter).Apply()\n\t/opt/app-root/src/pkg/controller/provider/container/ovirt/model.go:760\ngithub.com/konveyor/forklift-controller/pkg/controller/provider/container/ovirt.(*Reconciler).changeSet()\n\t/opt/app-root/src/pkg/controller/provider/container/ovirt/reconciler.go:393\ngithub.com/konveyor/forklift-controller/pkg/controller/provider/container/ovirt.(*Reconciler).refresh()\n\t/opt/app-root/src/pkg/controller/provider/container/ovirt/reconciler.go:367\ngithub.com/konveyor/forklift-controller/pkg/controller/provider/container/ovirt.(*Reconciler).Start.func1()\n\t/opt/app-root/src/pkg/controller/provider/container/ovirt/reconciler.go:139\nruntime.goexit()\n\t/usr/lib/golang/src/runtime/asm_amd64.s:1373"}
```