### PR TITLE
Controller v0.6.0 compat.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/gin-gonic/gin v1.6.3
 	github.com/go-logr/logr v0.3.0
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.1.0
-	github.com/konveyor/controller v0.5.0
+	github.com/konveyor/controller v0.6.0
 	github.com/onsi/gomega v1.10.3
 	github.com/pkg/profile v1.3.0
 	github.com/prometheus/client_golang v1.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -735,6 +735,8 @@ github.com/konveyor/controller v0.4.6 h1:GL/Xm0SsxQ46sm1bCiLoll6iHtoRK9GWUemfEGp
 github.com/konveyor/controller v0.4.6/go.mod h1:j0DSNesS0XHmqOLcJEuwB+qIRkdJ3mSIEJFA2byC12c=
 github.com/konveyor/controller v0.5.0 h1:PmAFidRzMwHmbt8ShA/yow60kap1JgZIAtRMdGmNZSs=
 github.com/konveyor/controller v0.5.0/go.mod h1:j0DSNesS0XHmqOLcJEuwB+qIRkdJ3mSIEJFA2byC12c=
+github.com/konveyor/controller v0.6.0 h1:E6P/z64KYEBA9RjkY9xtscqPhBCsCEpTOdVK8Nao5IY=
+github.com/konveyor/controller v0.6.0/go.mod h1:j0DSNesS0XHmqOLcJEuwB+qIRkdJ3mSIEJFA2byC12c=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=

