### PR TITLE
vNIC profile optional in VM endpoint.

### DIFF
--- a/pkg/controller/provider/web/ovirt/disk.go
+++ b/pkg/controller/provider/web/ovirt/disk.go
@@ -191,8 +191,9 @@ func (r *Disk) With(m *model.Disk) {
 
 //
 // Expand the resource.
+// The profile.ID is optional.
 func (r *Disk) Expand(db libmodel.DB) (err error) {
-	if r.Profile.ID == "" { // Optional.
+	if r.Profile.ID == "" {
 		return
 	}
 	profile := &model.DiskProfile{

--- a/pkg/controller/provider/web/ovirt/vm.go
+++ b/pkg/controller/provider/web/ovirt/vm.go
@@ -277,9 +277,13 @@ func (r *VM) Link(p *api.Provider) {
 
 //
 // Expand the resource.
+// The vNIC profile.ID is optional.
 func (r *VM) Expand(db libmodel.DB) (err error) {
 	for i := range r.NICs {
 		nic := &r.NICs[i]
+		if nic.Profile.ID == "" {
+			continue
+		}
 		profile := &model.NICProfile{
 			Base: model.Base{ID: nic.Profile.ID},
 		}


### PR DESCRIPTION
Apparently the vNIC profile ref is optional. 

https://bugzilla.redhat.com/show_bug.cgi?id=1979652