### PR TITLE
Do not consider powering off as down status for ovirt VM

### DIFF
--- a/pkg/controller/plan/adapter/ovirt/client.go
+++ b/pkg/controller/plan/adapter/ovirt/client.go
@@ -115,7 +115,7 @@ func (r *Client) PowerState(vmRef ref.Ref) (state string, err error) {
 	}
 	status, _ := vm.Status()
 	switch status {
-	case ovirtsdk.VMSTATUS_DOWN, ovirtsdk.VMSTATUS_POWERING_DOWN:
+	case ovirtsdk.VMSTATUS_DOWN:
 		state = powerOff
 	case ovirtsdk.VMSTATUS_UP, ovirtsdk.VMSTATUS_POWERING_UP:
 		state = powerOn


### PR DESCRIPTION
"powering_down" status for VMs blocks snapshot removal, so it is likely more correct to wait just for "down" status