### PR TITLE
Fix warm migration finalization state transition

### DIFF
--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -546,7 +546,7 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 		}
 	case CopyingPaused:
 		if r.Migration.Spec.Cutover != nil && !r.Migration.Spec.Cutover.After(time.Now()) {
-			vm.Phase = CreateFinalSnapshot
+			vm.Phase = StorePowerState
 		} else if vm.Warm.NextPrecopyAt != nil && !vm.Warm.NextPrecopyAt.After(time.Now()) {
 			vm.Phase = CreateSnapshot
 		}


### PR DESCRIPTION
Needs to head to StorePowerState after copying rather than CreateFinalSnapshot.