### PR TITLE
use access token with raw http client

### DIFF
--- a/pkg/controller/provider/container/ovirt/client.go
+++ b/pkg/controller/provider/container/ovirt/client.go
@@ -112,7 +112,17 @@ func (r *Client) connect() (err error) {
 
 	response := &ovirtTokenResponse{}
 	url.RawQuery = values.Encode()
-	client.Get(url.String(), response)
+	status, err := client.Get(url.String(), response)
+	if err != nil {
+		return
+	}
+
+	// Providing bad credentials when requesting the token results
+	// in 400, and not 401. So checking for != 200 instead
+	if status != http.StatusOK {
+		err = liberr.New("Request for token failed", "status", status)
+		return
+	}
 
 	// Set the access token we received
 	client.Header = http.Header{

--- a/pkg/controller/provider/container/ovirt/collector.go
+++ b/pkg/controller/provider/container/ovirt/collector.go
@@ -3,6 +3,12 @@ package ovirt
 import (
 	"context"
 	"fmt"
+	liburl "net/url"
+	libpath "path"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/go-logr/logr"
 	liberr "github.com/konveyor/controller/pkg/error"
 	libmodel "github.com/konveyor/controller/pkg/inventory/model"
@@ -12,11 +18,6 @@ import (
 	model "github.com/konveyor/forklift-controller/pkg/controller/provider/model/ovirt"
 	core "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
-	liburl "net/url"
-	libpath "path"
-	"strconv"
-	"strings"
-	"time"
 )
 
 //
@@ -26,6 +27,9 @@ const (
 	RetryInterval = 5 * time.Second
 	// Refresh interval.
 	RefreshInterval = 10 * time.Second
+
+	// Default timeout for the HTTP client
+	DefaultClientTimeout = 30 * time.Minute
 )
 
 //
@@ -69,10 +73,28 @@ func New(db libmodel.DB, provider *api.Provider, secret *core.Secret) (r *Collec
 		libpath.Join(
 			provider.GetNamespace(),
 			provider.GetName()))
+	clientLog := logging.WithName("client|ovirt").WithValues(
+		"provider",
+		libpath.Join(
+			provider.GetNamespace(),
+			provider.GetName()))
+
+	var err error
+	clientTimeout := DefaultClientTimeout
+	if timeout, ok := provider.Spec.Settings["ovirtClientTimeout"]; ok {
+		if clientTimeout, err = time.ParseDuration(timeout); err != nil {
+			log.Error(err, "Couldn't parse timeout, falling back to default")
+			clientTimeout = DefaultClientTimeout
+		}
+	}
+
 	r = &Collector{
 		client: &Client{
-			url:    provider.Spec.URL,
-			secret: secret,
+			url:           provider.Spec.URL,
+			secret:        secret,
+			log:           clientLog,
+			clientTimeout: clientTimeout,
+			created:       time.Now(),
 		},
 		provider: provider,
 		db:       db,


### PR DESCRIPTION
This would make the client usable with setups that have keycloak enabled, and is the standard way to access the API.

Since we cannot rely on the "exp" field return from oVirt, the current approach refreshes the client every 30 minutes (default session timeout) by requesting a new token or when the token is expired (in the event it doesn't use the default Long.MAX_VALUE).