### PR TITLE
Bug 2015940: Omit Migration label from List call when building the VM CR map

### DIFF
--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -86,12 +86,14 @@ func (r *KubeVirt) VirtualMachineMap() (mp VirtualMachineMap, err error) {
 // List VirtualMachine CRs.
 // Each VirtualMachine represents an imported kubevirt VM with associated DataVolumes.
 func (r *KubeVirt) ListVMs() ([]VirtualMachine, error) {
+	planLabels := r.planLabels()
+	delete(planLabels, kMigration)
 	vList := &cnv.VirtualMachineList{}
 	err := r.Destination.Client.List(
 		context.TODO(),
 		vList,
 		&client.ListOptions{
-			LabelSelector: labels.SelectorFromSet(r.planLabels()),
+			LabelSelector: labels.SelectorFromSet(planLabels),
 			Namespace:     r.Plan.Spec.TargetNamespace,
 		},
 	)


### PR DESCRIPTION
Removing the Migration label from the label selector in `ListVMs` allows the VM CR map to be built when there is not an active migration.