### PR TITLE
Fix support for standalone host.

### DIFF
--- a/pkg/controller/provider/container/vsphere/model.go
+++ b/pkg/controller/provider/container/vsphere/model.go
@@ -50,7 +50,8 @@ func (b *Base) Ref(in types.AnyType) (ref model.Ref) {
 			ref.Kind = model.FolderKind
 		case Datacenter:
 			ref.Kind = model.DatacenterKind
-		case Cluster:
+		case Cluster,
+			ComputeResource:
 			ref.Kind = model.ClusterKind
 		case Network,
 			DVPortGroup,

--- a/pkg/controller/provider/model/vsphere/model.go
+++ b/pkg/controller/provider/model/vsphere/model.go
@@ -6,11 +6,14 @@ import (
 )
 
 //
-// Networks (variant).
+// Variants.
 const (
+	// Network.
 	NetStandard    = "Standard"
 	NetDvPortGroup = "DvPortGroup"
 	NetDvSwitch    = "DvSwitch"
+	// Cluster.
+	ComputeResource = "ComputeResource"
 )
 
 //
@@ -42,6 +45,8 @@ type Model interface {
 type Base struct {
 	// Managed object ID.
 	ID string `sql:"pk"`
+	// Variant
+	Variant string `sql:"d0,index(variant)"`
 	// Name
 	Name string `sql:"d0,index(name)"`
 	// Parent
@@ -216,7 +221,6 @@ type Switch struct {
 
 type Network struct {
 	Base
-	Variant  string    `sql:"d0"`
 	Tag      string    `sql:""`
 	DVSwitch Ref       `sql:""`
 	Host     []DVSHost `sql:""`

--- a/pkg/controller/provider/web/vsphere/cluster.go
+++ b/pkg/controller/provider/web/vsphere/cluster.go
@@ -63,7 +63,16 @@ func (h ClusterHandler) List(ctx *gin.Context) {
 	}()
 	db := h.Collector.DB()
 	list := []model.Cluster{}
-	err = db.List(&list, h.ListOptions(ctx))
+	options := h.ListOptions(ctx)
+	realCluster := libmodel.Eq("variant", "")
+	if options.Predicate != nil {
+		options.Predicate = libmodel.And(
+			options.Predicate,
+			realCluster)
+	} else {
+		options.Predicate = realCluster
+	}
+	err = db.List(&list, options)
 	if err != nil {
 		return
 	}
@@ -196,8 +205,8 @@ type Cluster struct {
 //
 // Build the resource using the model.
 func (r *Cluster) With(m *model.Cluster) {
-	r.Folder = m.Folder
 	r.Resource.With(&m.Base)
+	r.Folder = m.Folder
 	r.DasEnabled = m.DasEnabled
 	r.DrsEnabled = m.DrsEnabled
 	r.DrsBehavior = m.DrsBehavior

--- a/pkg/controller/provider/web/vsphere/resource.go
+++ b/pkg/controller/provider/web/vsphere/resource.go
@@ -9,6 +9,8 @@ import (
 type Resource struct {
 	// Object ID.
 	ID string `json:"id"`
+	// Variant
+	Variant string `json:"variant,omitempty"`
 	// Parent.
 	Parent model.Ref `json:"parent"`
 	// Path
@@ -25,6 +27,7 @@ type Resource struct {
 // Build the resource using the model.
 func (r *Resource) With(m *model.Base) {
 	r.ID = m.ID
+	r.Variant = m.Variant
 	r.Parent = m.Parent
 	r.Revision = m.Revision
 	r.Name = m.Name


### PR DESCRIPTION
Fix support for stand-alone Hosts.

A host system can be contained by any `ComputeResource`.  A cluster IsA  `ComputeResource`.  Standalone host will be contained by a `ComputeResource` (that is not a Cluster).

Both `ComputeResource` and `ClusterComputeResources` are stored in the model as `Cluster`.  However, the base `ComputeResource` containing stand-alone hosts are denoted using the `variant=ComputeResource` field.