### PR TITLE
Fix oVirt cluster.name.

### DIFF
--- a/pkg/controller/provider/container/ovirt/resource.go
+++ b/pkg/controller/provider/container/ovirt/resource.go
@@ -90,7 +90,7 @@ type Cluster struct {
 // Apply to (update) the model.
 func (r *Cluster) ApplyTo(m *model.Cluster) {
 	m.Name = r.Name
-	m.Name = r.Description
+	m.Description = r.Description
 	m.DataCenter = r.DataCenter.ID
 	m.HaReservation = r.bool(r.HaReservation)
 	m.KsmEnabled = r.bool(r.KSM.Enabled)


### PR DESCRIPTION
Fix oVirt cluster.name being overwritten with the description.

https://bugzilla.redhat.com/show_bug.cgi?id=1980353