### PR TITLE
Fix disks not detected and created when clone by template creation.

### DIFF
--- a/pkg/controller/provider/container/ovirt/collector.go
+++ b/pkg/controller/provider/container/ovirt/collector.go
@@ -297,10 +297,6 @@ func (r *Collector) create(ctx *Context, adapter Adapter) (err error) {
 		if err != nil {
 			return
 		}
-		r.log.V(3).Info(
-			"Model created.",
-			"model",
-			libmodel.Describe(m))
 	}
 	err = tx.Commit()
 	if err != nil {
@@ -417,20 +413,17 @@ func (r *Collector) refresh(ctx *Context) (err error) {
 		changeSet, applyErr := r.changeSet(ctx, event)
 		if applyErr == nil {
 			applyErr = r.apply(changeSet)
-		}
-		if applyErr != nil {
+			r.log.V(3).Info(
+				"Event applied.",
+				"event",
+				event)
+		} else {
 			r.log.Error(
 				applyErr,
 				"Apply event failed.",
 				"event",
 				event)
-			continue
 		}
-
-		r.log.V(3).Info(
-			"Event applied.",
-			"event",
-			event.Code)
 	}
 
 	return

--- a/pkg/controller/provider/container/ovirt/watch.go
+++ b/pkg/controller/provider/container/ovirt/watch.go
@@ -330,7 +330,8 @@ func (r *VMEventHandler) validated(batch []*policy.Task) {
 	}()
 	for _, task := range batch {
 		if task.Error != nil {
-			r.log.Error(err, task.Error.Error())
+			r.log.Error(
+				task.Error, "VM validation failed.")
 			continue
 		}
 		latest := &model.VM{Base: model.Base{ID: task.Ref.ID}}

--- a/pkg/controller/provider/container/vsphere/watch.go
+++ b/pkg/controller/provider/container/vsphere/watch.go
@@ -330,7 +330,8 @@ func (r *VMEventHandler) validated(batch []*policy.Task) {
 	}()
 	for _, task := range batch {
 		if task.Error != nil {
-			r.log.Error(err, task.Error.Error())
+			r.log.Error(
+				task.Error, "VM validation failed.")
 			continue
 		}
 		latest := &model.VM{Base: model.Base{ID: task.Ref.ID}}

--- a/pkg/controller/provider/web/ovirt/disk.go
+++ b/pkg/controller/provider/web/ovirt/disk.go
@@ -3,6 +3,7 @@ package ovirt
 import (
 	"errors"
 	"github.com/gin-gonic/gin"
+	liberr "github.com/konveyor/controller/pkg/error"
 	libmodel "github.com/konveyor/controller/pkg/inventory/model"
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
 	model "github.com/konveyor/forklift-controller/pkg/controller/provider/model/ovirt"
@@ -196,6 +197,11 @@ func (r *Disk) Expand(db libmodel.DB) (err error) {
 	if r.Profile.ID == "" {
 		return
 	}
+	defer func() {
+		if err != nil {
+			err = liberr.Wrap(err, "disk", r.ID)
+		}
+	}()
 	profile := &model.DiskProfile{
 		Base: model.Base{ID: r.Profile.ID},
 	}

--- a/pkg/controller/provider/web/ovirt/vm.go
+++ b/pkg/controller/provider/web/ovirt/vm.go
@@ -3,6 +3,7 @@ package ovirt
 import (
 	"errors"
 	"github.com/gin-gonic/gin"
+	liberr "github.com/konveyor/controller/pkg/error"
 	libmodel "github.com/konveyor/controller/pkg/inventory/model"
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
 	model "github.com/konveyor/forklift-controller/pkg/controller/provider/model/ovirt"
@@ -281,6 +282,11 @@ func (r *VM) Link(p *api.Provider) {
 // Expand the resource.
 // The vNIC profile.ID is optional.
 func (r *VM) Expand(db libmodel.DB) (err error) {
+	defer func() {
+		if err != nil {
+			err = liberr.Wrap(err, "vm", r.ID)
+		}
+	}()
 	for i := range r.NICs {
 		nic := &r.NICs[i]
 		if nic.Profile.ID == "" {

--- a/pkg/controller/validation/policy/client.go
+++ b/pkg/controller/validation/policy/client.go
@@ -386,12 +386,12 @@ func (r *Pool) Start() {
 		for task := range r.output {
 			if task.Error == nil {
 				log.V(4).Info(
-					"VM Validation succeeded.",
+					"VM validation succeeded.",
 					"task",
 					task.String())
 			} else {
 				log.Info(
-					"VM Validation failed.",
+					"VM validation failed.",
 					"task",
 					task.String())
 			}


### PR DESCRIPTION
Fix disk creation not detected when cloned by template creation.
When a template is created the reference VMs disks are cloned (created).  As a result, we have VMs created with the template (thin provisioned) that references disks that are not in inventory. We need to refresh the disks when a template is created.  
It may seem _heavy-handed_ to fetch all of the disks but it's simpler than fetching the template and inspecting the disks.  Also, disk resources are relatively small resources and I doubt that template creation is a high volume event.

--- 
This PR also improves some logging.

---

This PR also address the latency between when events are generated and the current state of the RHV model.
For example, here is a list of events grabbed in a query:
- VM Created
- Disk attached.
- Snapshot created.
- VM started.
- VM deleted.  <--- note.

When all of these are processed, the VM will no longer be in the RHV db.  So, we need to handle this gracefully.