### PR TITLE
Default to retaining warm migration importer pods.

### DIFF
--- a/pkg/settings/features.go
+++ b/pkg/settings/features.go
@@ -24,7 +24,7 @@ type Features struct {
 // Load settings.
 func (r *Features) Load() (err error) {
 	r.OvirtWarmMigration = getEnvBool(FeatureOvirtWarmMigration, false)
-	r.RetainPrecopyImporterPods = getEnvBool(FeatureRetainPrecopyImporterPods, false)
+	r.RetainPrecopyImporterPods = getEnvBool(FeatureRetainPrecopyImporterPods, true)
 	r.VsphereIncrementalBackup = getEnvBool(FeatureVsphereIncrementalBackup, false)
 	return
 }


### PR DESCRIPTION
Change the FEATURE_RETAIN_PRECOPY_IMPORTER_PODS default to true, to preserve importer pods in a warm migration. This workaround should not be needed anymore now that the bug in CDI has been fixed.