### PR TITLE
Support very large oVirt instances.

### DIFF
--- a/pkg/controller/provider/container/ovirt/watch.go
+++ b/pkg/controller/provider/container/ovirt/watch.go
@@ -225,7 +225,7 @@ func (r *VMEventHandler) harvest() {
 // VMs that have been reported through the model event
 // watch are ignored.
 func (r *VMEventHandler) list() {
-	r.log.V(1).Info("List VMs that need to be validated.")
+	r.log.V(3).Info("List VMs that need to be validated.")
 	version, err := policy.Agent.Version()
 	if err != nil {
 		r.log.Error(err, err.Error())

--- a/pkg/controller/provider/container/vsphere/watch.go
+++ b/pkg/controller/provider/container/vsphere/watch.go
@@ -225,7 +225,7 @@ func (r *VMEventHandler) harvest() {
 // VMs that have been reported through the model event
 // watch are ignored.
 func (r *VMEventHandler) list() {
-	r.log.V(1).Info("List VMs that need to be validated.")
+	r.log.V(3).Info("List VMs that need to be validated.")
 	version, err := policy.Agent.Version()
 	if err != nil {
 		r.log.Error(err, err.Error())

--- a/pkg/controller/validation/policy/client.go
+++ b/pkg/controller/validation/policy/client.go
@@ -388,7 +388,7 @@ func (r *Pool) Start() {
 				log.Info(
 					"VM Validation failed.",
 					"task",
-					task)
+					task.String())
 			}
 			task.notify()
 		}


### PR DESCRIPTION
Changes to support very large oVirt instances.

Listing all of the collections can be very slow so the we need to apply any events that occurred since we started before declaring parity and validating VMs.  This makes the state of the data collector (reconciler) more complex.  A _phases_ pattern seemed to fit. Also, since the RHV API is slow, we need a way to cancel all operations by passing the cancel _Context_ to the `Adapter`. 

Fetch VMs in pages.  This is needed to support not _crushing_ the RHV API and to cancel/abort faster.  The page size=100 is based on observed performance and seems like a good balance.  Does not seem to add much time to the overall duration yet provides somewhat timely cancel behavior.
 
Adjust logging level for - listing VMs to validate to level=3.