### PR TITLE
Bug 2036208: Fix handling of multiple nics attached to same network

### DIFF
--- a/pkg/controller/plan/adapter/base/doc.go
+++ b/pkg/controller/plan/adapter/base/doc.go
@@ -78,4 +78,6 @@ type Validator interface {
 	MaintenanceMode(vmRef ref.Ref) (bool, error)
 	// Validate whether warm migration is supported from this provider type.
 	WarmMigration() bool
+	// Validate that no more than one of a VM's networks is mapped to the pod network.
+	PodNetwork(vmRef ref.Ref) (bool, error)
 }

--- a/pkg/controller/plan/adapter/ovirt/validator.go
+++ b/pkg/controller/plan/adapter/ovirt/validator.go
@@ -57,6 +57,45 @@ func (r *Validator) NetworksMapped(vmRef ref.Ref) (ok bool, err error) {
 }
 
 //
+// Validate that no more than one of a VM's networks is mapped to the pod network.
+func (r *Validator) PodNetwork(vmRef ref.Ref) (ok bool, err error) {
+	if r.plan.Referenced.Map.Network == nil {
+		return
+	}
+	vm := &model.Workload{}
+	err = r.inventory.Find(vm, vmRef)
+	if err != nil {
+		err = liberr.Wrap(
+			err,
+			"VM not found in inventory.",
+			"vm",
+			vmRef.String())
+		return
+	}
+
+	mapping := r.plan.Referenced.Map.Network.Spec.Map
+	podMapped := 0
+	for i := range mapping {
+		mapped := &mapping[i]
+		ref := mapped.Source
+		network := &model.Network{}
+		fErr := r.inventory.Find(network, ref)
+		if fErr != nil {
+			err = fErr
+			return
+		}
+		for _, nic := range vm.NICs {
+			if nic.Profile.Network == network.ID && mapped.Destination.Type == Pod {
+				podMapped++
+			}
+		}
+	}
+
+	ok = podMapped <= 1
+	return
+}
+
+//
 // Validate that a VM's disk backing storage has been mapped.
 func (r *Validator) StorageMapped(vmRef ref.Ref) (ok bool, err error) {
 	if r.plan.Referenced.Map.Storage == nil {


### PR DESCRIPTION
* Adds a validation to ensure that no more than one
  nic is mapped to the pod network at a time.
* Create kubevirt nics for all source nics attached
  to the same network.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2036208