### PR TITLE
Make sure snapshot disk ID matches target disk ID.

### DIFF
--- a/pkg/controller/plan/adapter/ovirt/client.go
+++ b/pkg/controller/plan/adapter/ovirt/client.go
@@ -253,6 +253,14 @@ func (r *Client) getDiskSnapshot(diskID, targetSnapshotID string) (diskSnapshotI
 			if !ok {
 				continue
 			}
+			snapshotDisk, ok := diskSnapshot.Disk()
+			if !ok {
+				continue
+			}
+			snapshotDiskID, ok := snapshotDisk.Id()
+			if !ok {
+				continue
+			}
 			snapshot, ok := diskSnapshot.Snapshot()
 			if !ok {
 				continue
@@ -261,7 +269,7 @@ func (r *Client) getDiskSnapshot(diskID, targetSnapshotID string) (diskSnapshotI
 			if !ok {
 				continue
 			}
-			if targetSnapshotID == sid {
+			if snapshotDiskID == diskID && targetSnapshotID == sid {
 				diskSnapshotID = id
 				return
 			}


### PR DESCRIPTION
Fix a bug with multi-disk RHV warm imports, where every datavolume would be given the same disk snapshot ID for different disks (CDI has the same bug and accepts the import).

Found while investigating [RHBZ#2055201](https://bugzilla.redhat.com/show_bug.cgi?id=2055201), but not actually a complete fix.