### PR TITLE
Fix folder traversal spec not recursing fully

### DIFF
--- a/pkg/controller/provider/container/vsphere/collector.go
+++ b/pkg/controller/provider/container/vsphere/collector.go
@@ -131,18 +131,6 @@ const (
 )
 
 //
-// Folder traversal Spec.
-var TsDFolder = &types.TraversalSpec{
-	Type: Folder,
-	Path: fChildEntity,
-	SelectSet: []types.BaseSelectionSpec{
-		&types.SelectionSpec{
-			Name: TraverseFolders,
-		},
-	},
-}
-
-//
 // Datacenter/VM traversal Spec.
 var TsDatacenterVM = &types.TraversalSpec{
 	Type: Datacenter,
@@ -211,7 +199,9 @@ var TsRootFolder = &types.TraversalSpec{
 	Type: Folder,
 	Path: fChildEntity,
 	SelectSet: []types.BaseSelectionSpec{
-		TsDFolder,
+		&types.SelectionSpec{
+			Name: TraverseFolders,
+		},
 		TsDatacenterVM,
 		TsDatacenterHost,
 		TsDatacenterNet,


### PR DESCRIPTION
By having a different "Folder -> childEntity" traversal from the "root" recursive traversal, the propertyFilter was not fully traversing a
vSphere tree recursively.  This was specifically preventing other objects such as datacenters and clusters that were nested in folders from being traversed to.

Steps to reproduce:
Run a govmomi vcsim with nested datacenters: `go/bin/vcsim -app 2 -cluster 4 -dc 4 -ds 8 -folder 32 -host 16 -nsx 2 -pg 4 -pg-nsx 2 -pod 2 -pool 8 -standalone-host 2 -vm 64`

Before:
```
{{} enter Folder:group-d1 [{{} name assign Datacenters}] []}
{{} enter Folder:group-2 [{{} name assign F0}] []}
{{} enter Folder:group-619 [{{} name assign F1}] []}
{{} enter Folder:group-1236 [{{} name assign F2}] []}
{{} enter Folder:group-1853 [{{} name assign F3}] []}
```

Note it doesn't even traverse into the datacenters under the top-level folders

After:
```
{{} enter Folder:group-d1 [{{} name assign Datacenters}] []}
{{} enter Folder:group-2 [{{} name assign F0}] []}
{{} enter Folder:group-4 [{{} name assign vm}] []}
{{} enter Folder:group-14 [{{} name assign F0}] []}
{{} enter Folder:group-5 [{{} name assign host}] []}
{{} enter Folder:group-12 [{{} name assign F0}] []}
{{} enter Folder:group-7 [{{} name assign network}] []}
{{} enter Folder:group-13 [{{} name assign F0}] []}
{{} enter Folder:group-6 [{{} name assign datastore}] []}
{{} enter StoragePod:storagepod-9 [{{} name assign DC0_POD0}] []}
{{} enter StoragePod:storagepod-10 [{{} name assign DC0_POD1}] []}
{{} enter Folder:group-11 [{{} name assign F0}] []}
{{} enter Folder:group-619 [{{} name assign F1}] []}
{{} enter Folder:group-621 [{{} name assign vm}] []}
{{} enter Folder:group-631 [{{} name assign F1}] []}
{{} enter Folder:group-622 [{{} name assign host}] []}
{{} enter Folder:group-629 [{{} name assign F1}] []}
{{} enter Folder:group-624 [{{} name assign network}] []}
{{} enter Folder:group-630 [{{} name assign F1}] []}
{{} enter Folder:group-623 [{{} name assign datastore}] []}
{{} enter StoragePod:storagepod-626 [{{} name assign DC1_POD0}] []}
{{} enter StoragePod:storagepod-627 [{{} name assign DC1_POD1}] []}
{{} enter Folder:group-628 [{{} name assign F1}] []}
{{} enter Folder:group-1236 [{{} name assign F2}] []}
{{} enter Folder:group-1238 [{{} name assign vm}] []}
{{} enter Folder:group-1248 [{{} name assign F2}] []}
{{} enter Folder:group-1239 [{{} name assign host}] []}
{{} enter Folder:group-1246 [{{} name assign F2}] []}
{{} enter Folder:group-1241 [{{} name assign network}] []}
{{} enter Folder:group-1247 [{{} name assign F2}] []}
{{} enter Folder:group-1240 [{{} name assign datastore}] []}
{{} enter StoragePod:storagepod-1243 [{{} name assign DC2_POD0}] []}
{{} enter StoragePod:storagepod-1244 [{{} name assign DC2_POD1}] []}
{{} enter Folder:group-1245 [{{} name assign F2}] []}
{{} enter Folder:group-1853 [{{} name assign F3}] []}
{{} enter Folder:group-1855 [{{} name assign vm}] []}
{{} enter Folder:group-1865 [{{} name assign F3}] []}
{{} enter Folder:group-1856 [{{} name assign host}] []}
{{} enter Folder:group-1863 [{{} name assign F3}] []}
{{} enter Folder:group-1858 [{{} name assign network}] []}
{{} enter Folder:group-1864 [{{} name assign F3}] []}
{{} enter Folder:group-1857 [{{} name assign datastore}] []}
{{} enter StoragePod:storagepod-1860 [{{} name assign DC3_POD0}] []}
{{} enter StoragePod:storagepod-1861 [{{} name assign DC3_POD1}] []}
{{} enter Folder:group-1862 [{{} name assign F3}] []}
```