### PR TITLE
DB file path unique by provider name and UID.

### DIFF
--- a/pkg/controller/provider/controller.go
+++ b/pkg/controller/provider/controller.go
@@ -316,9 +316,12 @@ func (r *Reconciler) updateContainer(provider *api.Provider) (err error) {
 // Build DB for provider.
 func (r *Reconciler) getDB(provider *api.Provider) (db libmodel.DB) {
 	dir := Settings.Inventory.WorkingDir
-	dir = filepath.Join(dir, provider.Namespace)
-	os.MkdirAll(dir, 0755)
-	file := provider.Name + ".db"
+	dir = filepath.Join(
+		dir,
+		provider.Namespace,
+		provider.Name)
+	_ = os.MkdirAll(dir, 0755)
+	file := string(provider.UID) + ".db"
 	path := filepath.Join(dir, file)
 	models := model.Models(provider)
 	db = libmodel.New(path, models...)


### PR DESCRIPTION
The RHV data collector can be slow to shutdown.  In cases where a provider with the same name is deleted/added, there can be multiple DB clients open on the same DB file which may cause locking issues with sqlite3.

```
{"level":"info","ts":1626087031.6307125,"logger":"web|provider","msg":"","sql":"\nSELECT\nCOUNT(*)\nFROM
DataCenter\n;\n","params":null,"url":"/providers?detail=1","error":"database is locked","stacktrace ...
```