--- a/pkg/controller/provider/container/doc.go
+++ b/pkg/controller/provider/container/doc.go
@@ -15,7 +15,7 @@ import (
 func Build(
 	db libmodel.DB,
 	provider *api.Provider,
-	secret *core.Secret) libcontainer.Reconciler {
+	secret *core.Secret) libcontainer.Collector {
 	//
 	switch provider.Type() {
 	case api.OpenShift:

--- a/pkg/controller/provider/container/ocp/collection.go
+++ b/pkg/controller/provider/container/ocp/collection.go
@@ -32,14 +32,14 @@ func (r *StorageClass) Object() runtime.Object {
 // Reconcile.
 // Achieve initial consistency.
 func (r *StorageClass) Reconcile(ctx context.Context) (err error) {
-	pClient := r.Reconciler.Client()
+	pClient := r.Collector.Client()
 	list := &storage.StorageClassList{}
 	err = pClient.List(context.TODO(), list)
 	if err != nil {
 		err = liberr.Wrap(err)
 		return
 	}
-	db := r.Reconciler.DB()
+	db := r.Collector.DB()
 	tx, err := db.Begin()
 	if err != nil {
 		err = liberr.Wrap(err)
@@ -54,7 +54,7 @@ func (r *StorageClass) Reconcile(ctx context.Context) (err error) {
 		}
 		m := &model.StorageClass{}
 		m.With(&resource)
-		r.Reconciler.UpdateThreshold(m)
+		r.Collector.UpdateThreshold(m)
 		r.log.Info("Create", libref.ToKind(m), m.String())
 		err = tx.Insert(m)
 		if err != nil {
@@ -80,7 +80,7 @@ func (r *StorageClass) Create(e event.CreateEvent) bool {
 	}
 	m := &model.StorageClass{}
 	m.With(object)
-	r.Reconciler.Create(m)
+	r.Collector.Create(m)
 
 	return false
 }
@@ -94,7 +94,7 @@ func (r *StorageClass) Update(e event.UpdateEvent) bool {
 	}
 	m := &model.StorageClass{}
 	m.With(object)
-	r.Reconciler.Update(m)
+	r.Collector.Update(m)
 
 	return false
 }
@@ -108,7 +108,7 @@ func (r *StorageClass) Delete(e event.DeleteEvent) bool {
 	}
 	m := &model.StorageClass{}
 	m.With(object)
-	r.Reconciler.Delete(m)
+	r.Collector.Delete(m)
 
 	return false
 }
@@ -136,14 +136,14 @@ func (r *NetworkAttachmentDefinition) Object() runtime.Object {
 // Reconcile.
 // Achieve initial consistency.
 func (r *NetworkAttachmentDefinition) Reconcile(ctx context.Context) (err error) {
-	pClient := r.Reconciler.Client()
+	pClient := r.Collector.Client()
 	list := &net.NetworkAttachmentDefinitionList{}
 	err = pClient.List(context.TODO(), list)
 	if err != nil {
 		err = liberr.Wrap(err)
 		return
 	}
-	db := r.Reconciler.DB()
+	db := r.Collector.DB()
 	tx, err := db.Begin()
 	if err != nil {
 		err = liberr.Wrap(err)
@@ -158,7 +158,7 @@ func (r *NetworkAttachmentDefinition) Reconcile(ctx context.Context) (err error)
 		}
 		m := &model.NetworkAttachmentDefinition{}
 		m.With(&resource)
-		r.Reconciler.UpdateThreshold(m)
+		r.Collector.UpdateThreshold(m)
 		r.log.Info("Create", libref.ToKind(m), m.String())
 		err = tx.Insert(m)
 		if err != nil {
@@ -184,7 +184,7 @@ func (r *NetworkAttachmentDefinition) Create(e event.CreateEvent) bool {
 	}
 	m := &model.NetworkAttachmentDefinition{}
 	m.With(object)
-	r.Reconciler.Create(m)
+	r.Collector.Create(m)
 
 	return false
 }
@@ -198,7 +198,7 @@ func (r *NetworkAttachmentDefinition) Update(e event.UpdateEvent) bool {
 	}
 	m := &model.NetworkAttachmentDefinition{}
 	m.With(object)
-	r.Reconciler.Update(m)
+	r.Collector.Update(m)
 
 	return false
 }
@@ -212,7 +212,7 @@ func (r *NetworkAttachmentDefinition) Delete(e event.DeleteEvent) bool {
 	}
 	m := &model.NetworkAttachmentDefinition{}
 	m.With(object)
-	r.Reconciler.Delete(m)
+	r.Collector.Delete(m)
 
 	return false
 }
@@ -240,14 +240,14 @@ func (r *Namespace) Object() runtime.Object {
 // Reconcile.
 // Achieve initial consistency.
 func (r *Namespace) Reconcile(ctx context.Context) (err error) {
-	pClient := r.Reconciler.Client()
+	pClient := r.Collector.Client()
 	list := &core.NamespaceList{}
 	err = pClient.List(context.TODO(), list)
 	if err != nil {
 		err = liberr.Wrap(err)
 		return
 	}
-	db := r.Reconciler.DB()
+	db := r.Collector.DB()
 	tx, err := db.Begin()
 	if err != nil {
 		err = liberr.Wrap(err)
@@ -262,7 +262,7 @@ func (r *Namespace) Reconcile(ctx context.Context) (err error) {
 		}
 		m := &model.Namespace{}
 		m.With(&resource)
-		r.Reconciler.UpdateThreshold(m)
+		r.Collector.UpdateThreshold(m)
 		r.log.Info("Create", libref.ToKind(m), m.String())
 		err = tx.Insert(m)
 		if err != nil {
@@ -288,7 +288,7 @@ func (r *Namespace) Create(e event.CreateEvent) bool {
 	}
 	m := &model.Namespace{}
 	m.With(object)
-	r.Reconciler.Create(m)
+	r.Collector.Create(m)
 
 	return false
 }
@@ -302,7 +302,7 @@ func (r *Namespace) Update(e event.UpdateEvent) bool {
 	}
 	m := &model.Namespace{}
 	m.With(object)
-	r.Reconciler.Update(m)
+	r.Collector.Update(m)
 
 	return false
 }
@@ -316,7 +316,7 @@ func (r *Namespace) Delete(e event.DeleteEvent) bool {
 	}
 	m := &model.Namespace{}
 	m.With(object)
-	r.Reconciler.Delete(m)
+	r.Collector.Delete(m)
 
 	return false
 }
@@ -344,14 +344,14 @@ func (r *VM) Object() runtime.Object {
 // Reconcile.
 // Achieve initial consistency.
 func (r *VM) Reconcile(ctx context.Context) (err error) {
-	pClient := r.Reconciler.Client()
+	pClient := r.Collector.Client()
 	list := &cnv.VirtualMachineList{}
 	err = pClient.List(context.TODO(), list)
 	if err != nil {
 		err = liberr.Wrap(err)
 		return
 	}
-	db := r.Reconciler.DB()
+	db := r.Collector.DB()
 	tx, err := db.Begin()
 	if err != nil {
 		err = liberr.Wrap(err)
@@ -366,7 +366,7 @@ func (r *VM) Reconcile(ctx context.Context) (err error) {
 		}
 		m := &model.VM{}
 		m.With(&resource)
-		r.Reconciler.UpdateThreshold(m)
+		r.Collector.UpdateThreshold(m)
 		r.log.Info("Create", libref.ToKind(m), m.String())
 		err = tx.Insert(m)
 		if err != nil {
@@ -392,7 +392,7 @@ func (r *VM) Create(e event.CreateEvent) bool {
 	}
 	m := &model.VM{}
 	m.With(object)
-	r.Reconciler.Create(m)
+	r.Collector.Create(m)
 
 	return false
 }
@@ -406,7 +406,7 @@ func (r *VM) Update(e event.UpdateEvent) bool {
 	}
 	m := &model.VM{}
 	m.With(object)
-	r.Reconciler.Update(m)
+	r.Collector.Update(m)
 
 	return false
 }
@@ -420,7 +420,7 @@ func (r *VM) Delete(e event.DeleteEvent) bool {
 	}
 	m := &model.VM{}
 	m.With(object)
-	r.Reconciler.Delete(m)
+	r.Collector.Delete(m)
 
 	return false
 }

--- a/pkg/controller/provider/container/ocp/collector.go
+++ b/pkg/controller/provider/container/ocp/collector.go
@@ -11,10 +11,10 @@ import (
 )
 
 //
-// New reconciler.
-func New(db libmodel.DB, provider *api.Provider, secret *core.Secret) libcontainer.Reconciler {
-	return &Reconciler{
-		Reconciler: libocp.New(
+// New collector.
+func New(db libmodel.DB, provider *api.Provider, secret *core.Secret) libcontainer.Collector {
+	return &Collector{
+		Collector: libocp.New(
 			db,
 			provider,
 			secret,
@@ -50,7 +50,7 @@ func New(db libmodel.DB, provider *api.Provider, secret *core.Secret) libcontain
 }
 
 //
-// OCP reconciler.
-type Reconciler struct {
-	*libocp.Reconciler
+// OCP collector.
+type Collector struct {
+	*libocp.Collector
 }

--- a/pkg/controller/provider/container/ovirt/model.go
+++ b/pkg/controller/provider/container/ovirt/model.go
@@ -306,7 +306,7 @@ func (r *NetworkAdapter) Apply(ctx *Context, event *Event) (updater Updater, err
 		return
 	}
 	updater = func(tx *libmodel.Tx) (err error) {
-		stored, err := tx.Iter(
+		stored, err := tx.Find(
 			&model.Network{},
 			model.ListOptions{
 				Detail: model.MaxDetail,
@@ -387,7 +387,7 @@ func (r *NICProfileAdapter) Apply(ctx *Context, event *Event) (updater Updater, 
 		return
 	}
 	updater = func(tx *libmodel.Tx) (err error) {
-		stored, err := tx.Iter(
+		stored, err := tx.Find(
 			&model.NICProfile{},
 			model.ListOptions{
 				Detail: model.MaxDetail,
@@ -462,7 +462,7 @@ func (r *DiskProfileAdapter) Apply(ctx *Context, event *Event) (updater Updater,
 		return
 	}
 	updater = func(tx *libmodel.Tx) (err error) {
-		stored, err := tx.Iter(
+		stored, err := tx.Find(
 			&model.DiskProfile{},
 			model.ListOptions{
 				Detail: model.MaxDetail,
@@ -872,7 +872,7 @@ func (r *VMAdapter) Apply(ctx *Context, event *Event) (updater Updater, err erro
 			return
 		}
 		updater = func(tx *libmodel.Tx) (err error) {
-			stored, err := tx.Iter(
+			stored, err := tx.Find(
 				&model.VM{},
 				model.ListOptions{
 					Detail: model.MaxDetail,
@@ -954,7 +954,7 @@ func (r *DiskAdapter) Apply(ctx *Context, event *Event) (updater Updater, err er
 		return
 	}
 	updater = func(tx *libmodel.Tx) (err error) {
-		stored, err := tx.Iter(
+		stored, err := tx.Find(
 			&model.Disk{},
 			model.ListOptions{
 				Detail: model.MaxDetail,

--- a/pkg/controller/provider/container/ovirt/watch.go
+++ b/pkg/controller/provider/container/ovirt/watch.go
@@ -242,7 +242,7 @@ func (r *VMEventHandler) list() {
 	if r.canceled() {
 		return
 	}
-	itr, err := r.DB.Iter(
+	itr, err := r.DB.Find(
 		&model.VM{},
 		libmodel.ListOptions{
 			Predicate: libmodel.Or(
@@ -534,7 +534,7 @@ func (r *NICProfileHandler) validate(profile *model.NICProfile) {
 	defer func() {
 		_ = tx.End()
 	}()
-	itr, err := tx.Iter(
+	itr, err := tx.Find(
 		&model.VM{},
 		model.ListOptions{
 			Detail: model.MaxDetail,
@@ -606,7 +606,7 @@ func (r *DiskProfileHandler) validate(profile *model.DiskProfile) {
 		_ = tx.End()
 	}()
 	affectedDisks := map[string]bool{}
-	itr, err := tx.Iter(
+	itr, err := tx.Find(
 		&model.Disk{},
 		model.ListOptions{
 			Detail: model.MaxDetail,
@@ -626,7 +626,7 @@ func (r *DiskProfileHandler) validate(profile *model.DiskProfile) {
 			break
 		}
 	}
-	itr, err = tx.Iter(
+	itr, err = tx.Find(
 		&model.VM{},
 		model.ListOptions{
 			Detail: model.MaxDetail,

--- a/pkg/controller/provider/container/vsphere/watch.go
+++ b/pkg/controller/provider/container/vsphere/watch.go
@@ -242,7 +242,7 @@ func (r *VMEventHandler) list() {
 	if r.canceled() {
 		return
 	}
-	itr, err := r.DB.Iter(
+	itr, err := r.DB.Find(
 		&model.VM{},
 		libmodel.ListOptions{
 			Predicate: libmodel.Or(

--- a/pkg/controller/provider/controller.go
+++ b/pkg/controller/provider/controller.go
@@ -239,9 +239,9 @@ func (r Reconciler) Reconcile(request reconcile.Request) (result reconcile.Resul
 //
 // Update the provider.
 func (r *Reconciler) updateProvider(provider *api.Provider) (err error) {
-	rl, found := r.container.Get(provider)
+	collector, found := r.container.Get(provider)
 	if found {
-		*(rl.Owner().(*api.Provider)) = *provider
+		*(collector.Owner().(*api.Provider)) = *provider
 	}
 
 	return
@@ -268,7 +268,7 @@ func (r *Reconciler) updateContainer(provider *api.Provider) (err error) {
 		current.Shutdown()
 		_ = current.DB().Close(true)
 		r.Log.V(2).Info(
-			"Shutdown found (data) reconciler.")
+			"Shutdown found collector.")
 	}
 	db := r.getDB(provider)
 	secret, err := r.getSecret(provider)
@@ -279,13 +279,14 @@ func (r *Reconciler) updateContainer(provider *api.Provider) (err error) {
 	if err != nil {
 		return
 	}
-	err = r.container.Add(container.Build(db, provider, secret))
+	collector := container.Build(db, provider, secret)
+	err = r.container.Add(collector)
 	if err != nil {
 		return
 	}
 
 	r.Log.V(2).Info(
-		"Data reconciler added/started.")
+		"Data collector added/started.")
 
 	return
 }

--- a/pkg/controller/provider/model/ocp/model.go
+++ b/pkg/controller/provider/model/ocp/model.go
@@ -63,7 +63,6 @@ func (m *Base) With(r Resource) {
 
 //
 // Get kubernetes resource version.
-// Needed by the data reconciler.
 func (m *Base) ResourceVersion() uint64 {
 	n, _ := strconv.ParseUint(m.Version, 10, 64)
 	return n

--- a/pkg/controller/provider/model/vsphere/model.go
+++ b/pkg/controller/provider/model/vsphere/model.go
@@ -76,20 +76,6 @@ func (m *Base) WithRef(ref Ref) {
 	m.ID = ref.ID
 }
 
-//
-// Created.
-func (m *Base) Created() {
-	m.Revision = 1
-}
-
-//
-// Updated.
-// Increment revision. Should ONLY be called by
-// the reconciler.
-func (m *Base) Updated() {
-	m.Revision++
-}
-
 // Determine object path.
 func (m *Base) Path(db libmodel.DB) (path string, err error) {
 	parts := []string{m.Name}

--- a/pkg/controller/provider/web/base/handler.go
+++ b/pkg/controller/provider/web/base/handler.go
@@ -55,8 +55,8 @@ type Handler struct {
 	Container *libcontainer.Container
 	// Provider referenced in the request.
 	Provider *api.Provider
-	// Reconciler responsible for the provider.
-	Reconciler libcontainer.Reconciler
+	// Collector responsible for the provider.
+	Collector libcontainer.Collector
 	// Resources include details.
 	Detail bool
 }
@@ -106,13 +106,13 @@ func (h *Handler) setProvider(ctx *gin.Context) (status int) {
 		},
 	}
 	if h.Provider.UID != "" {
-		if h.Reconciler, found = h.Container.Get(h.Provider); !found {
+		if h.Collector, found = h.Container.Get(h.Provider); !found {
 			status = http.StatusNotFound
 			return
 		}
 		ctx.Header(ProviderHeader, uid)
-		h.Provider = h.Reconciler.Owner().(*api.Provider)
-		status = h.EnsureParity(h.Reconciler, time.Second*30)
+		h.Provider = h.Collector.Owner().(*api.Provider)
+		status = h.EnsureParity(h.Collector, time.Second*30)
 	} else {
 		status = http.StatusOK
 	}

--- a/pkg/controller/provider/web/ocp/namespace.go
+++ b/pkg/controller/provider/web/ocp/namespace.go
@@ -47,7 +47,7 @@ func (h NamespaceHandler) List(ctx *gin.Context) {
 		h.watch(ctx)
 		return
 	}
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	list := []model.Namespace{}
 	err := db.List(&list, h.ListOptions(ctx))
 	if err != nil {
@@ -82,7 +82,7 @@ func (h NamespaceHandler) Get(ctx *gin.Context) {
 			UID: ctx.Param(NsParam),
 		},
 	}
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	err := db.Get(m)
 	if errors.Is(err, model.NotFound) {
 		ctx.Status(http.StatusNotFound)
@@ -107,7 +107,7 @@ func (h NamespaceHandler) Get(ctx *gin.Context) {
 //
 // Watch.
 func (h NamespaceHandler) watch(ctx *gin.Context) {
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	err := h.Watch(
 		ctx,
 		db,

--- a/pkg/controller/provider/web/ocp/netattachdefinition.go
+++ b/pkg/controller/provider/web/ocp/netattachdefinition.go
@@ -48,7 +48,7 @@ func (h NadHandler) List(ctx *gin.Context) {
 		h.watch(ctx)
 		return
 	}
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	list := []model.NetworkAttachmentDefinition{}
 	err := db.List(&list, h.ListOptions(ctx))
 	if err != nil {
@@ -83,7 +83,7 @@ func (h NadHandler) Get(ctx *gin.Context) {
 			UID: ctx.Param(NadParam),
 		},
 	}
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	err := db.Get(m)
 	if errors.Is(err, model.NotFound) {
 		ctx.Status(http.StatusNotFound)
@@ -108,7 +108,7 @@ func (h NadHandler) Get(ctx *gin.Context) {
 //
 // Watch.
 func (h NadHandler) watch(ctx *gin.Context) {
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	err := h.Watch(
 		ctx,
 		db,

--- a/pkg/controller/provider/web/ocp/provider.go
+++ b/pkg/controller/provider/web/ocp/provider.go
@@ -90,16 +90,16 @@ func (h *ProviderHandler) ListContent(ctx *gin.Context) (content []interface{}, 
 	content = []interface{}{}
 	list := h.Container.List()
 	ns := ctx.Param(base.NsParam)
-	for _, reconciler := range list {
-		if p, cast := reconciler.Owner().(*api.Provider); cast {
+	for _, collector := range list {
+		if p, cast := collector.Owner().(*api.Provider); cast {
 			if p.Type() != api.OpenShift {
 				continue
 			}
 			if ns != "" && ns != p.Namespace {
 				continue
 			}
-			if reconciler, found := h.Container.Get(p); found {
-				h.Reconciler = reconciler
+			if collector, found := h.Container.Get(p); found {
+				h.Collector = collector
 			} else {
 				continue
 			}
@@ -128,7 +128,7 @@ func (h ProviderHandler) AddCount(r *Provider) (err error) {
 	if !h.Detail {
 		return nil
 	}
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	// VM
 	n, err := db.Count(&model.VM{}, nil)
 	if err != nil {

--- a/pkg/controller/provider/web/ocp/storageclass.go
+++ b/pkg/controller/provider/web/ocp/storageclass.go
@@ -48,7 +48,7 @@ func (h StorageClassHandler) List(ctx *gin.Context) {
 		h.watch(ctx)
 		return
 	}
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	list := []model.StorageClass{}
 	err := db.List(&list, h.ListOptions(ctx))
 	if err != nil {
@@ -83,7 +83,7 @@ func (h StorageClassHandler) Get(ctx *gin.Context) {
 			UID: ctx.Param(StorageClassParam),
 		},
 	}
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	err := db.Get(m)
 	if errors.Is(err, model.NotFound) {
 		ctx.Status(http.StatusNotFound)
@@ -108,7 +108,7 @@ func (h StorageClassHandler) Get(ctx *gin.Context) {
 //
 // Watch.
 func (h StorageClassHandler) watch(ctx *gin.Context) {
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	err := h.Watch(
 		ctx,
 		db,

--- a/pkg/controller/provider/web/ocp/vm.go
+++ b/pkg/controller/provider/web/ocp/vm.go
@@ -48,7 +48,7 @@ func (h VMHandler) List(ctx *gin.Context) {
 		h.watch(ctx)
 		return
 	}
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	list := []model.VM{}
 	err := db.List(&list, h.ListOptions(ctx))
 	if err != nil {
@@ -83,7 +83,7 @@ func (h VMHandler) Get(ctx *gin.Context) {
 			UID: ctx.Param(VmParam),
 		},
 	}
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	err := db.Get(m)
 	if errors.Is(err, model.NotFound) {
 		ctx.Status(http.StatusNotFound)
@@ -108,7 +108,7 @@ func (h VMHandler) Get(ctx *gin.Context) {
 //
 // Watch.
 func (h VMHandler) watch(ctx *gin.Context) {
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	err := h.Watch(
 		ctx,
 		db,

--- a/pkg/controller/provider/web/ovirt/cluster.go
+++ b/pkg/controller/provider/web/ovirt/cluster.go
@@ -50,7 +50,7 @@ func (h ClusterHandler) List(ctx *gin.Context) {
 		h.watch(ctx)
 		return
 	}
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	list := []model.Cluster{}
 	err := db.List(&list, h.ListOptions(ctx))
 	if err != nil {
@@ -85,7 +85,7 @@ func (h ClusterHandler) Get(ctx *gin.Context) {
 			ID: ctx.Param(ClusterParam),
 		},
 	}
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	err := db.Get(m)
 	if errors.Is(err, model.NotFound) {
 		ctx.Status(http.StatusNotFound)
@@ -110,7 +110,7 @@ func (h ClusterHandler) Get(ctx *gin.Context) {
 //
 // Watch.
 func (h ClusterHandler) watch(ctx *gin.Context) {
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	err := h.Watch(
 		ctx,
 		db,

--- a/pkg/controller/provider/web/ovirt/datacenter.go
+++ b/pkg/controller/provider/web/ovirt/datacenter.go
@@ -50,7 +50,7 @@ func (h DataCenterHandler) List(ctx *gin.Context) {
 		h.watch(ctx)
 		return
 	}
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	list := []model.DataCenter{}
 	err := db.List(&list, h.ListOptions(ctx))
 	if err != nil {
@@ -85,7 +85,7 @@ func (h DataCenterHandler) Get(ctx *gin.Context) {
 			ID: ctx.Param(DataCenterParam),
 		},
 	}
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	err := db.Get(m)
 	if errors.Is(err, model.NotFound) {
 		ctx.Status(http.StatusNotFound)
@@ -110,7 +110,7 @@ func (h DataCenterHandler) Get(ctx *gin.Context) {
 //
 // Watch.
 func (h DataCenterHandler) watch(ctx *gin.Context) {
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	err := h.Watch(
 		ctx,
 		db,

--- a/pkg/controller/provider/web/ovirt/disk.go
+++ b/pkg/controller/provider/web/ovirt/disk.go
@@ -48,7 +48,7 @@ func (h DiskHandler) List(ctx *gin.Context) {
 		h.watch(ctx)
 		return
 	}
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	list := []model.Disk{}
 	err := db.List(&list, h.ListOptions(ctx))
 	if err != nil {
@@ -63,7 +63,7 @@ func (h DiskHandler) List(ctx *gin.Context) {
 	for _, m := range list {
 		r := &Disk{}
 		r.With(&m)
-		err = r.Expand(h.Reconciler.DB())
+		err = r.Expand(h.Collector.DB())
 		if err != nil {
 			log.Trace(
 				err,
@@ -93,7 +93,7 @@ func (h DiskHandler) Get(ctx *gin.Context) {
 			ID: ctx.Param(DiskParam),
 		},
 	}
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	err := db.Get(m)
 	if errors.Is(err, model.NotFound) {
 		ctx.Status(http.StatusNotFound)
@@ -109,7 +109,7 @@ func (h DiskHandler) Get(ctx *gin.Context) {
 	}
 	r := &Disk{}
 	r.With(m)
-	err = r.Expand(h.Reconciler.DB())
+	err = r.Expand(h.Collector.DB())
 	if err != nil {
 		log.Trace(
 			err,
@@ -130,14 +130,14 @@ func (h *DiskHandler) Expand(r *Disk) (err error) {
 	if !h.Detail {
 		return
 	}
-	err = r.Expand(h.Reconciler.DB())
+	err = r.Expand(h.Collector.DB())
 	return
 }
 
 //
 // Watch.
 func (h DiskHandler) watch(ctx *gin.Context) {
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	err := h.Watch(
 		ctx,
 		db,

--- a/pkg/controller/provider/web/ovirt/diskprofile.go
+++ b/pkg/controller/provider/web/ovirt/diskprofile.go
@@ -48,7 +48,7 @@ func (h DiskProfileHandler) List(ctx *gin.Context) {
 		h.watch(ctx)
 		return
 	}
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	list := []model.DiskProfile{}
 	err := db.List(&list, h.ListOptions(ctx))
 	if err != nil {
@@ -83,7 +83,7 @@ func (h DiskProfileHandler) Get(ctx *gin.Context) {
 			ID: ctx.Param(DiskProfileParam),
 		},
 	}
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	err := db.Get(m)
 	if errors.Is(err, model.NotFound) {
 		ctx.Status(http.StatusNotFound)
@@ -108,7 +108,7 @@ func (h DiskProfileHandler) Get(ctx *gin.Context) {
 //
 // Watch.
 func (h DiskProfileHandler) watch(ctx *gin.Context) {
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	err := h.Watch(
 		ctx,
 		db,

--- a/pkg/controller/provider/web/ovirt/host.go
+++ b/pkg/controller/provider/web/ovirt/host.go
@@ -48,7 +48,7 @@ func (h HostHandler) List(ctx *gin.Context) {
 		h.watch(ctx)
 		return
 	}
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	list := []model.Host{}
 	err := db.List(&list, h.ListOptions(ctx))
 	if err != nil {
@@ -84,7 +84,7 @@ func (h HostHandler) Get(ctx *gin.Context) {
 			ID: ctx.Param(HostParam),
 		},
 	}
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	err := db.Get(m)
 	if errors.Is(err, model.NotFound) {
 		ctx.Status(http.StatusNotFound)
@@ -109,7 +109,7 @@ func (h HostHandler) Get(ctx *gin.Context) {
 //
 // Watch.
 func (h HostHandler) watch(ctx *gin.Context) {
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	err := h.Watch(
 		ctx,
 		db,

--- a/pkg/controller/provider/web/ovirt/network.go
+++ b/pkg/controller/provider/web/ovirt/network.go
@@ -48,7 +48,7 @@ func (h NetworkHandler) List(ctx *gin.Context) {
 		h.watch(ctx)
 		return
 	}
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	list := []model.Network{}
 	err := db.List(&list, h.ListOptions(ctx))
 	if err != nil {
@@ -83,7 +83,7 @@ func (h NetworkHandler) Get(ctx *gin.Context) {
 			ID: ctx.Param(NetworkParam),
 		},
 	}
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	err := db.Get(m)
 	if errors.Is(err, model.NotFound) {
 		ctx.Status(http.StatusNotFound)
@@ -108,7 +108,7 @@ func (h NetworkHandler) Get(ctx *gin.Context) {
 //
 // Watch.
 func (h NetworkHandler) watch(ctx *gin.Context) {
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	err := h.Watch(
 		ctx,
 		db,

--- a/pkg/controller/provider/web/ovirt/nicprofile.go
+++ b/pkg/controller/provider/web/ovirt/nicprofile.go
@@ -48,7 +48,7 @@ func (h NICProfileHandler) List(ctx *gin.Context) {
 		h.watch(ctx)
 		return
 	}
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	list := []model.NICProfile{}
 	err := db.List(&list, h.ListOptions(ctx))
 	if err != nil {
@@ -83,7 +83,7 @@ func (h NICProfileHandler) Get(ctx *gin.Context) {
 			ID: ctx.Param(NICProfileParam),
 		},
 	}
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	err := db.Get(m)
 	if errors.Is(err, model.NotFound) {
 		ctx.Status(http.StatusNotFound)
@@ -108,7 +108,7 @@ func (h NICProfileHandler) Get(ctx *gin.Context) {
 //
 // Watch.
 func (h NICProfileHandler) watch(ctx *gin.Context) {
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	err := h.Watch(
 		ctx,
 		db,

--- a/pkg/controller/provider/web/ovirt/provider.go
+++ b/pkg/controller/provider/web/ovirt/provider.go
@@ -95,16 +95,16 @@ func (h *ProviderHandler) ListContent(ctx *gin.Context) (content []interface{}, 
 	content = []interface{}{}
 	list := h.Container.List()
 	ns := ctx.Param(base.NsParam)
-	for _, reconciler := range list {
-		if p, cast := reconciler.Owner().(*api.Provider); cast {
+	for _, collector := range list {
+		if p, cast := collector.Owner().(*api.Provider); cast {
 			if p.Type() != api.OVirt {
 				continue
 			}
 			if ns != "" && ns != p.Namespace {
 				continue
 			}
-			if reconciler, found := h.Container.Get(p); found {
-				h.Reconciler = reconciler
+			if collector, found := h.Container.Get(p); found {
+				h.Collector = collector
 			} else {
 				continue
 			}
@@ -134,7 +134,7 @@ func (h ProviderHandler) AddDerived(r *Provider) (err error) {
 	if !h.Detail {
 		return
 	}
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	// DataCenter
 	n, err = db.Count(&ovirt.DataCenter{}, nil)
 	if err != nil {

--- a/pkg/controller/provider/web/ovirt/storage.go
+++ b/pkg/controller/provider/web/ovirt/storage.go
@@ -48,7 +48,7 @@ func (h StorageDomainHandler) List(ctx *gin.Context) {
 		h.watch(ctx)
 		return
 	}
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	list := []model.StorageDomain{}
 	err := db.List(&list, h.ListOptions(ctx))
 	if err != nil {
@@ -83,7 +83,7 @@ func (h StorageDomainHandler) Get(ctx *gin.Context) {
 			ID: ctx.Param(StorageDomainParam),
 		},
 	}
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	err := db.Get(m)
 	if errors.Is(err, model.NotFound) {
 		ctx.Status(http.StatusNotFound)
@@ -108,7 +108,7 @@ func (h StorageDomainHandler) Get(ctx *gin.Context) {
 //
 // Watch.
 func (h StorageDomainHandler) watch(ctx *gin.Context) {
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	err := h.Watch(
 		ctx,
 		db,

--- a/pkg/controller/provider/web/ovirt/tree.go
+++ b/pkg/controller/provider/web/ovirt/tree.go
@@ -43,7 +43,7 @@ func (h *TreeHandler) Prepare(ctx *gin.Context) int {
 		ctx.Status(status)
 		return status
 	}
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	err := db.List(
 		&h.datacenters,
 		model.ListOptions{
@@ -84,7 +84,7 @@ func (h TreeHandler) Tree(ctx *gin.Context) {
 		ctx.Status(http.StatusBadRequest)
 		return
 	}
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	content := TreeNode{}
 	for _, dc := range h.datacenters {
 		tr := Tree{

--- a/pkg/controller/provider/web/ovirt/vm.go
+++ b/pkg/controller/provider/web/ovirt/vm.go
@@ -48,7 +48,7 @@ func (h VMHandler) List(ctx *gin.Context) {
 		h.watch(ctx)
 		return
 	}
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	list := []model.VM{}
 	err := db.List(&list, h.ListOptions(ctx))
 	if err != nil {
@@ -93,7 +93,7 @@ func (h VMHandler) Get(ctx *gin.Context) {
 		},
 	}
 	h.Detail = true
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	err := db.Get(m)
 	if errors.Is(err, model.NotFound) {
 		ctx.Status(http.StatusNotFound)
@@ -130,14 +130,14 @@ func (h *VMHandler) Expand(r *VM) (err error) {
 	if !h.Detail {
 		return
 	}
-	err = r.Expand(h.Reconciler.DB())
+	err = r.Expand(h.Collector.DB())
 	return
 }
 
 //
 // Watch.
 func (h VMHandler) watch(ctx *gin.Context) {
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	err := h.Watch(
 		ctx,
 		db,

--- a/pkg/controller/provider/web/ovirt/workload.go
+++ b/pkg/controller/provider/web/ovirt/workload.go
@@ -48,7 +48,7 @@ func (h WorkloadHandler) Get(ctx *gin.Context) {
 			ID: ctx.Param(VMParam),
 		},
 	}
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	err := db.Get(m)
 	if errors.Is(err, model.NotFound) {
 		ctx.Status(http.StatusNotFound)
@@ -65,7 +65,7 @@ func (h WorkloadHandler) Get(ctx *gin.Context) {
 	h.Detail = true
 	r := Workload{}
 	r.With(m)
-	err = r.Expand(h.Reconciler.DB())
+	err = r.Expand(h.Collector.DB())
 	if err != nil {
 		log.Trace(
 			err,

--- a/pkg/controller/provider/web/vsphere/cluster.go
+++ b/pkg/controller/provider/web/vsphere/cluster.go
@@ -50,7 +50,7 @@ func (h ClusterHandler) List(ctx *gin.Context) {
 		h.watch(ctx)
 		return
 	}
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	list := []model.Cluster{}
 	err := db.List(&list, h.ListOptions(ctx))
 	if err != nil {
@@ -85,7 +85,7 @@ func (h ClusterHandler) Get(ctx *gin.Context) {
 			ID: ctx.Param(ClusterParam),
 		},
 	}
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	err := db.Get(m)
 	if errors.Is(err, model.NotFound) {
 		ctx.Status(http.StatusNotFound)
@@ -118,7 +118,7 @@ func (h ClusterHandler) Get(ctx *gin.Context) {
 //
 // Watch.
 func (h ClusterHandler) watch(ctx *gin.Context) {
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	err := h.Watch(
 		ctx,
 		db,

--- a/pkg/controller/provider/web/vsphere/datacenter.go
+++ b/pkg/controller/provider/web/vsphere/datacenter.go
@@ -50,7 +50,7 @@ func (h DatacenterHandler) List(ctx *gin.Context) {
 		h.watch(ctx)
 		return
 	}
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	list := []model.Datacenter{}
 	err := db.List(&list, h.ListOptions(ctx))
 	if err != nil {
@@ -85,7 +85,7 @@ func (h DatacenterHandler) Get(ctx *gin.Context) {
 			ID: ctx.Param(DatacenterParam),
 		},
 	}
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	err := db.Get(m)
 	if errors.Is(err, model.NotFound) {
 		ctx.Status(http.StatusNotFound)
@@ -119,7 +119,7 @@ func (h DatacenterHandler) Get(ctx *gin.Context) {
 //
 // Watch.
 func (h DatacenterHandler) watch(ctx *gin.Context) {
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	err := h.Watch(
 		ctx,
 		db,

--- a/pkg/controller/provider/web/vsphere/datastore.go
+++ b/pkg/controller/provider/web/vsphere/datastore.go
@@ -49,7 +49,7 @@ func (h DatastoreHandler) List(ctx *gin.Context) {
 		h.watch(ctx)
 		return
 	}
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	list := []model.Datastore{}
 	err := db.List(&list, h.ListOptions(ctx))
 	if err != nil {
@@ -93,7 +93,7 @@ func (h DatastoreHandler) Get(ctx *gin.Context) {
 			ID: ctx.Param(DatastoreParam),
 		},
 	}
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	err := db.Get(m)
 	if errors.Is(err, model.NotFound) {
 		ctx.Status(http.StatusNotFound)
@@ -127,7 +127,7 @@ func (h DatastoreHandler) Get(ctx *gin.Context) {
 //
 // Watch.
 func (h DatastoreHandler) watch(ctx *gin.Context) {
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	err := h.Watch(
 		ctx,
 		db,
@@ -165,7 +165,7 @@ func (h DatastoreHandler) filter(ctx *gin.Context, list *[]model.Datastore) (err
 	if len(strings.Split(name, "/")) < 2 {
 		return
 	}
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	kept := []model.Datastore{}
 	for _, m := range *list {
 		path, pErr := m.Path(db)

--- a/pkg/controller/provider/web/vsphere/folder.go
+++ b/pkg/controller/provider/web/vsphere/folder.go
@@ -50,7 +50,7 @@ func (h FolderHandler) List(ctx *gin.Context) {
 		h.watch(ctx)
 		return
 	}
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	list := []model.Folder{}
 	err := db.List(&list, h.ListOptions(ctx))
 	if err != nil {
@@ -85,7 +85,7 @@ func (h FolderHandler) Get(ctx *gin.Context) {
 			ID: ctx.Param(FolderParam),
 		},
 	}
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	err := db.Get(m)
 	if errors.Is(err, model.NotFound) {
 		ctx.Status(http.StatusNotFound)
@@ -119,7 +119,7 @@ func (h FolderHandler) Get(ctx *gin.Context) {
 //
 // Watch.
 func (h FolderHandler) watch(ctx *gin.Context) {
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	err := h.Watch(
 		ctx,
 		db,

--- a/pkg/controller/provider/web/vsphere/host.go
+++ b/pkg/controller/provider/web/vsphere/host.go
@@ -50,7 +50,7 @@ func (h HostHandler) List(ctx *gin.Context) {
 		h.watch(ctx)
 		return
 	}
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	list := []model.Host{}
 	err := db.List(&list, h.ListOptions(ctx))
 	if err != nil {
@@ -104,7 +104,7 @@ func (h HostHandler) Get(ctx *gin.Context) {
 			ID: ctx.Param(HostParam),
 		},
 	}
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	err := db.Get(m)
 	if errors.Is(err, model.NotFound) {
 		ctx.Status(http.StatusNotFound)
@@ -147,7 +147,7 @@ func (h HostHandler) Get(ctx *gin.Context) {
 //
 // Watch.
 func (h HostHandler) watch(ctx *gin.Context) {
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	err := h.Watch(
 		ctx,
 		db,
@@ -185,7 +185,7 @@ func (h HostHandler) filter(ctx *gin.Context, list *[]model.Host) (err error) {
 	if len(strings.Split(name, "/")) < 2 {
 		return
 	}
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	kept := []model.Host{}
 	for _, m := range *list {
 		path, pErr := m.Path(db)
@@ -210,7 +210,7 @@ func (h *HostHandler) buildAdapters(host *Host) (err error) {
 		return
 	}
 	builder := AdapterBuilder{
-		db: h.Reconciler.DB(),
+		db: h.Collector.DB(),
 	}
 
 	err = builder.build(host)

--- a/pkg/controller/provider/web/vsphere/network.go
+++ b/pkg/controller/provider/web/vsphere/network.go
@@ -49,7 +49,7 @@ func (h NetworkHandler) List(ctx *gin.Context) {
 		h.watch(ctx)
 		return
 	}
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	list := []model.Network{}
 	err := db.List(&list, h.ListOptions(ctx))
 	if err != nil {
@@ -93,7 +93,7 @@ func (h NetworkHandler) Get(ctx *gin.Context) {
 			ID: ctx.Param(NetworkParam),
 		},
 	}
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	err := db.Get(m)
 	if errors.Is(err, model.NotFound) {
 		ctx.Status(http.StatusNotFound)
@@ -127,7 +127,7 @@ func (h NetworkHandler) Get(ctx *gin.Context) {
 //
 // Watch.
 func (h NetworkHandler) watch(ctx *gin.Context) {
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	err := h.Watch(
 		ctx,
 		db,
@@ -165,7 +165,7 @@ func (h NetworkHandler) filter(ctx *gin.Context, list *[]model.Network) (err err
 	if len(strings.Split(name, "/")) < 2 {
 		return
 	}
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	kept := []model.Network{}
 	for _, m := range *list {
 		path, pErr := m.Path(db)

--- a/pkg/controller/provider/web/vsphere/provider.go
+++ b/pkg/controller/provider/web/vsphere/provider.go
@@ -95,16 +95,16 @@ func (h *ProviderHandler) ListContent(ctx *gin.Context) (content []interface{}, 
 	content = []interface{}{}
 	list := h.Container.List()
 	ns := ctx.Param(base.NsParam)
-	for _, reconciler := range list {
-		if p, cast := reconciler.Owner().(*api.Provider); cast {
+	for _, collector := range list {
+		if p, cast := collector.Owner().(*api.Provider); cast {
 			if p.Type() != api.VSphere {
 				continue
 			}
 			if ns != "" && ns != p.Namespace {
 				continue
 			}
-			if reconciler, found := h.Container.Get(p); found {
-				h.Reconciler = reconciler
+			if collector, found := h.Container.Get(p); found {
+				h.Collector = collector
 			} else {
 				continue
 			}
@@ -134,7 +134,7 @@ func (h ProviderHandler) AddDerived(r *Provider) (err error) {
 	if !h.Detail {
 		return
 	}
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	// About
 	about := &vsphere.About{}
 	err = db.Get(about)

--- a/pkg/controller/provider/web/vsphere/tree.go
+++ b/pkg/controller/provider/web/vsphere/tree.go
@@ -46,7 +46,7 @@ func (h *TreeHandler) Prepare(ctx *gin.Context) int {
 		ctx.Status(status)
 		return status
 	}
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	err := db.List(
 		&h.datacenters,
 		model.ListOptions{
@@ -87,7 +87,7 @@ func (h TreeHandler) VmTree(ctx *gin.Context) {
 		ctx.Status(http.StatusBadRequest)
 		return
 	}
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	content := TreeNode{}
 	for _, dc := range h.datacenters {
 		ref := dc.Vms
@@ -150,7 +150,7 @@ func (h TreeHandler) HostTree(ctx *gin.Context) {
 		ctx.Status(http.StatusBadRequest)
 		return
 	}
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	content := TreeNode{}
 	for _, dc := range h.datacenters {
 		ref := dc.Clusters

--- a/pkg/controller/provider/web/vsphere/vm.go
+++ b/pkg/controller/provider/web/vsphere/vm.go
@@ -50,7 +50,7 @@ func (h VMHandler) List(ctx *gin.Context) {
 		h.watch(ctx)
 		return
 	}
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	list := []model.VM{}
 	err := db.List(&list, h.ListOptions(ctx))
 	if err != nil {
@@ -94,7 +94,7 @@ func (h VMHandler) Get(ctx *gin.Context) {
 			ID: ctx.Param(VMParam),
 		},
 	}
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	err := db.Get(m)
 	if errors.Is(err, model.NotFound) {
 		ctx.Status(http.StatusNotFound)
@@ -128,7 +128,7 @@ func (h VMHandler) Get(ctx *gin.Context) {
 //
 // Watch.
 func (h VMHandler) watch(ctx *gin.Context) {
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	err := h.Watch(
 		ctx,
 		db,
@@ -166,7 +166,7 @@ func (h VMHandler) filter(ctx *gin.Context, list *[]model.VM) (err error) {
 	if len(strings.Split(name, "/")) < 2 {
 		return
 	}
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	kept := []model.VM{}
 	for _, m := range *list {
 		path, pErr := m.Path(db)

--- a/pkg/controller/provider/web/vsphere/workload.go
+++ b/pkg/controller/provider/web/vsphere/workload.go
@@ -48,7 +48,7 @@ func (h WorkloadHandler) Get(ctx *gin.Context) {
 			ID: ctx.Param(VMParam),
 		},
 	}
-	db := h.Reconciler.DB()
+	db := h.Collector.DB()
 	err := db.Get(m)
 	if errors.Is(err, model.NotFound) {
 		ctx.Status(http.StatusNotFound)


### PR DESCRIPTION
General controller v0.6.0 API compatability.
- (data) `Reconciler` renamed: `Collector`.  The term _reconciler_ just too overloaded in openshift.
- DB.Iter() renamed: DB.Find().

Fixes [1985558](https://bugzilla.redhat.com/show_bug.cgi?id=1985558) issue with inventory watch events used to trigger VM (re)validation.