### PR TITLE
Fix provider not ready detection.

### DIFF
--- a/pkg/controller/provider/web/base/handler.go
+++ b/pkg/controller/provider/web/base/handler.go
@@ -24,9 +24,14 @@ const (
 )
 
 //
-// Header.
+// Reply Header.
 const (
-	ProviderHeader = "X-Provider"
+	// Explains reason behind status code.
+	ReasonHeader = "X-Reason"
+	// Explains 404 caused by provider not found in
+	// inventory as opposed to the requested resource
+	// not found within the provider in the inventory.
+	UnknownProvider = "ProviderNotFound"
 )
 
 //
@@ -107,10 +112,10 @@ func (h *Handler) setProvider(ctx *gin.Context) (status int) {
 	}
 	if h.Provider.UID != "" {
 		if h.Collector, found = h.Container.Get(h.Provider); !found {
+			ctx.Header(ReasonHeader, UnknownProvider)
 			status = http.StatusNotFound
 			return
 		}
-		ctx.Header(ProviderHeader, uid)
 		h.Provider = h.Collector.Owner().(*api.Provider)
 		status = h.EnsureParity(h.Collector, time.Second*10)
 	} else {


### PR DESCRIPTION
Fix provider not ready detection for URL paths for resources _under a provider_.

The current approach:

When the provider is found (by server), a header X-Provider is set to the provider CR UID.
When the provider is not found (by server), returns a 404.  The client on 404 checks for the X-Provider header.  If found, determines the provider was found but the resource at the URL path is not found.

The flaw, is that an incorrect URL with result in a 404 and no X-Provider header and will be mistaken for ProviderNotFound.

The new approach:

Invert the logic.  When provider is not found (by server), still return 404 but sets an `X-Reason` reply header to _ProviderNotFound_.
 