### PR TITLE
NO ISSUE: Modifying Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,12 +68,7 @@ docker-push:
 controller-gen:
 ifeq (, $(shell which controller-gen))
 	@{ \
-	set -e ;\
-	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
-	cd $$CONTROLLER_GEN_TMP_DIR ;\
-	go mod init tmp ;\
-	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.5.0 ;\
-	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
+	go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.2 ;\
 	}
 CONTROLLER_GEN=$(GOBIN)/controller-gen
 else


### PR DESCRIPTION
Modifying Makefile, with current implementation for newer go version controller-gen is not being installed properly and the build failed, changing "go get" to "go install" and removing the temp dir since it's not required, the binary file is placed under $HOME/go/bin. 
Also changing controller-gen to a newer version (still support legacy features) and switching docker with podman.