### PR TITLE
Skip image conversion when importing from ovirt

### DIFF
--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -7,6 +7,7 @@ import (
 	libcnd "github.com/konveyor/controller/pkg/condition"
 	liberr "github.com/konveyor/controller/pkg/error"
 	libitr "github.com/konveyor/controller/pkg/itinerary"
+	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/plan"
 	"github.com/konveyor/forklift-controller/pkg/controller/plan/adapter"
 	plancontext "github.com/konveyor/forklift-controller/pkg/controller/plan/context"
@@ -90,8 +91,8 @@ var (
 			{Name: CreateVM},
 			{Name: ScheduleVM},
 			{Name: CopyDisks},
-			{Name: CreateGuestConversionPod},
-			{Name: ConvertGuest},
+			{Name: CreateGuestConversionPod, All: RequiresConversion},
+			{Name: ConvertGuest, All: RequiresConversion},
 			{Name: PostHook, All: HasPostHook},
 			{Name: Completed},
 		},
@@ -115,8 +116,8 @@ var (
 			{Name: CreateFinalSnapshot},
 			{Name: AddFinalCheckpoint},
 			{Name: Finalize},
-			{Name: CreateGuestConversionPod},
-			{Name: ConvertGuest},
+			{Name: CreateGuestConversionPod, All: RequiresConversion},
+			{Name: ConvertGuest, All: RequiresConversion},
 			{Name: PostHook, All: HasPostHook},
 			{Name: Completed},
 		},
@@ -1347,6 +1348,8 @@ func (r *Predicate) Evaluate(flag libitr.Flag) (allowed bool, err error) {
 		_, allowed = r.vm.FindHook(PreHook)
 	case HasPostHook:
 		_, allowed = r.vm.FindHook(PostHook)
+	case RequiresConversion:
+		allowed = r.context.Source.Provider.Type() == api.VSphere
 	}
 
 	return


### PR DESCRIPTION
When importing a VM from ovirt provider the images (disks) don't require
conversion to kubevirt. The virt-v2v pod and execution should be skipped
to save time and resources.