### PR TITLE
VM validation event tuning and logging.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/gin-gonic/gin v1.7.2
 	github.com/go-logr/logr v0.3.0
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.1.0
-	github.com/konveyor/controller v0.6.0
+	github.com/konveyor/controller v0.6.1
 	github.com/onsi/gomega v1.10.3
 	github.com/pkg/profile v1.3.0
 	github.com/prometheus/client_golang v1.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -741,6 +741,8 @@ github.com/konveyor/controller v0.5.0 h1:PmAFidRzMwHmbt8ShA/yow60kap1JgZIAtRMdGm
 github.com/konveyor/controller v0.5.0/go.mod h1:j0DSNesS0XHmqOLcJEuwB+qIRkdJ3mSIEJFA2byC12c=
 github.com/konveyor/controller v0.6.0 h1:E6P/z64KYEBA9RjkY9xtscqPhBCsCEpTOdVK8Nao5IY=
 github.com/konveyor/controller v0.6.0/go.mod h1:j0DSNesS0XHmqOLcJEuwB+qIRkdJ3mSIEJFA2byC12c=
+github.com/konveyor/controller v0.6.1 h1:+hqgq5gCNMDw4ZVqUa4/FVb73HnzXwes313T1wVk/Gs=
+github.com/konveyor/controller v0.6.1/go.mod h1:j0DSNesS0XHmqOLcJEuwB+qIRkdJ3mSIEJFA2byC12c=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=


### PR DESCRIPTION
Using _transaction labels_ introduced in controller/v0.6.1, **ignore** _echo_ events generated when VMs are updated after they are validated.  Also, use buffered _input_ channel to add some _"slack"_.  Both prevent the VM model event handler from getting blocked on the first event during initial validation on provider startup.  For very large vCenter providers (node-5), I have seen watch queue overflow log entries:

"full queue, event discarded."

Log the "VM validated" at level: 3 which matches the default logging level when deployed by the operator.