### PR TITLE
Fix processing RHV events for removal.

### DIFF
--- a/pkg/controller/provider/container/ovirt/model.go
+++ b/pkg/controller/provider/container/ovirt/model.go
@@ -247,8 +247,8 @@ func (r *DataCenterAdapter) Apply(ctx *Context, event *Event) (updater Updater, 
 	case USER_REMOVE_STORAGE_POOL:
 		updater = func(tx *libmodel.Tx) (err error) {
 			err = tx.Delete(
-				&model.Cluster{
-					Base: model.Base{ID: event.DataCenter.Ref},
+				&model.DataCenter{
+					Base: model.Base{ID: event.DataCenter.ID},
 				})
 			return
 		}
@@ -613,7 +613,7 @@ func (r *ClusterAdapter) Apply(ctx *Context, event *Event) (updater Updater, err
 		updater = func(tx *libmodel.Tx) (err error) {
 			err = tx.Delete(
 				&model.Cluster{
-					Base: model.Base{ID: event.Cluster.Ref},
+					Base: model.Base{ID: event.Cluster.ID},
 				})
 			return
 		}
@@ -702,7 +702,7 @@ func (r *HostAdapter) Apply(ctx *Context, event *Event) (updater Updater, err er
 		updater = func(tx *libmodel.Tx) (err error) {
 			err = tx.Delete(
 				&model.Host{
-					Base: model.Base{ID: event.Host.Ref},
+					Base: model.Base{ID: event.Host.ID},
 				})
 			return
 		}
@@ -861,7 +861,7 @@ func (r *VMAdapter) Apply(ctx *Context, event *Event) (updater Updater, err erro
 		updater = func(tx *libmodel.Tx) (err error) {
 			err = tx.Delete(
 				&model.VM{
-					Base: model.Base{ID: event.VM.Ref},
+					Base: model.Base{ID: event.VM.ID},
 				})
 			return
 		}

--- a/pkg/controller/provider/container/ovirt/watch.go
+++ b/pkg/controller/provider/container/ovirt/watch.go
@@ -330,7 +330,7 @@ func (r *VMEventHandler) validated(batch []*policy.Task) {
 	}()
 	for _, task := range batch {
 		if task.Error != nil {
-			r.log.Info(task.Error.Error())
+			r.log.Error(err, task.Error.Error())
 			continue
 		}
 		latest := &model.VM{Base: model.Base{ID: task.Ref.ID}}

--- a/pkg/controller/provider/container/vsphere/watch.go
+++ b/pkg/controller/provider/container/vsphere/watch.go
@@ -330,7 +330,7 @@ func (r *VMEventHandler) validated(batch []*policy.Task) {
 	}()
 	for _, task := range batch {
 		if task.Error != nil {
-			r.log.Info(task.Error.Error())
+			r.log.Error(err, task.Error.Error())
 			continue
 		}
 		latest := &model.VM{Base: model.Base{ID: task.Ref.ID}}


### PR DESCRIPTION
Fix processing RHV events for removal of (dataCenter, cluster, host & VM)
Event handler using `Ref` but should be using `ID` which results  in _model.NotFound_ error and leaving the object in the inventory.  This is especially bad for VMs because it results in 500 errors trying to expand them in the web API.

Also, log validation task error as log.Error() to include more context.

https://bugzilla.redhat.com/show_bug.cgi?id=1986106