### PR TITLE
Fix OpenShift VM template processing

### DIFF
--- a/pkg/controller/plan/adapter/ovirt/builder.go
+++ b/pkg/controller/plan/adapter/ovirt/builder.go
@@ -245,7 +245,9 @@ func (r *Builder) VirtualMachine(vmRef ref.Ref, object *cnv.VirtualMachineSpec, 
 		return
 	}
 
-	object.Template = &cnv.VirtualMachineInstanceTemplateSpec{}
+	if object.Template == nil {
+		object.Template = &cnv.VirtualMachineInstanceTemplateSpec{}
+	}
 	r.mapDisks(vm, dataVolumes, object)
 	r.mapFirmware(vm, &vm.Cluster, object)
 	r.mapCPU(vm, object)
@@ -382,6 +384,9 @@ func (r *Builder) mapFirmware(vm *model.Workload, cluster *model.Cluster, object
 }
 
 func (r *Builder) mapDisks(vm *model.Workload, dataVolumes []cdi.DataVolume, object *cnv.VirtualMachineSpec) {
+	var kVolumes []cnv.Volume
+	var kDisks []cnv.Disk
+
 	dvMap := make(map[string]*cdi.DataVolume)
 	for i := range dataVolumes {
 		dv := &dataVolumes[i]
@@ -416,9 +421,11 @@ func (r *Builder) mapDisks(vm *model.Workload, dataVolumes []cdi.DataVolume, obj
 				},
 			},
 		}
-		object.Template.Spec.Volumes = append(object.Template.Spec.Volumes, volume)
-		object.Template.Spec.Domain.Devices.Disks = append(object.Template.Spec.Domain.Devices.Disks, disk)
+		kVolumes = append(kVolumes, volume)
+		kDisks = append(kDisks, disk)
 	}
+	object.Template.Spec.Volumes = kVolumes
+	object.Template.Spec.Domain.Devices.Disks = kDisks
 }
 
 //

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -328,7 +328,9 @@ func (r *Builder) VirtualMachine(vmRef ref.Ref, object *cnv.VirtualMachineSpec, 
 		return
 	}
 
-	object.Template = &cnv.VirtualMachineInstanceTemplateSpec{}
+	if object.Template == nil {
+		object.Template = &cnv.VirtualMachineInstanceTemplateSpec{}
+	}
 	r.mapDisks(vm, dataVolumes, object)
 	r.mapFirmware(vm, object)
 	r.mapCPU(vm, object)
@@ -455,6 +457,9 @@ func (r *Builder) mapFirmware(vm *model.VM, object *cnv.VirtualMachineSpec) {
 }
 
 func (r *Builder) mapDisks(vm *model.VM, dataVolumes []cdi.DataVolume, object *cnv.VirtualMachineSpec) {
+	var kVolumes []cnv.Volume
+	var kDisks []cnv.Disk
+
 	disks := vm.Disks
 	sort.Slice(disks, func(i, j int) bool {
 		return disks[i].Key < disks[j].Key
@@ -484,9 +489,11 @@ func (r *Builder) mapDisks(vm *model.VM, dataVolumes []cdi.DataVolume, object *c
 				},
 			},
 		}
-		object.Template.Spec.Volumes = append(object.Template.Spec.Volumes, volume)
-		object.Template.Spec.Domain.Devices.Disks = append(object.Template.Spec.Domain.Devices.Disks, kubevirtDisk)
+		kVolumes = append(kVolumes, volume)
+		kDisks = append(kDisks, kubevirtDisk)
 	}
+	object.Template.Spec.Volumes = kVolumes
+	object.Template.Spec.Domain.Devices.Disks = kDisks
 }
 
 //

--- a/pkg/controller/provider/container/vsphere/model.go
+++ b/pkg/controller/provider/container/vsphere/model.go
@@ -596,7 +596,13 @@ func (v *VmAdapter) Apply(u types.ObjectUpdate) {
 				}
 			case fGuestID:
 				if s, cast := p.Val.(string); cast {
-					v.model.GuestID = s
+					// When the VM isn't powered on, the guest tools don't report
+					// the guest id. Only set the guest id if it's being reported,
+					// so that the stored value isn't erased when the VM
+					// is powered down.
+					if s != "" {
+						v.model.GuestID = s
+					}
 				}
 			case fBalloonedMemory:
 				if n, cast := p.Val.(int32); cast {


### PR DESCRIPTION
* Don't overwrite the template spec if it exists.
* Do overwrite existing disks and volumes.
* Cause vSphere GuestID not to be wiped out
  of inventory when the VM is powered off.