### PR TITLE
Bug 1942651: vSphere: pass changeID instead of snapshot to CDI

### DIFF
--- a/pkg/controller/plan/adapter/base/doc.go
+++ b/pkg/controller/plan/adapter/base/doc.go
@@ -58,8 +58,10 @@ type Client interface {
 	PoweredOff(vmRef ref.Ref) (bool, error)
 	// Create a snapshot of the source VM.
 	CreateSnapshot(vmRef ref.Ref) (string, error)
-	// Remove a snapshot of the source VM.
-	RemoveSnapshot(vmRef ref.Ref, snapshot string, all bool) error
+	// Remove all warm migration snapshots.
+	RemoveSnapshots(vmRef ref.Ref, precopies []plan.Precopy) error
+	// Create a DataVolume checkpoint out of a pair of snapshot IDs.
+	CreateCheckpoint(vmRef ref.Ref, current, previous string) (checkpoint cdi.DataVolumeCheckpoint, err error)
 	// Close connections to the provider API.
 	Close()
 }

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -259,7 +259,7 @@ func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, _ *core.Config
 				dvSpec := cdi.DataVolumeSpec{
 					Source: cdi.DataVolumeSource{
 						VDDK: &cdi.DataVolumeSourceVDDK{
-							BackingFile: disk.File,
+							BackingFile: r.trimBackingFileName(disk.File),
 							UUID:        vm.UUID,
 							URL:         url,
 							SecretRef:   secret.Name,

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -476,7 +476,7 @@ func (r *KubeVirt) EnsureDataVolumes(vm *plan.VMStatus) (err error) {
 	return
 }
 
-func (r *KubeVirt) SetDataVolumeCheckpoint(vm *plan.VMStatus, final bool) (err error) {
+func (r *KubeVirt) SetDataVolumeCheckpoint(vm *plan.VMStatus, checkpoint cdi.DataVolumeCheckpoint, final bool) (err error) {
 	list := &cdi.DataVolumeList{}
 	err = r.Destination.Client.List(
 		context.TODO(),
@@ -493,11 +493,7 @@ func (r *KubeVirt) SetDataVolumeCheckpoint(vm *plan.VMStatus, final bool) (err e
 		if len(dv.Spec.Checkpoints) >= len(vm.Warm.Precopies) {
 			continue
 		}
-		n := len(vm.Warm.Precopies)
-		dv.Spec.Checkpoints = append(dv.Spec.Checkpoints, cdi.DataVolumeCheckpoint{
-			Current:  vm.Warm.Precopies[n-1].Snapshot,
-			Previous: vm.Warm.Precopies[n-2].Snapshot,
-		})
+		dv.Spec.Checkpoints = append(dv.Spec.Checkpoints, checkpoint)
 		dv.Spec.FinalCheckpoint = final
 		err = r.Destination.Client.Update(context.TODO(), &dv)
 		if err != nil {

--- a/pkg/settings/features.go
+++ b/pkg/settings/features.go
@@ -5,6 +5,7 @@ package settings
 const (
 	FeatureOvirtWarmMigration        = "FEATURE_OVIRT_WARM_MIGRATION"
 	FeatureRetainPrecopyImporterPods = "FEATURE_RETAIN_PRECOPY_IMPORTER_PODS"
+	FeatureVsphereIncrementalBackup  = "FEATURE_VSPHERE_INCREMENTAL_BACKUP"
 )
 
 //
@@ -15,6 +16,8 @@ type Features struct {
 	// Whether importer pods should be retained during warm migration.
 	// Workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2016290
 	RetainPrecopyImporterPods bool
+	// Whether to use changeID-based incremental backup workflow (with a version of CDI that supports it)
+	VsphereIncrementalBackup bool
 }
 
 //
@@ -22,5 +25,6 @@ type Features struct {
 func (r *Features) Load() (err error) {
 	r.OvirtWarmMigration = getEnvBool(FeatureOvirtWarmMigration, false)
 	r.RetainPrecopyImporterPods = getEnvBool(FeatureRetainPrecopyImporterPods, false)
+	r.VsphereIncrementalBackup = getEnvBool(FeatureVsphereIncrementalBackup, false)
 	return
 }


### PR DESCRIPTION
This adds support for the improved incremental backup process for VDDK in CDI, along with a feature gate to enable it. This feature allows vSphere snapshots to be cleaned up after each precopy, rather than having to wait to clean up at the end. In addition, this causes the snapshots to be removed when the plan is archived or a VM migration is canceled.