### PR TITLE
Cascading delete in oVirt model.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/gin-gonic/gin v1.7.2
 	github.com/go-logr/logr v0.3.0
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.1.0
-	github.com/konveyor/controller v0.6.1
+	github.com/konveyor/controller v0.7.0
 	github.com/onsi/gomega v1.10.3
 	github.com/ovirt/go-ovirt v4.3.4+incompatible
 	github.com/pkg/profile v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -703,6 +703,8 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxv
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konveyor/controller v0.6.1 h1:+hqgq5gCNMDw4ZVqUa4/FVb73HnzXwes313T1wVk/Gs=
 github.com/konveyor/controller v0.6.1/go.mod h1:j0DSNesS0XHmqOLcJEuwB+qIRkdJ3mSIEJFA2byC12c=
+github.com/konveyor/controller v0.7.0 h1:e/BjjzwNyfGdployoXUd7hwk6ly2+Vm4+PPGMPXsJAA=
+github.com/konveyor/controller v0.7.0/go.mod h1:U2h8HnX1MXoUlLA8ySP+PJClK9+aR38mxtqLGAvAprE=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=

--- a/pkg/controller/provider/model/base/model.go
+++ b/pkg/controller/provider/model/base/model.go
@@ -8,6 +8,10 @@ import (
 type Model = libmodel.Model
 type ListOptions = libmodel.ListOptions
 
+func init() {
+	libmodel.DefaultDetail = 1
+}
+
 const (
 	MaxDetail = libmodel.MaxDetail
 )

--- a/pkg/controller/provider/model/ovirt/model.go
+++ b/pkg/controller/provider/model/ovirt/model.go
@@ -53,7 +53,7 @@ type DataCenter struct {
 
 type Cluster struct {
 	Base
-	DataCenter    string `sql:"d0,index(dataCenter)"`
+	DataCenter    string `sql:"d0,fk(dataCenter +cascade)"`
 	HaReservation bool   `sql:""`
 	KsmEnabled    bool   `sql:""`
 	BiosType      string `sql:""`
@@ -61,7 +61,7 @@ type Cluster struct {
 
 type Network struct {
 	Base
-	DataCenter string   `sql:"d0,index(dataCenter)"`
+	DataCenter string   `sql:"d0,fk(dataCenter +cascade)"`
 	VLan       string   `sql:""`
 	Usages     []string `sql:""`
 	Profiles   []string `sql:""`
@@ -69,7 +69,7 @@ type Network struct {
 
 type NICProfile struct {
 	Base
-	Network       string     `sql:"d0,index(network)"`
+	Network       string     `sql:"d0,fk(network +cascade)"`
 	PortMirroring bool       `sql:""`
 	NetworkFilter string     `sql:""`
 	QoS           string     `sql:""`
@@ -79,13 +79,13 @@ type NICProfile struct {
 
 type DiskProfile struct {
 	Base
-	StorageDomain string `sql:"d0,index(storageDomain)"`
+	StorageDomain string `sql:"d0,fk(storageDomain +cascade)"`
 	QoS           string `sql:""`
 }
 
 type StorageDomain struct {
 	Base
-	DataCenter string `sql:"d0,index(dataCenter)"`
+	DataCenter string `sql:"d0,fk(dataCenter +cascade)"`
 	Type       string `sql:""`
 	Storage    struct {
 		Type string
@@ -96,7 +96,7 @@ type StorageDomain struct {
 
 type Host struct {
 	Base
-	Cluster            string              `sql:"d0,index(cluster)"`
+	Cluster            string              `sql:"d0,fk(cluster +cascade)"`
 	Status             string              `sql:""`
 	ProductName        string              `sql:""`
 	ProductVersion     string              `sql:""`
@@ -122,7 +122,7 @@ type HostNIC struct {
 
 type VM struct {
 	Base
-	Cluster                     string           `sql:"d0,index(cluster)"`
+	Cluster                     string           `sql:"d0,fk(cluster +cascade)"`
 	Host                        string           `sql:"d0,index(host)"`
 	RevisionValidated           int64            `sql:"d0,index(revisionValidated)" eq:"-"`
 	PolicyVersion               int              `sql:"d0,index(policyVersion)" eq:"-"`
@@ -224,7 +224,7 @@ type Disk struct {
 	Base
 	Shared          bool   `sql:""`
 	Profile         string `sql:"index(profile)"`
-	StorageDomain   string `sql:"index(storageDomain)"`
+	StorageDomain   string `sql:"fk(storageDomain +cascade)"`
 	Status          string `sql:""`
 	ActualSize      int64  `sql:""`
 	Backup          string `sql:""`


### PR DESCRIPTION
When high-level (containing) entities such as DataCenter, StorageDomain and cluster are deleted, there are side effects in that all of the entities contained (owned) are silently deleted.

As a result, we need to mirror this behavior using non-enforced foreign keys.  The `fk` in the sql tag will automatically create an index.

Note: This is really hard to test in the wild because I don't have access to a real RHV provider that I can delete things like DataCenter, StorageDomain, Cluster etc.  So, I monkey-patched in the debugger and simulated it.

- [x] This PR requires: https://github.com/konveyor/controller/pull/97