### PR TITLE
Bug 2027336: VM validation event tuning and logging.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/gin-gonic/gin v1.7.2
 	github.com/go-logr/logr v0.3.0
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.1.0
-	github.com/konveyor/controller v0.6.0
+	github.com/konveyor/controller v0.6.1
 	github.com/onsi/gomega v1.10.3
 	github.com/pkg/profile v1.3.0
 	github.com/prometheus/client_golang v1.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -741,6 +741,8 @@ github.com/konveyor/controller v0.5.0 h1:PmAFidRzMwHmbt8ShA/yow60kap1JgZIAtRMdGm
 github.com/konveyor/controller v0.5.0/go.mod h1:j0DSNesS0XHmqOLcJEuwB+qIRkdJ3mSIEJFA2byC12c=
 github.com/konveyor/controller v0.6.0 h1:E6P/z64KYEBA9RjkY9xtscqPhBCsCEpTOdVK8Nao5IY=
 github.com/konveyor/controller v0.6.0/go.mod h1:j0DSNesS0XHmqOLcJEuwB+qIRkdJ3mSIEJFA2byC12c=
+github.com/konveyor/controller v0.6.1 h1:+hqgq5gCNMDw4ZVqUa4/FVb73HnzXwes313T1wVk/Gs=
+github.com/konveyor/controller v0.6.1/go.mod h1:j0DSNesS0XHmqOLcJEuwB+qIRkdJ3mSIEJFA2byC12c=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=

--- a/pkg/controller/provider/container/ovirt/watch.go
+++ b/pkg/controller/provider/container/ovirt/watch.go
@@ -34,10 +34,11 @@ import (
 	"time"
 )
 
-//
-// The (max) number of batched task results.
 const (
+        // The (max) number of batched task results.
 	MaxBatch = 1024
+	// Transaction label.
+￼	ValidationLabel = "VM-validated"
 )
 
 //
@@ -97,7 +98,7 @@ func (r *VMEventHandler) reset() {
 func (r *VMEventHandler) Started(uint64) {
 	r.log.Info("Started.")
 	r.taskResult = make(chan *policy.Task)
-	r.input = make(chan ReportedEvent)
+	r.input = make(chan ReportedEvent, 100)
 	r.context, r.cancel = context.WithCancel(context.Background())
 	go r.run()
 	go r.harvest()
@@ -130,6 +131,9 @@ func (r *VMEventHandler) Updated(event libmodel.Event) {
 	if r.canceled() {
 		return
 	}
+	if event.HasLabel(ValidationLabel) {
+￼		return
+￼	}
 	if vm, cast := event.Updated.(*model.VM); cast {
 		if !vm.Validated() {
 			if r.validate(vm) == nil {
@@ -320,7 +324,7 @@ func (r *VMEventHandler) validated(batch []*policy.Task) {
 		"VM (batch) completed.",
 		"count",
 		len(batch))
-	tx, err := r.DB.Begin()
+	tx, err := r.DB.Begin(ValidationLabel)
 	if err != nil {
 		r.log.Error(err, "Begin tx failed.")
 		return
@@ -352,7 +356,7 @@ func (r *VMEventHandler) validated(batch []*policy.Task) {
 			r.log.Error(err, "VM update failed.")
 			continue
 		}
-		r.log.V(4).Info(
+		r.log.V(3).Info(
 			"VM validated.",
 			"vmID",
 			latest.ID,

--- a/pkg/controller/provider/container/vsphere/watch.go
+++ b/pkg/controller/provider/container/vsphere/watch.go
@@ -34,10 +34,11 @@ import (
 	"time"
 )
 
-//
-// The (max) number of batched task results.
 const (
+        // The (max) number of batched task results.
 	MaxBatch = 1024
+	// Transaction label.
+￼	ValidationLabel = "VM-validated"
 )
 
 //
@@ -97,7 +98,7 @@ func (r *VMEventHandler) reset() {
 func (r *VMEventHandler) Started(uint64) {
 	r.log.Info("Started.")
 	r.taskResult = make(chan *policy.Task)
-	r.input = make(chan ReportedEvent)
+	r.input = make(chan ReportedEvent, 100)
 	r.context, r.cancel = context.WithCancel(context.Background())
 	go r.run()
 	go r.harvest()
@@ -130,6 +131,9 @@ func (r *VMEventHandler) Updated(event libmodel.Event) {
 	if r.canceled() {
 		return
 	}
+	if event.HasLabel(ValidationLabel) {
+￼		return
+￼	}
 	if vm, cast := event.Updated.(*model.VM); cast {
 		if !vm.Validated() {
 			if r.validate(vm) == nil {
@@ -320,7 +324,7 @@ func (r *VMEventHandler) validated(batch []*policy.Task) {
 		"VM (batch) completed.",
 		"count",
 		len(batch))
-	tx, err := r.DB.Begin()
+	tx, err := r.DB.Begin(ValidationLabel)
 	if err != nil {
 		r.log.Error(err, "Begin tx failed.")
 		return
@@ -352,7 +356,7 @@ func (r *VMEventHandler) validated(batch []*policy.Task) {
 			r.log.Error(err, "VM update failed.")
 			continue
 		}
-		r.log.V(4).Info(
+		r.log.V(3).Info(
 			"VM validated.",
 			"vmID",
 			latest.ID,


### PR DESCRIPTION
Using _transaction labels_ introduced in controller/v0.6.1, **ignore** _echo_ events generated when VMs are updated after they are validated.  Also, use buffered _input_ channel to add some _"slack"_.  Both prevent the VM model event handler from getting blocked on the first event during initial validation on provider startup.  For very large vCenter providers (node-5), I have seen watch queue overflow log entries:

"full queue, event discarded."

Log the "VM validated" at level: 3 which matches the default logging level when deployed by the operator.

Signed-off-by: Fabien Dupont <fabiendupont@pm.me>