### PR TITLE
Archive plans

### DIFF
--- a/config/crds/forklift.konveyor.io_plans.yaml
+++ b/config/crds/forklift.konveyor.io_plans.yaml
@@ -47,6 +47,9 @@ spec:
           spec:
             description: PlanSpec defines the desired state of Plan.
             properties:
+              archived:
+                description: Whether this plan should be archived.
+                type: boolean
               description:
                 description: Description
                 type: string

--- a/config/forklift.konveyor.io_plans.yaml
+++ b/config/forklift.konveyor.io_plans.yaml
@@ -47,6 +47,9 @@ spec:
           spec:
             description: PlanSpec defines the desired state of Plan.
             properties:
+              archived:
+                description: Whether this plan should be archived.
+                type: boolean
               description:
                 description: Description
                 type: string

--- a/pkg/apis/forklift/v1beta1/plan.go
+++ b/pkg/apis/forklift/v1beta1/plan.go
@@ -42,6 +42,8 @@ type PlanSpec struct {
 	Warm bool `json:"warm,omitempty"`
 	// The network attachment definition that should be used for disk transfer.
 	TransferNetwork *core.ObjectReference `json:"transferNetwork,omitempty"`
+	// Whether this plan should be archived.
+	Archived bool `json:"archived,omitempty"`
 }
 
 //

