### PR TITLE
[BACKPORT] Fix Ansible Hook runner

### DIFF
--- a/pkg/controller/plan/hook.go
+++ b/pkg/controller/plan/hook.go
@@ -216,10 +216,10 @@ func (r *HookRunner) template(mp *core.ConfigMap) (template *core.PodTemplateSpe
 		container.Command = []string{
 			"/bin/entrypoint",
 			"ansible-runner",
-			"-p",
-			"/tmp/hook/playbook.yml",
 			"run",
 			"/tmp/runner",
+			"-p",
+			"/tmp/hook/playbook.yml",
 		}
 	}
 


### PR DESCRIPTION
2.3 backport of https://github.com/konveyor/forklift-controller/pull/416

Pre/Post migration hooks failed with wrong command arguments with updated ansible runner, updating job
command arguments to make ansible runner working.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2053003