### PR TITLE
Add inventory fields needed for single VM import

### DIFF
--- a/pkg/controller/provider/container/ovirt/resource.go
+++ b/pkg/controller/provider/container/ovirt/resource.go
@@ -84,6 +84,7 @@ type Cluster struct {
 	KSM           struct {
 		Enabled string `json:"enabled"`
 	} `json:"ksm"`
+	BiosType string `json:"bios_type"`
 }
 
 //
@@ -94,6 +95,7 @@ func (r *Cluster) ApplyTo(m *model.Cluster) {
 	m.DataCenter = r.DataCenter.ID
 	m.HaReservation = r.bool(r.HaReservation)
 	m.KsmEnabled = r.bool(r.KSM.Enabled)
+	m.BiosType = r.BiosType
 }
 
 //
@@ -214,6 +216,7 @@ type VM struct {
 		Topology struct {
 			Sockets string `json:"sockets"`
 			Cores   string `json:"cores"`
+			Threads string `json:"threads"`
 		} `json:"topology"`
 	} `json:"cpu"`
 	CpuShares string `json:"cpu_shares"`
@@ -223,8 +226,11 @@ type VM struct {
 	Timezone struct {
 		Name string `json:"name"`
 	} `json:"time_zone"`
-	Status          string `json:"status"`
-	Stateless       string `json:"stateless"`
+	Status       string `json:"status"`
+	Stateless    string `json:"stateless"`
+	SerialNumber struct {
+		Value string `json:"value"`
+	} `json:"serial_number"`
 	PlacementPolicy struct {
 		Affinity string `json:"affinity"`
 	} `json:"placement_policy"`
@@ -332,6 +338,7 @@ func (r *VM) ApplyTo(m *model.VM) {
 	m.GuestName = r.Guest.Distribution + " " + r.Guest.Version.Full
 	m.CpuSockets = r.int16(r.CPU.Topology.Sockets)
 	m.CpuCores = r.int16(r.CPU.Topology.Cores)
+	m.CpuThreads = r.int16(r.CPU.Topology.Threads)
 	m.CpuShares = r.int16(r.CpuShares)
 	m.Memory = r.int64(r.Memory)
 	m.BIOS = r.BIOS.Type
@@ -341,6 +348,7 @@ func (r *VM) ApplyTo(m *model.VM) {
 	m.Timezone = r.Timezone.Name
 	m.Status = r.Status
 	m.Stateless = r.Stateless
+	m.SerialNumber = r.SerialNumber.Value
 	m.Display = r.Display.Type
 	m.HasIllegalImages = r.bool(r.HasIllegalImages)
 	m.BalloonedMemory = r.bool(r.MemoryPolicy.Ballooning)
@@ -575,6 +583,9 @@ type NICProfile struct {
 			Value string `json:"value"`
 		} `json:"custom_property"`
 	} `json:"custom_properties"`
+	PassThrough struct {
+		Mode string `json:"mode"`
+	} `json:"pass_through"`
 }
 
 //
@@ -585,6 +596,7 @@ func (r *NICProfile) ApplyTo(m *model.NICProfile) {
 	m.Network = r.Network.ID
 	m.NetworkFilter = r.NetworkFilter.ID
 	m.PortMirroring = r.bool(r.PortMirroring)
+	m.PassThrough = r.PassThrough.Mode == "enabled"
 	m.QoS = r.QoS.ID
 	r.addProperties(m)
 }

--- a/pkg/controller/provider/container/vsphere/model.go
+++ b/pkg/controller/provider/container/vsphere/model.go
@@ -650,6 +650,7 @@ func (v *VmAdapter) updateDisks(devArray *types.ArrayOfVirtualDevice) {
 			case *types.VirtualDiskFlatVer1BackingInfo:
 				backing := disk.Backing.(*types.VirtualDiskFlatVer1BackingInfo)
 				md := model.Disk{
+					Key:      disk.Key,
 					File:     backing.FileName,
 					Capacity: disk.CapacityInBytes,
 					Datastore: model.Ref{
@@ -661,6 +662,7 @@ func (v *VmAdapter) updateDisks(devArray *types.ArrayOfVirtualDevice) {
 			case *types.VirtualDiskFlatVer2BackingInfo:
 				backing := disk.Backing.(*types.VirtualDiskFlatVer2BackingInfo)
 				md := model.Disk{
+					Key:      disk.Key,
 					File:     backing.FileName,
 					Capacity: disk.CapacityInBytes,
 					Shared:   backing.Sharing != "sharingNone",
@@ -673,6 +675,7 @@ func (v *VmAdapter) updateDisks(devArray *types.ArrayOfVirtualDevice) {
 			case *types.VirtualDiskRawDiskMappingVer1BackingInfo:
 				backing := disk.Backing.(*types.VirtualDiskRawDiskMappingVer1BackingInfo)
 				md := model.Disk{
+					Key:      disk.Key,
 					File:     backing.FileName,
 					Capacity: disk.CapacityInBytes,
 					Shared:   backing.Sharing != "sharingNone",
@@ -686,6 +689,7 @@ func (v *VmAdapter) updateDisks(devArray *types.ArrayOfVirtualDevice) {
 			case *types.VirtualDiskRawDiskVer2BackingInfo:
 				backing := disk.Backing.(*types.VirtualDiskRawDiskVer2BackingInfo)
 				md := model.Disk{
+					Key:      disk.Key,
 					Capacity: disk.CapacityInBytes,
 					Shared:   backing.Sharing != "sharingNone",
 					RDM:      true,

--- a/pkg/controller/provider/model/ovirt/model.go
+++ b/pkg/controller/provider/model/ovirt/model.go
@@ -56,6 +56,7 @@ type Cluster struct {
 	DataCenter    string `sql:"d0,index(dataCenter)"`
 	HaReservation bool   `sql:""`
 	KsmEnabled    bool   `sql:""`
+	BiosType      string `sql:""`
 }
 
 type Network struct {
@@ -73,6 +74,7 @@ type NICProfile struct {
 	NetworkFilter string     `sql:""`
 	QoS           string     `sql:""`
 	Properties    []Property `sql:""`
+	PassThrough   bool       `sql:""`
 }
 
 type DiskProfile struct {
@@ -126,6 +128,7 @@ type VM struct {
 	GuestName                   string           `sql:""`
 	CpuSockets                  int16            `sql:""`
 	CpuCores                    int16            `sql:""`
+	CpuThreads                  int16            `sql:""`
 	CpuAffinity                 []CpuPinning     `sql:""`
 	CpuShares                   int16            `sql:""`
 	Memory                      int64            `sql:""`
@@ -141,6 +144,7 @@ type VM struct {
 	Timezone                    string           `sql:""`
 	Status                      string           `sql:""`
 	Stateless                   string           `sql:""`
+	SerialNumber                string           `sql:""`
 	HasIllegalImages            bool             `sql:""`
 	NumaNodeAffinity            []string         `sql:""`
 	LeaseStorageDomain          string           `sql:""`

--- a/pkg/controller/provider/model/vsphere/model.go
+++ b/pkg/controller/provider/model/vsphere/model.go
@@ -274,6 +274,7 @@ func (m *VM) Validated() bool {
 //
 // Virtual Disk.
 type Disk struct {
+	Key       int32  `json:"key"`
 	File      string `json:"file"`
 	Datastore Ref    `json:"datastore"`
 	Capacity  int64  `json:"capacity"`

--- a/pkg/controller/provider/web/ovirt/client.go
+++ b/pkg/controller/provider/web/ovirt/client.go
@@ -221,6 +221,38 @@ func (r *Finder) ByRef(resource interface{}, ref base.Ref) (err error) {
 			}
 			*resource.(*VM) = list[0]
 		}
+	case *Cluster:
+		id := ref.ID
+		if id != "" {
+			err = r.Get(resource, id)
+			return
+		}
+		name := ref.Name
+		if name != "" {
+			list := []Cluster{}
+			err = r.List(
+				&list,
+				base.Param{
+					Key:   DetailParam,
+					Value: "1",
+				},
+				base.Param{
+					Key:   NameParam,
+					Value: name,
+				})
+			if err != nil {
+				break
+			}
+			if len(list) == 0 {
+				err = liberr.Wrap(NotFoundError{Ref: ref})
+				break
+			}
+			if len(list) > 1 {
+				err = liberr.Wrap(RefNotUniqueError{Ref: ref})
+				break
+			}
+			*resource.(*Cluster) = list[0]
+		}
 	default:
 		err = liberr.Wrap(
 			ResourceNotResolvedError{

--- a/pkg/controller/provider/web/ovirt/cluster.go
+++ b/pkg/controller/provider/web/ovirt/cluster.go
@@ -185,6 +185,7 @@ type Cluster struct {
 	DataCenter    string `json:"dataCenter"`
 	HaReservation bool   `json:"haReservation"`
 	KsmEnabled    bool   `json:"ksmEnabled"`
+	BiosType      string `json:"biosType"`
 }
 
 //
@@ -194,6 +195,7 @@ func (r *Cluster) With(m *model.Cluster) {
 	r.DataCenter = m.DataCenter
 	r.HaReservation = m.HaReservation
 	r.KsmEnabled = m.KsmEnabled
+	r.BiosType = m.BiosType
 }
 
 //

--- a/pkg/controller/provider/web/ovirt/nicprofile.go
+++ b/pkg/controller/provider/web/ovirt/nicprofile.go
@@ -139,6 +139,7 @@ type NICProfile struct {
 	PortMirroring bool             `json:"portMirroring"`
 	QoS           string           `json:"qos"`
 	Properties    []model.Property `json:"properties"`
+	PassThrough   bool             `json:"passThrough"`
 }
 
 //
@@ -150,6 +151,7 @@ func (r *NICProfile) With(m *model.NICProfile) {
 	r.PortMirroring = m.PortMirroring
 	r.QoS = m.QoS
 	r.Properties = m.Properties
+	r.PassThrough = m.PassThrough
 }
 
 //

--- a/pkg/controller/provider/web/ovirt/vm.go
+++ b/pkg/controller/provider/web/ovirt/vm.go
@@ -217,6 +217,7 @@ type VM struct {
 	GuestName                   string           `json:"guestName"`
 	CpuSockets                  int16            `json:"cpuSockets"`
 	CpuCores                    int16            `json:"cpuCores"`
+	CpuThreads                  int16            `json:"cpuThreads"`
 	CpuShares                   int16            `json:"cpuShares"`
 	CpuAffinity                 []CpuPinning     `json:"cpuAffinity"`
 	Memory                      int64            `json:"memory"`
@@ -235,6 +236,7 @@ type VM struct {
 	Timezone                    string           `json:"timezone"`
 	Status                      string           `json:"status"`
 	Stateless                   string           `json:"stateless"`
+	SerialNumber                string           `json:"serialNumber"`
 	NICs                        []vNIC           `json:"nics"`
 	DiskAttachments             []DiskAttachment `json:"diskAttachments"`
 	HostDevices                 []HostDevice     `json:"hostDevices"`
@@ -277,6 +279,7 @@ func (r *VM) With(m *model.VM) {
 	r.GuestName = m.GuestName
 	r.CpuSockets = m.CpuSockets
 	r.CpuCores = m.CpuCores
+	r.CpuThreads = m.CpuThreads
 	r.CpuShares = m.CpuShares
 	r.CpuAffinity = m.CpuAffinity
 	r.Memory = m.Memory
@@ -295,6 +298,7 @@ func (r *VM) With(m *model.VM) {
 	r.Timezone = m.Timezone
 	r.Status = m.Status
 	r.Stateless = m.Stateless
+	r.SerialNumber = m.SerialNumber
 	r.HostDevices = m.HostDevices
 	r.CDROMs = m.CDROMs
 	r.WatchDogs = m.WatchDogs


### PR DESCRIPTION
Makes oVirt Cluster resolvable by ref. Also adds the following inventory fields that will be needed by the VM and DataVolume builders.

oVirt:
- Cluster: BiosType
- VM: CpuThreads, SerialNumber
- NICProfile: Passthrough

vSphere:
- Disk: Key