### PR TITLE
Disable hook jobs restarts and keep their pods

### DIFF
--- a/pkg/controller/plan/hook.go
+++ b/pkg/controller/plan/hook.go
@@ -149,7 +149,7 @@ func (r *HookRunner) ensureJob() (job *batch.Job, err error) {
 // Build the Job.
 func (r *HookRunner) job(mp *core.ConfigMap) (job *batch.Job, err error) {
 	template := r.template(mp)
-	backOff := int32(0)
+	backOff := int32(1)
 	job = &batch.Job{
 		Spec: batch.JobSpec{
 			Template:     *template,

--- a/pkg/controller/plan/hook.go
+++ b/pkg/controller/plan/hook.go
@@ -149,8 +149,12 @@ func (r *HookRunner) ensureJob() (job *batch.Job, err error) {
 // Build the Job.
 func (r *HookRunner) job(mp *core.ConfigMap) (job *batch.Job, err error) {
 	template := r.template(mp)
+	backOff := int32(0)
 	job = &batch.Job{
-		Spec: batch.JobSpec{Template: *template},
+		Spec: batch.JobSpec{
+			Template:     *template,
+			BackoffLimit: &backOff,
+		},
 		ObjectMeta: meta.ObjectMeta{
 			Namespace: r.Plan.Namespace,
 			GenerateName: strings.ToLower(
@@ -176,7 +180,7 @@ func (r *HookRunner) job(mp *core.ConfigMap) (job *batch.Job, err error) {
 func (r *HookRunner) template(mp *core.ConfigMap) (template *core.PodTemplateSpec) {
 	template = &core.PodTemplateSpec{
 		Spec: core.PodSpec{
-			RestartPolicy: "OnFailure",
+			RestartPolicy: core.RestartPolicyNever,
 			Containers: []core.Container{
 				{
 					Name:  "hook",


### PR DESCRIPTION
Pods created by Hook jobs should be persisted in order to allow access to their logs.

Disabling job pods restart and backofflimit.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2059333

## Notes

The backofflimit = 0 doesn't create any new pod when the initial one has failed (if there was e.g. 2, the initial one and two other pods were created in case of simulated failure).

### Example
```plan1h``` job restartPolicy=never, backOffLimit=2 -> 3 pods on failure
```plan1h2``` job restartPolicy=never, backOffLimit=0 -> 1 pod on success, 1 pod on failure -> should be OK

```
$ oc get jobs -n openshift-mtv 
NAME                                COMPLETIONS   DURATION   AGE
plan1h-vm-3696-prehook-ztrjh        0/1           49m        49m
plan1h2-vm-3696-posthook-ltj9m      0/1           16m        16m
plan1h2-vm-3696-prehook-54czd       1/1           7s         25m


$ oc get pods -n openshift-mtv 
NAME                                         READY   STATUS      RESTARTS      AGE
...
plan1h-vm-3696-prehook-ztrjh--1-6fqsm        0/1     Error       0             34m
plan1h-vm-3696-prehook-ztrjh--1-ksc72        0/1     Error       0             34m
plan1h-vm-3696-prehook-ztrjh--1-s7m8n        0/1     Error       0             34m
plan1h2-vm-3696-posthook-ltj9m--1-d5wwz      0/1     Error       0             63s
plan1h2-vm-3696-prehook-54czd--1-cr7bb       0/1     Completed   0             10m


```