### PR TITLE
Fix post hook not running.

### DIFF
--- a/pkg/apis/forklift/v1beta1/plan/vm.go
+++ b/pkg/apis/forklift/v1beta1/plan/vm.go
@@ -82,10 +82,10 @@ type Precopy struct {
 }
 
 //
-// Find the `Active` step.
-func (r *VMStatus) ActiveStep() (step *Step, found bool) {
+// Find a step by name.
+func (r *VMStatus) FindStep(name string) (step *Step, found bool) {
 	for _, s := range r.Pipeline {
-		if s.Name == r.Phase {
+		if s.Name == name {
 			found = true
 			step = s
 			break

--- a/pkg/controller/plan/hook.go
+++ b/pkg/controller/plan/hook.go
@@ -36,7 +36,7 @@ type HookRunner struct {
 // Run.
 func (r *HookRunner) Run(vm *planapi.VMStatus) (err error) {
 	r.vm = vm
-	step, found := vm.ActiveStep()
+	step, found := vm.FindStep(vm.Phase)
 	if !found {
 		err = liberr.New("Step not found.")
 		return

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -235,6 +235,16 @@ func (r *Migration) step(vm *plan.VMStatus) (err error) {
 				vm.Phase))
 	}
 	vm.ReflectPipeline()
+	if vm.Phase == Completed && vm.Error == nil {
+		vm.SetCondition(
+			libcnd.Condition{
+				Type:     Succeeded,
+				Status:   True,
+				Category: Advisory,
+				Message:  "The VM migration has SUCCEEDED.",
+				Durable:  true,
+			})
+	}
 	if vm.Error != nil {
 		vm.Phase = Completed
 		vm.SetCondition(

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -244,8 +244,7 @@ func (r *Migration) step(vm *plan.VMStatus) (err error) {
 				Message:  "The VM migration has SUCCEEDED.",
 				Durable:  true,
 			})
-	}
-	if vm.Error != nil {
+	} else if vm.Error != nil {
 		vm.Phase = Completed
 		vm.SetCondition(
 			libcnd.Condition{

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -171,7 +171,7 @@ func (r *Migration) step(vm *plan.VMStatus) (err error) {
 		if err != nil {
 			return
 		}
-		if step, found := vm.ActiveStep(); found {
+		if step, found := vm.FindStep(vm.Phase); found {
 			if step.MarkedCompleted() && step.Error == nil {
 				vm.Phase = r.next(vm.Phase)
 			}
@@ -203,16 +203,18 @@ func (r *Migration) step(vm *plan.VMStatus) (err error) {
 				return
 			}
 		}
-		completed, failed, rErr := r.updateVM(vm)
+		rErr := r.updateVM(vm)
 		if rErr != nil {
 			err = liberr.Wrap(rErr)
 			return
 		}
-		if completed {
-			if !failed {
-				vm.Phase = r.next(vm.Phase)
-			} else {
-				vm.Phase = Completed
+		if step, found := vm.FindStep(ImageConversion); found {
+			if step.MarkedCompleted() {
+				if step.Error == nil {
+					vm.Phase = r.next(vm.Phase)
+				} else {
+					vm.Phase = Completed
+				}
 			}
 		}
 	case Completed:
@@ -569,7 +571,7 @@ func (r *Migration) end() (completed bool, err error) {
 
 //
 // Update VM migration status.
-func (r *Migration) updateVM(vm *plan.VMStatus) (completed bool, failed bool, err error) {
+func (r *Migration) updateVM(vm *plan.VMStatus) (err error) {
 	if r.importMap == nil {
 		r.importMap, err = r.kubevirt.ImportMap()
 		if err != nil {
@@ -585,47 +587,6 @@ func (r *Migration) updateVM(vm *plan.VMStatus) (completed bool, failed bool, er
 		return
 	}
 	r.updatePipeline(vm, &imp)
-	conditions := imp.Conditions()
-	cnd := conditions.FindCondition(Succeeded)
-	if cnd != nil {
-		vm.MarkCompleted()
-		completed = true
-		if cnd.Status != True {
-			vm.AddError(cnd.Message)
-			failed = true
-		} else {
-			vm.SetCondition(
-				libcnd.Condition{
-					Type:     Succeeded,
-					Status:   True,
-					Category: Advisory,
-					Message:  "The VM migration has SUCCEEDED.",
-					Durable:  true,
-				})
-		}
-	} else {
-		cnd = conditions.FindCondition(string(vmio.Processing))
-		if cnd != nil && cnd.Reason == string(vmio.CopyingPaused) {
-			vm.SetCondition(
-				libcnd.Condition{
-					Type:     Paused,
-					Status:   True,
-					Category: Advisory,
-					Message:  "The VM migration is PAUSED.",
-					Durable:  false,
-				})
-		} else if cnd != nil && cnd.Reason == string(vmio.Pending) {
-			vm.SetCondition(
-				libcnd.Condition{
-					Type:     Pending,
-					Status:   True,
-					Category: Advisory,
-					Message:  "The VM migration is PENDING.",
-					Durable:  false,
-				})
-		}
-	}
-
 	if imp.Spec.Warm {
 		updateWarmStatus(vm, imp)
 	}
@@ -720,8 +681,27 @@ func (r *Migration) updatePipeline(vm *plan.VMStatus, imp *VmImport) {
 			conditions := imp.Conditions()
 			cnd := conditions.FindCondition("Processing")
 			if cnd != nil {
-				if cnd.Status == True && cnd.Reason == "ConvertingGuest" {
-					step.MarkStarted()
+				switch cnd.Reason {
+				case string(vmio.Pending):
+					vm.SetCondition(
+						libcnd.Condition{
+							Type:     Pending,
+							Status:   True,
+							Category: Advisory,
+							Message:  "The VM migration is PENDING.",
+						})
+				case string(vmio.CopyingPaused):
+					vm.SetCondition(
+						libcnd.Condition{
+							Type:     Paused,
+							Status:   True,
+							Category: Advisory,
+							Message:  "The VM migration is PAUSED.",
+						})
+				case string(vmio.ConvertingGuest):
+					if cnd.Status == True {
+						step.MarkStarted()
+					}
 				}
 				if step.MarkedStarted() {
 					step.Phase = cnd.Reason


### PR DESCRIPTION
The division of role/responsibility got blurred a little between:`Migration.updateVM()` and `Migration.updatePipeline()`.
In the process, updateVM() made an assumption that when the VMIO import completed, the VM status should be marked as completed.  As a result, the following `PostHook` step will never run.

I _think_ the fix is to move parts of updateVM() that interpreted VMIO Import status to updatePipeline() which only updates the step in the pipeline and anything that involves updating VM overall succeeded/failed status is moved to Migration.Run().