### PR TITLE
Handle user add VM (asynchronously).

### DIFF
--- a/pkg/controller/provider/container/ovirt/model.go
+++ b/pkg/controller/provider/container/ovirt/model.go
@@ -43,6 +43,8 @@ const (
 	USER_REMOVE_HOST = 44
 	// VM
 	USER_ADD_VM                           = 34
+	USER_ADD_VM_STARTED                   = 37
+	USER_ADD_VM_FINISHED_FAILED           = 52
 	USER_UPDATE_VM                        = 35
 	USER_REMOVE_VM                        = 113
 	USER_ADD_DISK_TO_VM_SUCCESS           = 97
@@ -730,6 +732,8 @@ func (r *VMAdapter) Event() []int {
 	return []int{
 		// Add
 		USER_ADD_VM,
+		USER_ADD_VM_STARTED,
+		USER_ADD_VM_FINISHED_FAILED,
 		// Update
 		USER_UPDATE_VM,
 		USER_UPDATE_VM_DISK,
@@ -803,7 +807,8 @@ func (r *VMAdapter) List(ctx *Context) (itr fb.Iterator, err error) {
 // Apply and event tot the inventory model.
 func (r *VMAdapter) Apply(ctx *Context, event *Event) (updater Updater, err error) {
 	switch event.code() {
-	case USER_ADD_VM:
+	case USER_ADD_VM,
+		USER_ADD_VM_STARTED:
 		object := &VM{}
 		err = ctx.client.get(event.VM.Ref, object, r.follow())
 		if err != nil {
@@ -851,7 +856,8 @@ func (r *VMAdapter) Apply(ctx *Context, event *Event) (updater Updater, err erro
 			err = tx.Update(m)
 			return
 		}
-	case USER_REMOVE_VM:
+	case USER_REMOVE_VM,
+		USER_ADD_VM_FINISHED_FAILED:
 		updater = func(tx *libmodel.Tx) (err error) {
 			err = tx.Delete(
 				&model.VM{

--- a/pkg/controller/provider/container/ovirt/reconciler.go
+++ b/pkg/controller/provider/container/ovirt/reconciler.go
@@ -405,13 +405,13 @@ func (r *Reconciler) refresh(ctx *Context) (err error) {
 			"event",
 			event)
 		var changeSet []Updater
-		changeSet, err = r.changeSet(ctx, event)
-		if err == nil {
-			err = r.apply(changeSet)
+		changeSet, applyErr := r.changeSet(ctx, event)
+		if applyErr == nil {
+			applyErr = r.apply(changeSet)
 		}
-		if err != nil {
+		if applyErr != nil {
 			r.log.Error(
-				err,
+				applyErr,
 				"Apply event failed.",
 				"event",
 				event)


### PR DESCRIPTION
Support both USER_ADD_VM(34) and USER_ADD_VM_STARTED(37) events.
There are two flows.
(A) With asynchronous tasks: First, USER_ADD_VM_STARTED is generated
(B) Without asynchronous tasks: First, USER_ADD_VM is generated

The disk and vNIC events follow.  Then, for asynchronous there a following:
USER_ADD_VM_FINISHED_SUCCESS or USER_ADD_VM_FINISHED_FAILURE (52).

We cannot simply rely on the USER_ADD_VM_FINISHED_SUCCESS create the VM because then, the update events for attaching disk and adding VMs will not find the VM in inventory to update (and fail).  So instead, the VM is created but then removed on USER_ADD_VM_FINISHED_FAILURE event.

https://bugzilla.redhat.com/show_bug.cgi?id=1982595
