### PR TITLE
Switch back to ubi8/ubi-minimal base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ RUN GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o manager github.com/konv
 
 
 # Runner image
-FROM registry.access.redhat.com/ubi8/ubi-micro:8.4
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
+RUN microdnf -y install tar && microdnf clean all
 
 COPY --from=builder /opt/app-root/src/manager /usr/local/bin/manager
 ENTRYPOINT ["/usr/local/bin/manager"]


### PR DESCRIPTION
With #303 we removed `tar` from the image and this breaks the ability to copy files with `oc cp`. Since, `ubi8/ubi-micro` doesn't ship `tar` and doesn't allow to install it, we need to roll back to using `ubi8/ubi-minimal` and install `tar` during the image build.