### PR TITLE
Bug 2024554: SEGV (nil) client pointer passed to methods.WaitForUpdatesEx().

### DIFF
--- a/pkg/controller/provider/container/vsphere/collector.go
+++ b/pkg/controller/provider/container/vsphere/collector.go
@@ -389,7 +389,6 @@ func (r *Collector) getUpdates(ctx context.Context) error {
 			tx.End()
 		}
 	}()
-next:
 	for {
 		response, err := methods.WaitForUpdatesEx(ctx, r.client, &req)
 		if err != nil {
@@ -401,16 +400,7 @@ next:
 		}
 		updateSet := response.Returnval
 		if updateSet == nil {
-			err := r.connect(ctx)
-			if err != nil {
-				r.log.Error(
-					err,
-					"failed to connect.",
-					"url",
-					r.url)
-				time.Sleep(RetryDelay)
-			}
-			continue next
+			continue
 		}
 		req.Version = updateSet.Version
 		tx, err = r.db.Begin()


### PR DESCRIPTION
Fix (nil) client pointer passed to WaitForUpdatesEx().
The updateSet returned by WaitForUpdatesEx() can be nil when on TCP connection timeout.  Retry instead of reconnect in this part of the code.  If there is a connection issue, the subsequent WaitForUpdatesEx()  will error.  The SEGV was because the error returned by connect() was only logged with resulted in r.client being used when nil.