### PR TITLE
Fix Ansible Hook runner

### DIFF
--- a/pkg/controller/plan/hook.go
+++ b/pkg/controller/plan/hook.go
@@ -216,10 +216,10 @@ func (r *HookRunner) template(mp *core.ConfigMap) (template *core.PodTemplateSpe
 		container.Command = []string{
 			"/bin/entrypoint",
 			"ansible-runner",
-			"-p",
-			"/tmp/hook/playbook.yml",
 			"run",
 			"/tmp/runner",
+			"-p",
+			"/tmp/hook/playbook.yml",
 		}
 	}
 


### PR DESCRIPTION
Pre/Post migration hooks failed with wrong command arguments, updating job command arguments to make ansible runner working.

Works on my cluster now (preHook step passes in Forklift UI) and job pod log looks OK.

Before
```
...
ansible-runner: error: argument command: invalid choice: '/tmp/hook/playbook.yml' (choose from 'run', 'start', 'stop', 'is-alive', 'transmit', 'worker', 'process')
```

After
```
...
TASK [debug] *******************************************************************
ok: [localhost] => {
    "msg": "testttt"
}

PLAY RECAP *********************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2053003