### PR TITLE
Removed Host.VMs property.

### DIFF
--- a/pkg/controller/provider/container/vsphere/collector.go
+++ b/pkg/controller/provider/container/vsphere/collector.go
@@ -647,7 +647,6 @@ func (r *Collector) propertySpec() []types.PropertySpec {
 				fCpuCores,
 				fDatastore,
 				fNetwork,
-				fVm,
 				fVSwitch,
 				fPortGroup,
 				fPNIC,

--- a/pkg/controller/provider/container/vsphere/model.go
+++ b/pkg/controller/provider/container/vsphere/model.go
@@ -273,8 +273,6 @@ func (v *HostAdapter) Apply(u types.ObjectUpdate) {
 				if b, cast := p.Val.(int16); cast {
 					v.model.CpuCores = b
 				}
-			case fVm:
-				v.model.Vms = v.RefList(p.Val)
 			case fProductName:
 				if s, cast := p.Val.(string); cast {
 					v.model.ProductName = s

--- a/pkg/controller/provider/model/vsphere/model.go
+++ b/pkg/controller/provider/model/vsphere/model.go
@@ -201,7 +201,6 @@ type Host struct {
 	Network            HostNetwork `sql:""`
 	Networks           []Ref       `sql:""`
 	Datastores         []Ref       `sql:""`
-	Vms                []Ref       `sql:""`
 }
 
 type HostNetwork struct {

--- a/pkg/controller/provider/web/vsphere/host.go
+++ b/pkg/controller/provider/web/vsphere/host.go
@@ -252,7 +252,6 @@ func (r *Host) With(m *model.Host) {
 	r.Network = m.Network
 	r.Networks = m.Networks
 	r.Datastores = m.Datastores
-	r.VMs = m.Vms
 	r.NetworkAdapters = []NetworkAdapter{}
 }
 


### PR DESCRIPTION
The `Host.VMs` list is very large and is updated whenever a VM is created,deleted.  As a result, when a VM is added and the list is updated, the controller re-validates all of the VMs on the host (because the host changed).
The `VM.Host` property (back-ref) provides that same linkage.