### PR TITLE
Fix excessive oVirt validation.

### DIFF
--- a/pkg/controller/provider/container/vsphere/reconciler.go
+++ b/pkg/controller/provider/container/vsphere/reconciler.go
@@ -860,11 +860,6 @@ func (r Reconciler) applyEnter(tx *libmodel.Tx, u types.ObjectUpdate) error {
 		return liberr.Wrap(err)
 	}
 
-	r.log.V(3).Info(
-		"Model created.",
-		"model",
-		libmodel.Describe(m))
-
 	return nil
 }
 
@@ -888,11 +883,6 @@ func (r Reconciler) applyModify(tx *libmodel.Tx, u types.ObjectUpdate) error {
 	if err != nil {
 		return liberr.Wrap(err)
 	}
-
-	r.log.V(3).Info(
-		"Model updated.",
-		"model",
-		libmodel.Describe(m))
 
 	return nil
 }
@@ -952,11 +942,6 @@ func (r Reconciler) applyLeave(tx *libmodel.Tx, u types.ObjectUpdate) error {
 	if err != nil {
 		return liberr.Wrap(err)
 	}
-
-	r.log.V(3).Info(
-		"Model deleted.",
-		"model",
-		libmodel.Describe(deleted))
 
 	return nil
 }

--- a/pkg/controller/provider/container/vsphere/watch.go
+++ b/pkg/controller/provider/container/vsphere/watch.go
@@ -41,6 +41,14 @@ const (
 )
 
 //
+// Endpoints.
+const (
+	BaseEndpoint       = "/v1/data/io/konveyor/forklift/vmware/"
+	VersionEndpoint    = BaseEndpoint + "rules_version"
+	ValidationEndpoint = BaseEndpoint + "validate"
+)
+
+//
 // Application settings.
 var Settings = &settings.Settings
 
@@ -193,8 +201,8 @@ func (r *VMEventHandler) run() {
 //   - No tasks have been received within
 //     the delay period.
 func (r *VMEventHandler) harvest() {
-	r.log.Info("Result started.")
-	defer r.log.Info("Result stopped.")
+	r.log.Info("Harvest started.")
+	defer r.log.Info("Harvest stopped.")
 	long := time.Hour
 	short := time.Second
 	delay := long
@@ -226,7 +234,7 @@ func (r *VMEventHandler) harvest() {
 // watch are ignored.
 func (r *VMEventHandler) list() {
 	r.log.V(3).Info("List VMs that need to be validated.")
-	version, err := policy.Agent.Version()
+	version, err := policy.Agent.Version(VersionEndpoint)
 	if err != nil {
 		r.log.Error(err, err.Error())
 		return
@@ -244,6 +252,12 @@ func (r *VMEventHandler) list() {
 	if err != nil {
 		r.log.Error(err, "List VM failed.")
 		return
+	}
+	if itr.Len() > 0 {
+		r.log.V(3).Info(
+			"List (unvalidated) VMs found.",
+			"count",
+			itr.Len())
 	}
 	for {
 		vm := &model.VM{}
@@ -275,7 +289,7 @@ func (r *VMEventHandler) canceled() bool {
 // Analyze the VM.
 func (r *VMEventHandler) validate(vm *model.VM) (err error) {
 	task := &policy.Task{
-		Path:     "/v1/data/io/konveyor/forklift/vmware/validate",
+		Path:     ValidationEndpoint,
 		Context:  r.context,
 		Workload: r.workload,
 		Result:   r.taskResult,
@@ -284,6 +298,10 @@ func (r *VMEventHandler) validate(vm *model.VM) (err error) {
 			ID: vm.ID,
 		},
 	}
+	r.log.V(4).Info(
+		"Validate VM.",
+		"vmID",
+		vm.ID)
 	err = policy.Agent.Submit(task)
 	if err != nil {
 		r.log.Error(err, "VM task (submit) failed.")
@@ -295,10 +313,13 @@ func (r *VMEventHandler) validate(vm *model.VM) (err error) {
 //
 // VMs validated.
 func (r *VMEventHandler) validated(batch []*policy.Task) {
-	r.log.V(3).Info("VM (batch) completed.", "batch", len(batch))
 	if len(batch) == 0 {
 		return
 	}
+	r.log.V(3).Info(
+		"VM (batch) completed.",
+		"count",
+		len(batch))
 	tx, err := r.DB.Begin()
 	if err != nil {
 		r.log.Error(err, "Begin tx failed.")
@@ -330,7 +351,7 @@ func (r *VMEventHandler) validated(batch []*policy.Task) {
 			r.log.Error(err, "VM update failed.")
 			continue
 		}
-		r.log.V(3).Info(
+		r.log.V(4).Info(
 			"VM validated.",
 			"vmID",
 			latest.ID,

--- a/pkg/controller/provider/web/ovirt/vm.go
+++ b/pkg/controller/provider/web/ovirt/vm.go
@@ -166,6 +166,7 @@ type VM struct {
 	Cluster                     string           `json:"cluster"`
 	Host                        string           `json:"host"`
 	RevisionValidated           int64            `json:"revisionValidated"`
+	PolicyVersion               int              `json:"policyVersion"`
 	GuestName                   string           `json:"guestName"`
 	CpuSockets                  int16            `json:"cpuSockets"`
 	CpuCores                    int16            `json:"cpuCores"`
@@ -225,6 +226,7 @@ func (r *VM) With(m *model.VM) {
 	r.Cluster = m.Cluster
 	r.Host = m.Host
 	r.RevisionValidated = m.RevisionValidated
+	r.PolicyVersion = m.PolicyVersion
 	r.GuestName = m.GuestName
 	r.CpuSockets = m.CpuSockets
 	r.CpuCores = m.CpuCores

--- a/pkg/settings/policy.go
+++ b/pkg/settings/policy.go
@@ -8,7 +8,6 @@ import (
 // Environment variables.
 const (
 	PolicyAgentURL            = "POLICY_AGENT_URL"
-	PolicyTLSEnabled          = "POLICY_TLS_ENABLED"
 	PolicyAgentCA             = "POLICY_AGENT_CA"
 	PolicyAgentWorkerLimit    = "POLICY_AGENT_WORKER_LIMIT"
 	PolicyAgentSearchInterval = "POLICY_AGENT_SEARCH_INTERVAL"
@@ -21,8 +20,6 @@ type PolicyAgent struct {
 	URL string
 	// TLS
 	TLS struct {
-		// Enabled.
-		Enabled bool
 		// CA path
 		CA string
 	}
@@ -42,7 +39,6 @@ func (r *PolicyAgent) Load() (err error) {
 		r.URL = s
 	}
 	// TLS
-	r.TLS.Enabled = getEnvBool(TLSEnabled, false)
 	if s, found := os.LookupEnv(PolicyAgentCA); found {
 		r.TLS.CA = s
 	} else {


### PR DESCRIPTION
As part of periodic listing VMs that need to be validated, the latest policy version is requested from the policy-agent (validation service).  The version for oVirt and vSphere are different but the path used by the controller in the URL was hard coded for /vmware/.  As a result, when getting the version intended to be match for oVirt (latest=1), it was the policy version for vSphere (latest-5).  This caused the query of:
```
where revision != revisionValidated OR policyVersion != :version
```
to always match ALL oVirt VMs becuase `:version` was incorrect for oVirt.

The fix is to pass the _endpoint_ for retrieving the version from the validation service like is done for validation.

https://bugzilla.redhat.com/show_bug.cgi?id=1985480

---

Also:
- adjusted the logging a little based on experience troubleshooting.
- made the validation service CA optional to make testing easier.