### PR TITLE
Slim-down API payloads.

### DIFF
--- a/pkg/controller/plan/adapter/ovirt/validator.go
+++ b/pkg/controller/plan/adapter/ovirt/validator.go
@@ -28,7 +28,7 @@ func (r *Validator) NetworksMapped(vmRef ref.Ref) (ok bool, err error) {
 	if r.plan.Referenced.Map.Network == nil {
 		return
 	}
-	vm := &model.VM{}
+	vm := &model.Workload{}
 	err = r.inventory.Find(vm, vmRef)
 	if err != nil {
 		err = liberr.Wrap(
@@ -54,7 +54,7 @@ func (r *Validator) StorageMapped(vmRef ref.Ref) (ok bool, err error) {
 	if r.plan.Referenced.Map.Storage == nil {
 		return
 	}
-	vm := &model.VM{}
+	vm := &model.Workload{}
 	err = r.inventory.Find(vm, vmRef)
 	if err != nil {
 		err = liberr.Wrap(

--- a/pkg/controller/provider/web/base/handler.go
+++ b/pkg/controller/provider/web/base/handler.go
@@ -5,6 +5,7 @@ import (
 	libcontainer "github.com/konveyor/controller/pkg/inventory/container"
 	libweb "github.com/konveyor/controller/pkg/inventory/web"
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
+	"github.com/konveyor/forklift-controller/pkg/controller/provider/model/base"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"net/http"
@@ -62,8 +63,8 @@ type Handler struct {
 	Provider *api.Provider
 	// Collector responsible for the provider.
 	Collector libcontainer.Collector
-	// Resources include details.
-	Detail bool
+	// Resources detail level.
+	Detail int
 }
 
 //
@@ -127,19 +128,26 @@ func (h *Handler) setProvider(ctx *gin.Context) (status int) {
 
 //
 // Set detail
-func (h *Handler) setDetail(ctx *gin.Context) int {
+// "all" = MaxDetail.
+func (h *Handler) setDetail(ctx *gin.Context) (status int) {
+	status = http.StatusOK
 	q := ctx.Request.URL.Query()
 	pDetail := q.Get(DetailParam)
-	if len(pDetail) > 0 {
-		b, err := strconv.ParseBool(pDetail)
-		if err == nil {
-			h.Detail = b
-		} else {
-			return http.StatusBadRequest
-		}
+	if len(pDetail) == 0 {
+		return
+	}
+	if strings.ToLower(pDetail) == "all" {
+		h.Detail = base.MaxDetail
+		return
+	}
+	n, err := strconv.Atoi(pDetail)
+	if err == nil {
+		h.Detail = n
+	} else {
+		status = http.StatusBadRequest
 	}
 
-	return http.StatusOK
+	return
 }
 
 //

--- a/pkg/controller/provider/web/ocp/base.go
+++ b/pkg/controller/provider/web/ocp/base.go
@@ -4,6 +4,7 @@ import (
 	"github.com/gin-gonic/gin"
 	libmodel "github.com/konveyor/controller/pkg/inventory/model"
 	"github.com/konveyor/controller/pkg/logging"
+	model "github.com/konveyor/forklift-controller/pkg/controller/provider/model/ocp"
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/web/base"
 )
 
@@ -56,9 +57,9 @@ func (h Handler) Predicate(ctx *gin.Context) (p libmodel.Predicate) {
 //
 // Build list options.
 func (h Handler) ListOptions(ctx *gin.Context) libmodel.ListOptions {
-	detail := 0
-	if h.Detail {
-		detail = 1
+	detail := h.Detail
+	if detail > 0 {
+		detail = model.MaxDetail
 	}
 	return libmodel.ListOptions{
 		Predicate: h.Predicate(ctx),

--- a/pkg/controller/provider/web/ocp/client.go
+++ b/pkg/controller/provider/web/ocp/client.go
@@ -99,7 +99,7 @@ func (r *Finder) ByRef(resource interface{}, ref base.Ref) (err error) {
 				&list,
 				base.Param{
 					Key:   DetailParam,
-					Value: "1",
+					Value: "all",
 				},
 				base.Param{
 					Key:   NsParam,
@@ -135,7 +135,7 @@ func (r *Finder) ByRef(resource interface{}, ref base.Ref) (err error) {
 				&list,
 				base.Param{
 					Key:   DetailParam,
-					Value: "1",
+					Value: "all",
 				},
 				base.Param{
 					Key:   NameParam,
@@ -169,7 +169,7 @@ func (r *Finder) ByRef(resource interface{}, ref base.Ref) (err error) {
 				&list,
 				base.Param{
 					Key:   DetailParam,
-					Value: "1",
+					Value: "all",
 				},
 				base.Param{
 					Key:   NsParam,

--- a/pkg/controller/provider/web/ocp/namespace.go
+++ b/pkg/controller/provider/web/ocp/namespace.go
@@ -99,7 +99,7 @@ func (h NamespaceHandler) Get(ctx *gin.Context) {
 	r := &Namespace{}
 	r.With(m)
 	r.Link(h.Provider)
-	content := r.Content(true)
+	content := r.Content(model.MaxDetail)
 
 	ctx.JSON(http.StatusOK, content)
 }
@@ -156,8 +156,8 @@ func (r *Namespace) Link(p *api.Provider) {
 
 //
 // As content.
-func (r *Namespace) Content(detail bool) interface{} {
-	if !detail {
+func (r *Namespace) Content(detail int) interface{} {
+	if detail == 0 {
 		return r.Resource
 	}
 

--- a/pkg/controller/provider/web/ocp/netattachdefinition.go
+++ b/pkg/controller/provider/web/ocp/netattachdefinition.go
@@ -100,7 +100,7 @@ func (h NadHandler) Get(ctx *gin.Context) {
 	r := &NetworkAttachmentDefinition{}
 	r.With(m)
 	r.Link(h.Provider)
-	content := r.Content(true)
+	content := r.Content(model.MaxDetail)
 
 	ctx.JSON(http.StatusOK, content)
 }
@@ -157,8 +157,8 @@ func (r *NetworkAttachmentDefinition) Link(p *api.Provider) {
 
 //
 // As content.
-func (r *NetworkAttachmentDefinition) Content(detail bool) interface{} {
-	if !detail {
+func (r *NetworkAttachmentDefinition) Content(detail int) interface{} {
+	if detail == 0 {
 		return r.Resource
 	}
 

--- a/pkg/controller/provider/web/ocp/provider.go
+++ b/pkg/controller/provider/web/ocp/provider.go
@@ -64,7 +64,7 @@ func (h ProviderHandler) Get(ctx *gin.Context) {
 		ctx.Status(http.StatusNotFound)
 		return
 	}
-	h.Detail = true
+	h.Detail = model.MaxDetail
 	m := &model.Provider{}
 	m.With(h.Provider)
 	r := Provider{}
@@ -79,7 +79,7 @@ func (h ProviderHandler) Get(ctx *gin.Context) {
 		return
 	}
 	r.Link()
-	content := r.Content(true)
+	content := r.Content(h.Detail)
 
 	ctx.JSON(http.StatusOK, content)
 }
@@ -125,7 +125,7 @@ func (h *ProviderHandler) ListContent(ctx *gin.Context) (content []interface{}, 
 //
 // Add counts.
 func (h ProviderHandler) AddCount(r *Provider) (err error) {
-	if !h.Detail {
+	if h.Detail == 0 {
 		return nil
 	}
 	db := h.Collector.DB()
@@ -182,8 +182,8 @@ func (r *Provider) Link() {
 
 //
 // As content.
-func (r *Provider) Content(detail bool) interface{} {
-	if !detail {
+func (r *Provider) Content(detail int) interface{} {
+	if detail == 0 {
 		return r.Resource
 	}
 

--- a/pkg/controller/provider/web/ocp/storageclass.go
+++ b/pkg/controller/provider/web/ocp/storageclass.go
@@ -100,7 +100,7 @@ func (h StorageClassHandler) Get(ctx *gin.Context) {
 	r := &StorageClass{}
 	r.With(m)
 	r.Link(h.Provider)
-	content := r.Content(true)
+	content := r.Content(model.MaxDetail)
 
 	ctx.JSON(http.StatusOK, content)
 }
@@ -157,8 +157,8 @@ func (r *StorageClass) Link(p *api.Provider) {
 
 //
 // As content.
-func (r *StorageClass) Content(detail bool) interface{} {
-	if !detail {
+func (r *StorageClass) Content(detail int) interface{} {
+	if detail == 0 {
 		return r.Resource
 	}
 

--- a/pkg/controller/provider/web/ocp/vm.go
+++ b/pkg/controller/provider/web/ocp/vm.go
@@ -100,7 +100,7 @@ func (h VMHandler) Get(ctx *gin.Context) {
 	r := &VM{}
 	r.With(m)
 	r.Link(h.Provider)
-	content := r.Content(true)
+	content := r.Content(model.MaxDetail)
 
 	ctx.JSON(http.StatusOK, content)
 }
@@ -157,8 +157,8 @@ func (r *VM) Link(p *api.Provider) {
 
 //
 // As content.
-func (r *VM) Content(detail bool) interface{} {
-	if !detail {
+func (r *VM) Content(detail int) interface{} {
+	if detail == 0 {
 		return r.Resource
 	}
 

--- a/pkg/controller/provider/web/ovirt/base.go
+++ b/pkg/controller/provider/web/ovirt/base.go
@@ -44,9 +44,9 @@ func (h Handler) Predicate(ctx *gin.Context) (p libmodel.Predicate) {
 //
 // Build list options.
 func (h Handler) ListOptions(ctx *gin.Context) libmodel.ListOptions {
-	detail := 0
-	if h.Detail {
-		detail = 1
+	detail := h.Detail
+	if detail > 0 {
+		detail = model.MaxDetail
 	}
 	return libmodel.ListOptions{
 		Predicate: h.Predicate(ctx),

--- a/pkg/controller/provider/web/ovirt/client.go
+++ b/pkg/controller/provider/web/ovirt/client.go
@@ -106,7 +106,7 @@ func (r *Finder) ByRef(resource interface{}, ref base.Ref) (err error) {
 				&list,
 				base.Param{
 					Key:   DetailParam,
-					Value: "1",
+					Value: "all",
 				},
 				base.Param{
 					Key:   NameParam,
@@ -138,7 +138,7 @@ func (r *Finder) ByRef(resource interface{}, ref base.Ref) (err error) {
 				&list,
 				base.Param{
 					Key:   DetailParam,
-					Value: "1",
+					Value: "all",
 				},
 				base.Param{
 					Key:   NameParam,
@@ -170,7 +170,7 @@ func (r *Finder) ByRef(resource interface{}, ref base.Ref) (err error) {
 				&list,
 				base.Param{
 					Key:   DetailParam,
-					Value: "1",
+					Value: "all",
 				},
 				base.Param{
 					Key:   NameParam,
@@ -202,7 +202,7 @@ func (r *Finder) ByRef(resource interface{}, ref base.Ref) (err error) {
 				&list,
 				base.Param{
 					Key:   DetailParam,
-					Value: "1",
+					Value: "all",
 				},
 				base.Param{
 					Key:   NameParam,
@@ -234,7 +234,7 @@ func (r *Finder) ByRef(resource interface{}, ref base.Ref) (err error) {
 				&list,
 				base.Param{
 					Key:   DetailParam,
-					Value: "1",
+					Value: "all",
 				},
 				base.Param{
 					Key:   NameParam,

--- a/pkg/controller/provider/web/ovirt/cluster.go
+++ b/pkg/controller/provider/web/ovirt/cluster.go
@@ -116,7 +116,7 @@ func (h ClusterHandler) Get(ctx *gin.Context) {
 	r.With(m)
 	r.Link(h.Provider)
 	r.Path = pb.Path(m)
-	content := r.Content(true)
+	content := r.Content(model.MaxDetail)
 
 	ctx.JSON(http.StatusOK, content)
 }
@@ -211,8 +211,8 @@ func (r *Cluster) Link(p *api.Provider) {
 
 //
 // As content.
-func (r *Cluster) Content(detail bool) interface{} {
-	if !detail {
+func (r *Cluster) Content(detail int) interface{} {
+	if detail == 0 {
 		return r.Resource
 	}
 

--- a/pkg/controller/provider/web/ovirt/datacenter.go
+++ b/pkg/controller/provider/web/ovirt/datacenter.go
@@ -106,7 +106,7 @@ func (h DataCenterHandler) Get(ctx *gin.Context) {
 	r.With(m)
 	r.Link(h.Provider)
 	r.Path = pb.Path(m)
-	content := r.Content(true)
+	content := r.Content(model.MaxDetail)
 
 	ctx.JSON(http.StatusOK, content)
 }
@@ -163,8 +163,8 @@ func (r *DataCenter) Link(p *api.Provider) {
 
 //
 // As content.
-func (r *DataCenter) Content(detail bool) interface{} {
-	if !detail {
+func (r *DataCenter) Content(detail int) interface{} {
+	if detail == 0 {
 		return r.Resource
 	}
 

--- a/pkg/controller/provider/web/ovirt/diskprofile.go
+++ b/pkg/controller/provider/web/ovirt/diskprofile.go
@@ -100,7 +100,7 @@ func (h DiskProfileHandler) Get(ctx *gin.Context) {
 	r := &DiskProfile{}
 	r.With(m)
 	r.Link(h.Provider)
-	content := r.Content(true)
+	content := r.Content(model.MaxDetail)
 
 	ctx.JSON(http.StatusOK, content)
 }
@@ -159,8 +159,8 @@ func (r *DiskProfile) Link(p *api.Provider) {
 
 //
 // As content.
-func (r *DiskProfile) Content(detail bool) interface{} {
-	if !detail {
+func (r *DiskProfile) Content(detail int) interface{} {
+	if detail == 0 {
 		return r.Resource
 	}
 

--- a/pkg/controller/provider/web/ovirt/host.go
+++ b/pkg/controller/provider/web/ovirt/host.go
@@ -90,7 +90,7 @@ func (h HostHandler) Get(ctx *gin.Context) {
 		ctx.Status(status)
 		return
 	}
-	h.Detail = true
+	h.Detail = model.MaxDetail
 	m := &model.Host{
 		Base: model.Base{
 			ID: ctx.Param(HostParam),
@@ -115,7 +115,7 @@ func (h HostHandler) Get(ctx *gin.Context) {
 	r.With(m)
 	r.Link(h.Provider)
 	r.Path = pb.Path(m)
-	content := r.Content(true)
+	content := r.Content(h.Detail)
 
 	ctx.JSON(http.StatusOK, content)
 }
@@ -223,8 +223,8 @@ func (r *Host) Link(p *api.Provider) {
 
 //
 // As content.
-func (r *Host) Content(detail bool) interface{} {
-	if !detail {
+func (r *Host) Content(detail int) interface{} {
+	if detail == 0 {
 		return r.Resource
 	}
 

--- a/pkg/controller/provider/web/ovirt/network.go
+++ b/pkg/controller/provider/web/ovirt/network.go
@@ -113,7 +113,7 @@ func (h NetworkHandler) Get(ctx *gin.Context) {
 	r.With(m)
 	r.Link(h.Provider)
 	r.Path = pb.Path(m)
-	content := r.Content(true)
+	content := r.Content(model.MaxDetail)
 
 	ctx.JSON(http.StatusOK, content)
 }
@@ -208,8 +208,8 @@ func (r *Network) Link(p *api.Provider) {
 
 //
 // As content.
-func (r *Network) Content(detail bool) interface{} {
-	if !detail {
+func (r *Network) Content(detail int) interface{} {
+	if detail == 0 {
 		return r.Resource
 	}
 

--- a/pkg/controller/provider/web/ovirt/nicprofile.go
+++ b/pkg/controller/provider/web/ovirt/nicprofile.go
@@ -100,7 +100,7 @@ func (h NICProfileHandler) Get(ctx *gin.Context) {
 	r := &NICProfile{}
 	r.With(m)
 	r.Link(h.Provider)
-	content := r.Content(true)
+	content := r.Content(model.MaxDetail)
 
 	ctx.JSON(http.StatusOK, content)
 }
@@ -167,8 +167,8 @@ func (r *NICProfile) Link(p *api.Provider) {
 
 //
 // As content.
-func (r *NICProfile) Content(detail bool) interface{} {
-	if !detail {
+func (r *NICProfile) Content(detail int) interface{} {
+	if detail == 0 {
 		return r.Resource
 	}
 

--- a/pkg/controller/provider/web/ovirt/provider.go
+++ b/pkg/controller/provider/web/ovirt/provider.go
@@ -69,7 +69,7 @@ func (h ProviderHandler) Get(ctx *gin.Context) {
 		ctx.Status(http.StatusNotFound)
 		return
 	}
-	h.Detail = true
+	h.Detail = model.MaxDetail
 	m := &model.Provider{}
 	m.With(h.Provider)
 	r := Provider{}
@@ -84,7 +84,7 @@ func (h ProviderHandler) Get(ctx *gin.Context) {
 		return
 	}
 	r.Link()
-	content := r.Content(true)
+	content := r.Content(h.Detail)
 
 	ctx.JSON(http.StatusOK, content)
 }
@@ -131,7 +131,7 @@ func (h *ProviderHandler) ListContent(ctx *gin.Context) (content []interface{}, 
 // Add derived fields.
 func (h *ProviderHandler) AddDerived(r *Provider) (err error) {
 	var n int64
-	if !h.Detail {
+	if h.Detail == 0 {
 		return
 	}
 	db := h.Collector.DB()
@@ -209,8 +209,8 @@ func (r *Provider) Link() {
 
 //
 // As content.
-func (r *Provider) Content(detail bool) interface{} {
-	if !detail {
+func (r *Provider) Content(detail int) interface{} {
+	if detail == 0 {
 		return r.Resource
 	}
 

--- a/pkg/controller/provider/web/ovirt/storage.go
+++ b/pkg/controller/provider/web/ovirt/storage.go
@@ -114,7 +114,7 @@ func (h StorageDomainHandler) Get(ctx *gin.Context) {
 	r.With(m)
 	r.Link(h.Provider)
 	r.Path = pb.Path(m)
-	content := r.Content(true)
+	content := r.Content(model.MaxDetail)
 
 	ctx.JSON(http.StatusOK, content)
 }
@@ -213,8 +213,8 @@ func (r *StorageDomain) Link(p *api.Provider) {
 
 //
 // As content.
-func (r *StorageDomain) Content(detail bool) interface{} {
-	if !detail {
+func (r *StorageDomain) Content(detail int) interface{} {
+	if detail == 0 {
 		return r.Resource
 	}
 

--- a/pkg/controller/provider/web/ovirt/tree.go
+++ b/pkg/controller/provider/web/ovirt/tree.go
@@ -92,7 +92,7 @@ func (h TreeHandler) Tree(ctx *gin.Context) {
 			NodeBuilder: &NodeBuilder{
 				handler:     h.Handler,
 				pathBuilder: pb,
-				detail: map[string]bool{
+				detail: map[string]int{
 					model.VmKind: h.Detail,
 				},
 			},
@@ -127,7 +127,7 @@ func (h TreeHandler) Tree(ctx *gin.Context) {
 // Tree (branch) navigator.
 type BranchNavigator struct {
 	db     libmodel.DB
-	detail bool
+	detail int
 }
 
 //
@@ -192,8 +192,8 @@ func (n *BranchNavigator) listHost(p *model.Cluster) (list []model.Host, err err
 
 func (n *BranchNavigator) listVM(p *model.Cluster) (list []model.VM, err error) {
 	detail := 0
-	if n.detail {
-		detail = 1
+	if n.detail > 0 {
+		detail = model.MaxDetail
 	}
 	list = []model.VM{}
 	err = n.db.List(
@@ -211,7 +211,7 @@ type NodeBuilder struct {
 	// Handler.
 	handler Handler
 	// Resource details by kind.
-	detail map[string]bool
+	detail map[string]int
 	// Path builder.
 	pathBuilder PathBuilder
 }
@@ -296,10 +296,10 @@ func (r *NodeBuilder) Node(parent *TreeNode, m model.Model) *TreeNode {
 
 //
 // Build with detail.
-func (r *NodeBuilder) withDetail(kind string) bool {
+func (r *NodeBuilder) withDetail(kind string) int {
 	if b, found := r.detail[kind]; found {
 		return b
 	}
 
-	return false
+	return 0
 }

--- a/pkg/controller/provider/web/vsphere/base.go
+++ b/pkg/controller/provider/web/vsphere/base.go
@@ -43,9 +43,9 @@ func (h Handler) Predicate(ctx *gin.Context) (p libmodel.Predicate) {
 //
 // Build list options.
 func (h Handler) ListOptions(ctx *gin.Context) libmodel.ListOptions {
-	detail := 0
-	if h.Detail {
-		detail = 1
+	detail := h.Detail
+	if detail > 0 {
+		detail = model.MaxDetail
 	}
 	return libmodel.ListOptions{
 		Predicate: h.Predicate(ctx),

--- a/pkg/controller/provider/web/vsphere/client.go
+++ b/pkg/controller/provider/web/vsphere/client.go
@@ -116,7 +116,7 @@ func (r *Finder) ByRef(resource interface{}, ref base.Ref) (err error) {
 				&list,
 				base.Param{
 					Key:   DetailParam,
-					Value: "1",
+					Value: "all",
 				},
 				base.Param{
 					Key:   NameParam,
@@ -148,7 +148,7 @@ func (r *Finder) ByRef(resource interface{}, ref base.Ref) (err error) {
 				&list,
 				base.Param{
 					Key:   DetailParam,
-					Value: "1",
+					Value: "all",
 				},
 				base.Param{
 					Key:   NameParam,
@@ -180,7 +180,7 @@ func (r *Finder) ByRef(resource interface{}, ref base.Ref) (err error) {
 				&list,
 				base.Param{
 					Key:   DetailParam,
-					Value: "1",
+					Value: "all",
 				},
 				base.Param{
 					Key:   NameParam,
@@ -212,7 +212,7 @@ func (r *Finder) ByRef(resource interface{}, ref base.Ref) (err error) {
 				&list,
 				base.Param{
 					Key:   DetailParam,
-					Value: "1",
+					Value: "all",
 				},
 				base.Param{
 					Key:   NameParam,
@@ -244,7 +244,7 @@ func (r *Finder) ByRef(resource interface{}, ref base.Ref) (err error) {
 				&list,
 				base.Param{
 					Key:   DetailParam,
-					Value: "1",
+					Value: "all",
 				},
 				base.Param{
 					Key:   NameParam,

--- a/pkg/controller/provider/web/vsphere/cluster.go
+++ b/pkg/controller/provider/web/vsphere/cluster.go
@@ -116,7 +116,7 @@ func (h ClusterHandler) Get(ctx *gin.Context) {
 	r.With(m)
 	r.Link(h.Provider)
 	r.Path = pb.Path(m)
-	content := r.Content(true)
+	content := r.Content(model.MaxDetail)
 
 	ctx.JSON(http.StatusOK, content)
 }
@@ -221,8 +221,8 @@ func (r *Cluster) Link(p *api.Provider) {
 
 //
 // As content.
-func (r *Cluster) Content(detail bool) interface{} {
-	if !detail {
+func (r *Cluster) Content(detail int) interface{} {
+	if detail == 0 {
 		return r.Resource
 	}
 

--- a/pkg/controller/provider/web/vsphere/datacenter.go
+++ b/pkg/controller/provider/web/vsphere/datacenter.go
@@ -106,7 +106,7 @@ func (h DatacenterHandler) Get(ctx *gin.Context) {
 	r.With(m)
 	r.Link(h.Provider)
 	r.Path = pb.Path(m)
-	content := r.Content(true)
+	content := r.Content(model.MaxDetail)
 
 	ctx.JSON(http.StatusOK, content)
 }
@@ -171,8 +171,8 @@ func (r *Datacenter) Link(p *api.Provider) {
 
 //
 // As content.
-func (r *Datacenter) Content(detail bool) interface{} {
-	if !detail {
+func (r *Datacenter) Content(detail int) interface{} {
+	if detail == 0 {
 		return r.Resource
 	}
 

--- a/pkg/controller/provider/web/vsphere/datastore.go
+++ b/pkg/controller/provider/web/vsphere/datastore.go
@@ -114,7 +114,7 @@ func (h DatastoreHandler) Get(ctx *gin.Context) {
 	r.With(m)
 	r.Link(h.Provider)
 	r.Path = pb.Path(m)
-	content := r.Content(true)
+	content := r.Content(model.MaxDetail)
 
 	ctx.JSON(http.StatusOK, content)
 }
@@ -209,8 +209,8 @@ func (r *Datastore) Link(p *api.Provider) {
 
 //
 // As content.
-func (r *Datastore) Content(detail bool) interface{} {
-	if !detail {
+func (r *Datastore) Content(detail int) interface{} {
+	if detail == 0 {
 		return r.Resource
 	}
 

--- a/pkg/controller/provider/web/vsphere/folder.go
+++ b/pkg/controller/provider/web/vsphere/folder.go
@@ -106,7 +106,7 @@ func (h FolderHandler) Get(ctx *gin.Context) {
 	r.With(m)
 	r.Link(h.Provider)
 	r.Path = pb.Path(m)
-	content := r.Content(true)
+	content := r.Content(model.MaxDetail)
 
 	ctx.JSON(http.StatusOK, content)
 }
@@ -169,8 +169,8 @@ func (r *Folder) Link(p *api.Provider) {
 
 //
 // Content.
-func (r *Folder) Content(detail bool) interface{} {
-	if !detail {
+func (r *Folder) Content(detail int) interface{} {
+	if detail == 0 {
 		return r.Resource
 	}
 

--- a/pkg/controller/provider/web/vsphere/host.go
+++ b/pkg/controller/provider/web/vsphere/host.go
@@ -95,7 +95,7 @@ func (h HostHandler) Get(ctx *gin.Context) {
 		ctx.Status(status)
 		return
 	}
-	h.Detail = true
+	h.Detail = model.MaxDetail
 	m := &model.Host{
 		Base: model.Base{
 			ID: ctx.Param(HostParam),
@@ -129,7 +129,7 @@ func (h HostHandler) Get(ctx *gin.Context) {
 	}
 	r.Link(h.Provider)
 	r.Path = pb.Path(m)
-	content := r.Content(true)
+	content := r.Content(h.Detail)
 
 	ctx.JSON(http.StatusOK, content)
 }
@@ -194,7 +194,7 @@ func (h *HostHandler) filter(ctx *gin.Context, list *[]model.Host) (err error) {
 //
 // Build the network adapters.
 func (h *HostHandler) buildAdapters(host *Host) (err error) {
-	if !h.Detail {
+	if h.Detail == 0 {
 		return
 	}
 	builder := AdapterBuilder{
@@ -260,8 +260,8 @@ func (r *Host) Link(p *api.Provider) {
 
 //
 // As content.
-func (r *Host) Content(detail bool) interface{} {
-	if !detail {
+func (r *Host) Content(detail int) interface{} {
+	if detail == 0 {
 		return r.Resource
 	}
 

--- a/pkg/controller/provider/web/vsphere/network.go
+++ b/pkg/controller/provider/web/vsphere/network.go
@@ -114,7 +114,7 @@ func (h NetworkHandler) Get(ctx *gin.Context) {
 	r.With(m)
 	r.Link(h.Provider)
 	r.Path = pb.Path(m)
-	content := r.Content(true)
+	content := r.Content(model.MaxDetail)
 
 	ctx.JSON(http.StatusOK, content)
 }
@@ -214,8 +214,8 @@ func (r *Network) Link(p *api.Provider) {
 
 //
 // As content.
-func (r *Network) Content(detail bool) interface{} {
-	if !detail {
+func (r *Network) Content(detail int) interface{} {
+	if detail == 0 {
 		return r.Resource
 	}
 

--- a/pkg/controller/provider/web/vsphere/provider.go
+++ b/pkg/controller/provider/web/vsphere/provider.go
@@ -69,7 +69,7 @@ func (h ProviderHandler) Get(ctx *gin.Context) {
 		ctx.Status(http.StatusNotFound)
 		return
 	}
-	h.Detail = true
+	h.Detail = model.MaxDetail
 	m := &model.Provider{}
 	m.With(h.Provider)
 	r := Provider{}
@@ -84,7 +84,7 @@ func (h ProviderHandler) Get(ctx *gin.Context) {
 		return
 	}
 	r.Link()
-	content := r.Content(true)
+	content := r.Content(h.Detail)
 
 	ctx.JSON(http.StatusOK, content)
 }
@@ -131,7 +131,7 @@ func (h *ProviderHandler) ListContent(ctx *gin.Context) (content []interface{}, 
 // Add derived fields.
 func (h ProviderHandler) AddDerived(r *Provider) (err error) {
 	var n int64
-	if !h.Detail {
+	if h.Detail == 0 {
 		return
 	}
 	db := h.Collector.DB()
@@ -219,8 +219,8 @@ func (r *Provider) Link() {
 
 //
 // As content.
-func (r *Provider) Content(detail bool) interface{} {
-	if !detail {
+func (r *Provider) Content(detail int) interface{} {
+	if detail == 0 {
 		return r.Resource
 	}
 

--- a/pkg/controller/provider/web/vsphere/tree.go
+++ b/pkg/controller/provider/web/vsphere/tree.go
@@ -110,7 +110,7 @@ func (h TreeHandler) VmTree(ctx *gin.Context) {
 			NodeBuilder: &NodeBuilder{
 				provider:    h.Provider,
 				pathBuilder: pb,
-				detail: map[string]bool{
+				detail: map[string]int{
 					model.VmKind: h.Detail,
 				},
 			},
@@ -176,7 +176,7 @@ func (h TreeHandler) HostTree(ctx *gin.Context) {
 			NodeBuilder: &NodeBuilder{
 				provider:    h.Provider,
 				pathBuilder: pb,
-				detail: map[string]bool{
+				detail: map[string]int{
 					model.VmKind: h.Detail,
 				},
 			},
@@ -213,7 +213,7 @@ type HostNavigator struct {
 	// DB.
 	db libmodel.DB
 	// VM detail.
-	detail bool
+	detail int
 }
 
 //
@@ -276,8 +276,8 @@ func (n *HostNavigator) Next(p libmodel.Model) (r []libmodel.Model, err error) {
 		}
 	case *model.Host:
 		detail := 0
-		if n.detail {
-			detail = 1
+		if n.detail > 0 {
+			detail = model.MaxDetail
 		}
 		list := []model.VM{}
 		err = n.db.List(
@@ -305,7 +305,7 @@ type VMNavigator struct {
 	// DB.
 	db libmodel.DB
 	// VM detail.
-	detail bool
+	detail int
 }
 
 //
@@ -338,8 +338,8 @@ func (n *VMNavigator) Next(p libmodel.Model) (r []libmodel.Model, err error) {
 		}
 		// VM
 		detail := 0
-		if n.detail {
-			detail = 1
+		if n.detail > 0 {
+			detail = model.MaxDetail
 		}
 		vm := []model.VM{}
 		err = n.db.List(
@@ -367,7 +367,7 @@ type NodeBuilder struct {
 	// Provider.
 	provider *api.Provider
 	// Resource details by kind.
-	detail map[string]bool
+	detail map[string]int
 	// Path builder.
 	pathBuilder PathBuilder
 }
@@ -462,10 +462,10 @@ func (r *NodeBuilder) Node(parent *TreeNode, m libmodel.Model) *TreeNode {
 
 //
 // Build with detail.
-func (r *NodeBuilder) withDetail(kind string) bool {
+func (r *NodeBuilder) withDetail(kind string) int {
 	if b, found := r.detail[kind]; found {
 		return b
 	}
 
-	return false
+	return 0
 }


### PR DESCRIPTION
Slim-down API VM payloads.

Model the VM resource aggregated by detail level.
All of the endpoints will be refactored to apply the pattern but only the `VM` resources in the _oVirt_ and _vSphere_ packages will have any more than 2 levels (0, 1) of details to begin with.

Another change planned in the PR is to no longer call the (oVirt only) `Expand()` _composition_  methods on resources for Get() and List().  They result in (resource * N) DB queries. The composed (de-referenced) fields are only used by the `/workload` endpoint.

In the plan controller- the oVirt adapter, the Builder and Validator need to fetch and use the `Workload` instead of the `VM`.  The workload is an _expanded_ version of the VM which contains information needed to build the network and storage maps.