### PR TITLE
Bug 2021622: oVirt builder: fix null ptr bug in macConflicts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,10 @@ test: generate fmt vet manifests
 manager: generate fmt vet
 	go build -o bin/manager github.com/konveyor/forklift-controller/cmd/manager
 
+# Build manager binary with compiler optimizations disabled
+debug: generate fmt vet
+	go build -o bin/manager -gcflags=all="-N -l" github.com/konveyor/forklift-controller/cmd/manager
+
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run: generate fmt vet
 	export METRICS_PORT=8888;\

--- a/pkg/controller/plan/adapter/ovirt/builder.go
+++ b/pkg/controller/plan/adapter/ovirt/builder.go
@@ -9,6 +9,7 @@ import (
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/plan"
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/ref"
 	plancontext "github.com/konveyor/forklift-controller/pkg/controller/plan/context"
+	"github.com/konveyor/forklift-controller/pkg/controller/provider/web/base"
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/web/ocp"
 	model "github.com/konveyor/forklift-controller/pkg/controller/provider/web/ovirt"
 	core "k8s.io/api/core/v1"
@@ -114,7 +115,10 @@ type Builder struct {
 func (r *Builder) macConflicts(vm *model.Workload) (conflictingVMs []string, err error) {
 	if r.macConflictsMap == nil {
 		list := []ocp.VM{}
-		err = r.Destination.Inventory.List(&list)
+		err = r.Destination.Inventory.List(&list, base.Param{
+			Key:   base.DetailParam,
+			Value: "all",
+		})
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
The oVirt builder was not using the `detail=all` parameter when listing OCP VMs to build the mac conflict map, which was resulting in a null pointer issue due to the returned VMs not having their Object field populated. This fixes that issue by setting the correct detail level.

This change also adds a "debug" target to the Makefile to build the manager without optimizations so that the debugger works better.