### PR TITLE
Backport to release-v2.3.2: Default to retaining warm migration importer pods.

### DIFF
--- a/pkg/settings/features.go
+++ b/pkg/settings/features.go
@@ -24,7 +24,7 @@ type Features struct {
 // Load settings.
 func (r *Features) Load() (err error) {
 	r.OvirtWarmMigration = getEnvBool(FeatureOvirtWarmMigration, false)
-	r.RetainPrecopyImporterPods = getEnvBool(FeatureRetainPrecopyImporterPods, false)
+	r.RetainPrecopyImporterPods = getEnvBool(FeatureRetainPrecopyImporterPods, true)
 	r.VsphereIncrementalBackup = getEnvBool(FeatureVsphereIncrementalBackup, false)
 	return
 }


### PR DESCRIPTION
2.3.2 backport of #428

Fixes [BZ#2020304](https://bugzilla.redhat.com/show_bug.cgi?id=2020304)