### PR TITLE
Add preflight check to VM pipeline

### DIFF
--- a/pkg/controller/plan/adapter/base/doc.go
+++ b/pkg/controller/plan/adapter/base/doc.go
@@ -46,4 +46,6 @@ type Validator interface {
 	NetworksMapped(vmRef ref.Ref) (bool, error)
 	// Validate that a VM's Host isn't in maintenance mode.
 	MaintenanceMode(vmRef ref.Ref) (bool, error)
+	// Preflight check to ensure VM Import resource can be created from source VM.
+	Preflight(vmRef ref.Ref) (err error)
 }

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -100,27 +100,7 @@ func (r *Builder) Import(vmRef ref.Ref, object *vmio.VirtualMachineImportSpec) (
 				pErr.Error()))
 		return
 	}
-	if vm.IsTemplate {
-		err = liberr.New(
-			fmt.Sprintf(
-				"VM %s is a template",
-				vmRef.String()))
-		return
-	}
-	if types.VirtualMachineConnectionState(vm.ConnectionState) != types.VirtualMachineConnectionStateConnected {
-		err = liberr.New(
-			fmt.Sprintf(
-				"VM %s is not connected",
-				vmRef.String()))
-		return
-	}
-	if r.Plan.Spec.Warm && !vm.ChangeTrackingEnabled {
-		err = liberr.New(
-			fmt.Sprintf(
-				"Changed Block Tracking (CBT) is disabled for VM %s",
-				vmRef.String()))
-		return
-	}
+
 	uuid := vm.UUID
 	object.TargetVMName = &vm.Name
 	if !r.Plan.Spec.Warm {


### PR DESCRIPTION
It was requested in https://bugzilla.redhat.com/show_bug.cgi?id=1980628 (and I believe another BZ which I can't currently find), that an initialization step be added to the pipeline to catch errors that occur before the import is created and which are not directly related to disk transfer. This includes issues like the VM not being connected, the VM being a template, and CBT not being enabled for a warm migration.

This PR accomplishes that by adding a `Preflight` step to the VM pipeline, which calls a provider-specific `validator.Preflight` and reports any errors.

```
  vms:
      - completed: '2021-08-05T18:42:14Z'
        conditions:
          - category: Advisory
            durable: true
            lastTransitionTime: '2021-08-05T18:42:07Z'
            message: The VM migration has FAILED.
            status: 'True'
            type: Failed
        error:
          phase: Started
          reasons:
            - 'VM  id:vm-2828 name:''slucidi-centos''  lookup failed.'
        id: vm-2828
        name: slucidi-centos
        phase: Completed
        pipeline:
          - completed: '2021-08-05T18:42:14Z'
            description: Perform preflight check.
            error:
              phase: ''
              reasons:
                - 'VM  id:vm-2828 name:''slucidi-centos''  lookup failed.'
            name: Preflight
            progress:
              completed: 0
              total: 1
            started: '2021-08-05T18:42:07Z'
          - annotations:
              unit: MB
            description: Transfer disks.
            name: DiskTransfer
            progress:
              completed: 0
              total: 16384
            tasks:
              - annotations:
                  unit: MB
                name: '[datastore13] slucidi-centos/slucidi-centos.vmdk'
                progress:
                  completed: 0
                  total: 16384
          - description: Convert image to kubevirt.
            name: ImageConversion
            progress:
              completed: 0
              total: 1
        started: '2021-08-05T18:42:07Z'
```