### PR TITLE
Add support for single VM import to vSphere builder

### DIFF
--- a/pkg/controller/provider/container/vsphere/collector.go
+++ b/pkg/controller/provider/container/vsphere/collector.go
@@ -75,6 +75,7 @@ const (
 	fPortGroup      = "config.network.portgroup"
 	fPNIC           = "config.network.pnic"
 	fVNIC           = "config.network.vnic"
+	fTimezone       = "config.dateTimeInfo.timeZone.name"
 	fInMaintMode    = "summary.runtime.inMaintenanceMode"
 	fCpuSockets     = "summary.hardware.numCpuPkgs"
 	fCpuCores       = "summary.hardware.numCpuCores"
@@ -643,6 +644,7 @@ func (r *Collector) propertySpec() []types.PropertySpec {
 				fProductName,
 				fProductVersion,
 				fThumbprint,
+				fTimezone,
 				fMgtServerIp,
 				fInMaintMode,
 				fCpuSockets,

--- a/pkg/controller/provider/container/vsphere/model.go
+++ b/pkg/controller/provider/container/vsphere/model.go
@@ -269,6 +269,10 @@ func (v *HostAdapter) Apply(u types.ObjectUpdate) {
 				if s, cast := p.Val.(string); cast {
 					v.model.Thumbprint = s
 				}
+			case fTimezone:
+				if s, cast := p.Val.(string); cast {
+					v.model.Timezone = s
+				}
 			case fCpuSockets:
 				if b, cast := p.Val.(int16); cast {
 					v.model.CpuSockets = b

--- a/pkg/controller/provider/model/vsphere/model.go
+++ b/pkg/controller/provider/model/vsphere/model.go
@@ -135,6 +135,7 @@ type Host struct {
 	InMaintenanceMode  bool        `sql:""`
 	ManagementServerIp string      `sql:""`
 	Thumbprint         string      `sql:""`
+	Timezone           string      `sql:""`
 	CpuSockets         int16       `sql:""`
 	CpuCores           int16       `sql:""`
 	ProductName        string      `sql:""`

--- a/pkg/controller/provider/web/vsphere/host.go
+++ b/pkg/controller/provider/web/vsphere/host.go
@@ -215,6 +215,7 @@ type Host struct {
 	InMaintenanceMode  bool              `json:"inMaintenance"`
 	ManagementServerIp string            `json:"managementServerIp"`
 	Thumbprint         string            `json:"thumbprint"`
+	Timezone           string            `json:"timezone"`
 	CpuSockets         int16             `json:"cpuSockets"`
 	CpuCores           int16             `json:"cpuCores"`
 	ProductName        string            `json:"productName"`
@@ -235,6 +236,7 @@ func (r *Host) With(m *model.Host) {
 	r.InMaintenanceMode = m.InMaintenanceMode
 	r.ManagementServerIp = m.ManagementServerIp
 	r.Thumbprint = m.Thumbprint
+	r.Timezone = m.Timezone
 	r.CpuSockets = m.CpuSockets
 	r.CpuCores = m.CpuCores
 	r.ProductVersion = m.ProductVersion


### PR DESCRIPTION
As with the oVirt builder PR, obsolete methods are temporarily left in to satisfy interfaces until the refactor/reimplementation is complete.