### PR TITLE
[WIP] Enable minikube: Add ignore of empty Authorization

### DIFF
--- a/pkg/controller/provider/web/base/auth.go
+++ b/pkg/controller/provider/web/base/auth.go
@@ -47,7 +47,12 @@ func (r *Auth) Permit(ctx *gin.Context, p *api.Provider) (status int) {
 		r.cache = make(map[string]time.Time)
 	}
 	r.prune()
-	token := r.token(ctx)
+	header := ctx.GetHeader("Authorization")
+	if header == "" {
+		return
+	}
+
+	token := r.token(header)
 	if token == "" {
 		status = http.StatusUnauthorized
 		return
@@ -135,8 +140,7 @@ func (r *Auth) permit(token string, p *api.Provider) (allowed bool, err error) {
 
 //
 // Extract token.
-func (r *Auth) token(ctx *gin.Context) (token string) {
-	header := ctx.GetHeader("Authorization")
+func (r *Auth) token(header string) (token string) {
 	fields := strings.Fields(header)
 	if len(fields) == 2 && fields[0] == "Bearer" {
 		token = fields[1]

--- a/pkg/controller/provider/web/base/auth_test.go
+++ b/pkg/controller/provider/web/base/auth_test.go
@@ -96,7 +96,7 @@ func TestAuth(t *testing.T) {
 		},
 	}
 	// token.
-	g.Expect(auth.token(ctx)).To(gomega.Equal(token))
+	g.Expect(auth.token(ctx.GetHeader("Authorization"))).To(gomega.Equal(token))
 	// First call with no cached token.
 	status := auth.Permit(ctx, provider)
 	g.Expect(auth.cache[token]).ToNot(gomega.BeNil())


### PR DESCRIPTION
Related to the https://github.com/konveyor/forklift-ui/pull/969
The UI patch allows to disable the login but in the controller, it is still needed.
This patch allows the requests without `Authorization` as in minikube there is no oauth.