--- a/pkg/controller/plan/adapter/base/doc.go
+++ b/pkg/controller/plan/adapter/base/doc.go
@@ -30,8 +30,6 @@ type Adapter interface {
 type Builder interface {
 	// Build secret.
 	Secret(vmRef ref.Ref, in, object *core.Secret) error
-	// Return whether DataVolume import requires a provider-specific configmap.
-	RequiresConfigMap() bool
 	// Build DataVolume config map.
 	ConfigMap(vmRef ref.Ref, secret *core.Secret, object *core.ConfigMap) error
 	// Build the Kubevirt VirtualMachine spec.

--- a/pkg/controller/plan/adapter/ovirt/builder.go
+++ b/pkg/controller/plan/adapter/ovirt/builder.go
@@ -53,12 +53,6 @@ type Builder struct {
 }
 
 //
-// oVirt DataVolume imports require a certificate configmap.
-func (r *Builder) RequiresConfigMap() bool {
-	return true
-}
-
-//
 // Create DataVolume certificate configmap.
 func (r *Builder) ConfigMap(_ ref.Ref, in *core.Secret, object *core.ConfigMap) (err error) {
 	object.BinaryData["ca.pem"] = in.Data["cacert"]

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -65,12 +65,6 @@ type Builder struct {
 }
 
 //
-// vSphere DataVolume imports do not require a configmap.
-func (r *Builder) RequiresConfigMap() bool {
-	return false
-}
-
-//
 // Create DataVolume certificate configmap.
 // No-op for vSphere.
 func (r *Builder) ConfigMap(_ ref.Ref, _ *core.Secret, _ *core.ConfigMap) (err error) {

--- a/pkg/controller/plan/controller.go
+++ b/pkg/controller/plan/controller.go
@@ -360,7 +360,6 @@ func (r *Reconciler) execute(plan *api.Plan) (reQ time.Duration, err error) {
 	if err != nil {
 		return
 	}
-
 	//
 	// Find pending migrations.
 	pending := []*api.Migration{}

--- a/pkg/controller/plan/controller.go
+++ b/pkg/controller/plan/controller.go
@@ -202,6 +202,7 @@ func (r Reconciler) Reconcile(request reconcile.Request) (result reconcile.Resul
 
 	// Don't reconcile if the plan is archived.
 	if plan.Spec.Archived && plan.Status.HasCondition(Archived) {
+		r.Log.Info("Aborting reconcile of archived plan.")
 		return
 	}
 

--- a/pkg/controller/plan/controller.go
+++ b/pkg/controller/plan/controller.go
@@ -264,15 +264,6 @@ func (r Reconciler) Reconcile(request reconcile.Request) (result reconcile.Resul
 // Makes a best-effort attempt to clean up lingering
 // plan resources.
 func (r *Reconciler) archive(plan *api.Plan) {
-	ctx, err := plancontext.New(r, plan, r.Log)
-	if err != nil {
-		r.Log.Error(err, "Couldn't construct plan context while archiving plan.")
-		return
-	}
-
-	runner := Migration{Context: ctx}
-	runner.Archive()
-
 	plan.Status.SetCondition(
 		libcnd.Condition{
 			Type:     Archived,
@@ -281,6 +272,15 @@ func (r *Reconciler) archive(plan *api.Plan) {
 			Reason:   UserRequested,
 			Message:  "The migration plan has been archived.",
 		})
+
+	ctx, err := plancontext.New(r, plan, r.Log)
+	if err != nil {
+		r.Log.Error(err, "Couldn't construct plan context while archiving plan.")
+		return
+	}
+
+	runner := Migration{Context: ctx}
+	runner.Archive()
 
 	r.Log.Info("Plan archived.")
 }

--- a/pkg/controller/plan/controller.go
+++ b/pkg/controller/plan/controller.go
@@ -215,10 +215,7 @@ func (r Reconciler) Reconcile(request reconcile.Request) (result reconcile.Resul
 
 	if plan.Spec.Archived {
 		// Archive the plan.
-		err = r.archive(plan)
-		if err != nil {
-			return
-		}
+		r.archive(plan)
 	} else {
 		// Validations.
 		err = r.validate(plan)
@@ -264,9 +261,12 @@ func (r Reconciler) Reconcile(request reconcile.Request) (result reconcile.Resul
 
 //
 // Archive the plan.
-func (r *Reconciler) archive(plan *api.Plan) (err error) {
+// Makes a best-effort attempt to clean up lingering
+// plan resources.
+func (r *Reconciler) archive(plan *api.Plan) {
 	ctx, err := plancontext.New(r, plan, r.Log)
 	if err != nil {
+		r.Log.Error(err, "Couldn't construct plan context while archiving plan.")
 		return
 	}
 
@@ -283,8 +283,6 @@ func (r *Reconciler) archive(plan *api.Plan) (err error) {
 		})
 
 	r.Log.Info("Plan archived.")
-
-	return
 }
 
 //

--- a/pkg/controller/plan/handler/ovirt/handler.go
+++ b/pkg/controller/plan/handler/ovirt/handler.go
@@ -91,7 +91,7 @@ func (r *Handler) changed(models ...*ovirt.VM) {
 	for i := range list.Items {
 		plan := &list.Items[i]
 		ref := plan.Spec.Provider.Source
-		if !r.MatchProvider(ref) {
+		if plan.Spec.Archived || !r.MatchProvider(ref) {
 			continue
 		}
 		referenced := false

--- a/pkg/controller/plan/handler/vsphere/handler.go
+++ b/pkg/controller/plan/handler/vsphere/handler.go
@@ -91,7 +91,7 @@ func (r *Handler) changed(models ...*vsphere.VM) {
 	for i := range list.Items {
 		plan := &list.Items[i]
 		ref := plan.Spec.Provider.Source
-		if !r.MatchProvider(ref) {
+		if plan.Spec.Archived || !r.MatchProvider(ref) {
 			continue
 		}
 		referenced := false


### PR DESCRIPTION
Add support for archiving plans.

* Resources are now left behind when a migration fails. These resources are cleaned up when the Plan is retried, or when the Plan is archived. (Resources from canceled VMs are not retained)
* Setting the `archived` flag on the Plan causes all remaining resources (failed VMs, conversion and importer pods, configmaps, secrets, etc) to be cleaned up and the plan to get an `Archived` condition.
* kubevirt.go `Delete` methods now delete all left over resources for a plan rather than just those from a specific migration.

Misc

* Remove obsolete `RequiresConfigMap()` from Builder interface.
