### PR TITLE
[BACKPORT] Disable hook jobs restarts and keep their pods

### DIFF
--- a/pkg/controller/plan/hook.go
+++ b/pkg/controller/plan/hook.go
@@ -149,7 +149,7 @@ func (r *HookRunner) ensureJob() (job *batch.Job, err error) {
 // Build the Job.
 func (r *HookRunner) job(mp *core.ConfigMap) (job *batch.Job, err error) {
 	template := r.template(mp)
-	backOff := int32(0)
+	backOff := int32(1)
 	job = &batch.Job{
 		Spec: batch.JobSpec{
 			Template:     *template,

--- a/pkg/controller/plan/hook.go
+++ b/pkg/controller/plan/hook.go
@@ -149,8 +149,12 @@ func (r *HookRunner) ensureJob() (job *batch.Job, err error) {
 // Build the Job.
 func (r *HookRunner) job(mp *core.ConfigMap) (job *batch.Job, err error) {
 	template := r.template(mp)
+	backOff := int32(0)
 	job = &batch.Job{
-		Spec: batch.JobSpec{Template: *template},
+		Spec: batch.JobSpec{
+			Template:     *template,
+			BackoffLimit: &backOff,
+		},
 		ObjectMeta: meta.ObjectMeta{
 			Namespace: r.Plan.Namespace,
 			GenerateName: strings.ToLower(
@@ -176,7 +180,7 @@ func (r *HookRunner) job(mp *core.ConfigMap) (job *batch.Job, err error) {
 func (r *HookRunner) template(mp *core.ConfigMap) (template *core.PodTemplateSpec) {
 	template = &core.PodTemplateSpec{
 		Spec: core.PodSpec{
-			RestartPolicy: "OnFailure",
+			RestartPolicy: core.RestartPolicyNever,
 			Containers: []core.Container{
 				{
 					Name:  "hook",


### PR DESCRIPTION
2.3 backport of https://github.com/konveyor/forklift-controller/pull/419

Pods created by Hook jobs should be persisted in order to allow access to their logs.

Disabling job pods restart and setting backOffLimit to 1.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2059333