### PR TITLE
Add host.Status and new Host CR validation.

### DIFF
--- a/pkg/controller/provider/container/ovirt/resource.go
+++ b/pkg/controller/provider/container/ovirt/resource.go
@@ -150,6 +150,7 @@ func (r *Host) ApplyTo(m *model.Host) {
 	m.Name = r.Name
 	m.Description = r.Description
 	m.Cluster = r.Cluster.ID
+	m.Status = r.Status
 	m.ProductName = r.OS.Type
 	m.ProductVersion = r.OS.Version.Full
 	m.InMaintenance = r.Status == "maintenance"

--- a/pkg/controller/provider/container/vsphere/collector.go
+++ b/pkg/controller/provider/container/vsphere/collector.go
@@ -68,6 +68,7 @@ const (
 	fDrsVmCfg      = "configuration.drsVmConfig"
 	// Host
 	fVm             = "vm"
+	fOverallStatus  = "overallStatus"
 	fProductName    = "config.product.name"
 	fProductVersion = "config.product.version"
 	fVSwitch        = "config.network.vswitch"
@@ -638,6 +639,7 @@ func (r *Collector) propertySpec() []types.PropertySpec {
 			PathSet: []string{
 				fName,
 				fParent,
+				fOverallStatus,
 				fProductName,
 				fProductVersion,
 				fThumbprint,

--- a/pkg/controller/provider/container/vsphere/model.go
+++ b/pkg/controller/provider/container/vsphere/model.go
@@ -253,6 +253,10 @@ func (v *HostAdapter) Apply(u types.ObjectUpdate) {
 			switch p.Name {
 			case fParent:
 				v.model.Cluster = v.Ref(p.Val).ID
+			case fOverallStatus:
+				if s, cast := p.Val.(types.ManagedEntityStatus); cast {
+					v.model.Status = string(s)
+				}
 			case fInMaintMode:
 				if b, cast := p.Val.(bool); cast {
 					v.model.InMaintenanceMode = b

--- a/pkg/controller/provider/model/ovirt/model.go
+++ b/pkg/controller/provider/model/ovirt/model.go
@@ -97,6 +97,7 @@ type StorageDomain struct {
 type Host struct {
 	Base
 	Cluster            string              `sql:"d0,index(cluster)"`
+	Status             string              `sql:""`
 	ProductName        string              `sql:""`
 	ProductVersion     string              `sql:""`
 	InMaintenance      bool                `sql:""`

--- a/pkg/controller/provider/model/vsphere/model.go
+++ b/pkg/controller/provider/model/vsphere/model.go
@@ -131,6 +131,7 @@ type Cluster struct {
 type Host struct {
 	Base
 	Cluster            string      `sql:"d0,index(cluster)"`
+	Status             string      `sql:""`
 	InMaintenanceMode  bool        `sql:""`
 	ManagementServerIp string      `sql:""`
 	Thumbprint         string      `sql:""`

--- a/pkg/controller/provider/web/ovirt/host.go
+++ b/pkg/controller/provider/web/ovirt/host.go
@@ -182,6 +182,7 @@ func (h *HostHandler) filter(ctx *gin.Context, list *[]model.Host) (err error) {
 type Host struct {
 	Resource
 	Cluster            string              `json:"cluster"`
+	Status             string              `json:"status"`
 	ProductName        string              `json:"productName"`
 	ProductVersion     string              `json:"productVersion"`
 	InMaintenance      bool                `json:"inMaintenance"`
@@ -199,6 +200,7 @@ type hNIC = model.HostNIC
 func (r *Host) With(m *model.Host) {
 	r.Resource.With(&m.Base)
 	r.Cluster = m.Cluster
+	r.Status = m.Status
 	r.ProductName = m.ProductName
 	r.ProductVersion = m.ProductVersion
 	r.InMaintenance = m.InMaintenance

--- a/pkg/controller/provider/web/vsphere/host.go
+++ b/pkg/controller/provider/web/vsphere/host.go
@@ -211,6 +211,7 @@ func (h *HostHandler) buildAdapters(host *Host) (err error) {
 type Host struct {
 	Resource
 	Cluster            string            `json:"cluster"`
+	Status             string            `json:"status"`
 	InMaintenanceMode  bool              `json:"inMaintenance"`
 	ManagementServerIp string            `json:"managementServerIp"`
 	Thumbprint         string            `json:"thumbprint"`
@@ -230,6 +231,7 @@ type Host struct {
 func (r *Host) With(m *model.Host) {
 	r.Resource.With(&m.Base)
 	r.Cluster = m.Cluster
+	r.Status = m.Status
 	r.InMaintenanceMode = m.InMaintenanceMode
 	r.ManagementServerIp = m.ManagementServerIp
 	r.Thumbprint = m.Thumbprint


### PR DESCRIPTION
Ensure host.Status on both vSphere and RHV host resources in the REST API.
Add a new Host CR validation to report the when a Host CR references a _real_ host that does not have a "green" status.
Also, changed the `InMaintenance` condition to be _Critical_ instead of _Warn_ because if the _real_ host is in maintenance or does not have a green status, we don't want to connect through the host for migration.