### PR TITLE
Bug 2055201: Avoid starting importer before snapshots are ready to transfer.

### DIFF
--- a/pkg/controller/plan/adapter/base/doc.go
+++ b/pkg/controller/plan/adapter/base/doc.go
@@ -60,6 +60,8 @@ type Client interface {
 	CreateSnapshot(vmRef ref.Ref) (string, error)
 	// Remove all warm migration snapshots.
 	RemoveSnapshots(vmRef ref.Ref, precopies []planapi.Precopy) error
+	// Check if a snapshot is ready to transfer.
+	CheckSnapshotReady(vmRef ref.Ref, snapshot string) (bool, error)
 	// Set DataVolume checkpoints.
 	SetCheckpoints(vmRef ref.Ref, precopies []planapi.Precopy, datavolumes []cdi.DataVolume, final bool) (err error)
 	// Close connections to the provider API.

--- a/pkg/controller/plan/adapter/ovirt/client.go
+++ b/pkg/controller/plan/adapter/ovirt/client.go
@@ -95,22 +95,19 @@ func (r *Client) CheckSnapshotReady(vmRef ref.Ref, snapshot string) (ready bool,
 		err = liberr.Wrap(err)
 		return
 	}
-	if len(jobs) > 1 {
-		err = liberr.New("Multiple jobs found for correlation ID %s", correlationID)
-		return
-	} else if len(jobs) < 1 {
+	if len(jobs) < 1 {
 		err = liberr.New("No jobs found for correlation ID %", correlationID)
 		return
 	}
-	job := jobs[0]
-	switch job.MustStatus() {
-	case ovirtsdk.JOBSTATUS_FAILED, ovirtsdk.JOBSTATUS_ABORTED:
-		err = liberr.New("Snapshot creation failed! Correlation ID is %s", correlationID)
-		ready = false
-	case ovirtsdk.JOBSTATUS_STARTED, ovirtsdk.JOBSTATUS_UNKNOWN:
-		ready = false
-	case ovirtsdk.JOBSTATUS_FINISHED:
-		ready = true
+	ready = true
+	for _, job := range jobs {
+		switch job.MustStatus() {
+		case ovirtsdk.JOBSTATUS_FAILED, ovirtsdk.JOBSTATUS_ABORTED:
+			err = liberr.New("Snapshot creation failed! Correlation ID is %s", correlationID)
+			ready = false
+		case ovirtsdk.JOBSTATUS_STARTED, ovirtsdk.JOBSTATUS_UNKNOWN:
+			ready = false
+		}
 	}
 	return
 }

--- a/pkg/controller/plan/adapter/ovirt/client.go
+++ b/pkg/controller/plan/adapter/ovirt/client.go
@@ -91,6 +91,10 @@ func (r *Client) CheckSnapshotReady(vmRef ref.Ref, snapshot string) (ready bool,
 		return
 	}
 	jobs, err := r.getJobs(correlationID)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
 	if len(jobs) > 1 {
 		err = liberr.New("Multiple jobs found for correlation ID %s", correlationID)
 		return
@@ -278,6 +282,7 @@ func (r *Client) getJobs(correlationID string) (ovirtJob []*ovirtsdk.Job, err er
 	ovirtJobs, ok := jobResponse.Jobs()
 	if !ok {
 		err = liberr.New(fmt.Sprintf("Job %s source lookup failed", correlationID))
+		return
 	}
 	ovirtJob = ovirtJobs.Slice()
 	return

--- a/pkg/controller/plan/adapter/ovirt/client.go
+++ b/pkg/controller/plan/adapter/ovirt/client.go
@@ -1,6 +1,8 @@
 package ovirt
 
 import (
+	"crypto/md5"
+	"encoding/hex"
 	"fmt"
 
 	liberr "github.com/konveyor/controller/pkg/error"
@@ -36,6 +38,12 @@ type Client struct {
 func (r *Client) CreateSnapshot(vmRef ref.Ref) (snapshot string, err error) {
 	_, vmService, err := r.getVM(vmRef)
 	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	correlationID, err := r.getSnapshotCorrelationID(vmRef, nil)
+	if err != nil {
+		err = liberr.Wrap(err)
 		return
 	}
 	snapsService := vmService.SnapshotsService()
@@ -44,7 +52,7 @@ func (r *Client) CreateSnapshot(vmRef ref.Ref) (snapshot string, err error) {
 			Description(snapshotDesc).
 			PersistMemorystate(false).
 			MustBuild(),
-	).Query("correlation_id", r.Migration.Name).Send()
+	).Query("correlation_id", correlationID).Send()
 	if err != nil {
 		err = liberr.Wrap(err)
 		return
@@ -75,20 +83,29 @@ func (r *Client) RemoveSnapshots(vmRef ref.Ref, precopies []planapi.Precopy) (er
 }
 
 //
-// Check if a snapshot is ready to transfer, to avoid importer restarts
+// Check if a snapshot is ready to transfer, to avoid importer restarts.
 func (r *Client) CheckSnapshotReady(vmRef ref.Ref, snapshot string) (ready bool, err error) {
-	_, vmService, err := r.getVM(vmRef)
-	if err != nil {
-		return
-	}
-	snapsService := vmService.SnapshotsService()
-	snapService := snapsService.SnapshotService(snapshot)
-	snap, err := snapService.Get().Query("correlation_id", r.Migration.Name).Send()
+	correlationID, err := r.getSnapshotCorrelationID(vmRef, &snapshot)
 	if err != nil {
 		err = liberr.Wrap(err)
+		return
 	}
-	status := snap.MustSnapshot().MustSnapshotStatus()
-	if status == ovirtsdk.SNAPSHOTSTATUS_OK {
+	jobs, err := r.getJobs(correlationID)
+	if len(jobs) > 1 {
+		err = liberr.New("Multiple jobs found for correlation ID %s", correlationID)
+		return
+	} else if len(jobs) < 1 {
+		err = liberr.New("No jobs found for correlation ID %", correlationID)
+		return
+	}
+	job := jobs[0]
+	switch job.MustStatus() {
+	case ovirtsdk.JOBSTATUS_FAILED, ovirtsdk.JOBSTATUS_ABORTED:
+		err = liberr.New("Snapshot creation failed! Correlation ID is %s", correlationID)
+		ready = false
+	case ovirtsdk.JOBSTATUS_STARTED, ovirtsdk.JOBSTATUS_UNKNOWN:
+		ready = false
+	case ovirtsdk.JOBSTATUS_FINISHED:
 		ready = true
 	}
 	return
@@ -198,6 +215,72 @@ func (r *Client) Close() {
 		_ = r.connection.Close()
 		r.connection = nil
 	}
+}
+
+//
+// Derive a value from the plan name, the VM ID, and the index of the given
+// snapshot in the precopies list. This can be used as the correlation ID for
+// tracking the status of a snapshot creation command in the oVirt API. There
+// seems to be a limit on correlation ID lengths, so use the MD5 of this value
+// as the actual correlation ID. If there is no snapshot ID, assume the last
+// snapshot in the precopy list. This way, CreateSnapshot can set the
+// correlation ID without knowing the snapshot ID from the oVirt API, because
+// the snapshot ID hasn't been created yet.
+func (r *Client) getSnapshotCorrelationID(vmRef ref.Ref, snapshot *string) (correlationID string, err error) {
+	var vm *planapi.VMStatus
+	for _, vmstatus := range r.Migration.Status.VMs {
+		if vmstatus.ID == vmRef.ID {
+			vm = vmstatus
+			break
+		}
+	}
+	if vm == nil {
+		err = liberr.New("Could not find VM %s", vmRef.ID)
+		return
+	}
+	if vm.Warm == nil {
+		err = liberr.New("VM %s is not part of a warm migration plan", vmRef.ID)
+		return
+	}
+
+	precopyIndex := len(vm.Warm.Precopies)
+	if snapshot != nil {
+		var precopySnapshot *planapi.Precopy
+		for index, precopy := range vm.Warm.Precopies {
+			if *snapshot == precopy.Snapshot {
+				precopySnapshot = &precopy
+				precopyIndex = index
+				break
+			}
+		}
+		if precopySnapshot == nil {
+			err = liberr.New("Could not find snapshot %s in precopies list", *snapshot)
+			return
+		}
+	}
+
+	uniqueID := fmt.Sprintf("%s-%s-%d", r.Migration.Name, vmRef.ID, precopyIndex)
+	hashedID := md5.New()
+	hashedID.Write([]byte(uniqueID))
+	correlationID = hex.EncodeToString(hashedID.Sum(nil))
+	return
+}
+
+//
+// Find oVirt jobs with the given correlation ID.
+func (r *Client) getJobs(correlationID string) (ovirtJob []*ovirtsdk.Job, err error) {
+	jobService := r.connection.SystemService().JobsService().List()
+	jobResponse, err := jobService.Search(fmt.Sprintf("correlation_id=%s", correlationID)).Send()
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	ovirtJobs, ok := jobResponse.Jobs()
+	if !ok {
+		err = liberr.New(fmt.Sprintf("Job %s source lookup failed", correlationID))
+	}
+	ovirtJob = ovirtJobs.Slice()
+	return
 }
 
 //

--- a/pkg/controller/plan/adapter/vsphere/client.go
+++ b/pkg/controller/plan/adapter/vsphere/client.go
@@ -3,6 +3,8 @@ package vsphere
 import (
 	"context"
 	"fmt"
+	liburl "net/url"
+
 	liberr "github.com/konveyor/controller/pkg/error"
 	planapi "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/plan"
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/ref"
@@ -17,7 +19,6 @@ import (
 	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
 	cdi "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
-	liburl "net/url"
 )
 
 const (
@@ -59,6 +60,12 @@ func (r *Client) CreateSnapshot(vmRef ref.Ref) (id string, err error) {
 	id = res.Result.(types.ManagedObjectReference).Value
 
 	return
+}
+
+//
+// Check if a snapshot is ready to transfer.
+func (r *Client) CheckSnapshotReady(vmRef ref.Ref, snapshot string) (ready bool, err error) {
+	return true, nil
 }
 
 //


### PR DESCRIPTION
Bug [2055201](https://bugzilla.redhat.com/show_bug.cgi?id=2055201) shows frequent importer pod restarts for warm migrations from oVirt, and one of the reasons given by the oVirt API is "Cannot transfer Virtual Disk. Snapshot is currently being created for VM".

It should be easy enough to clean up these restarts by having the forklift controller wait for the snapshot to be marked ready, but I'm not sure if I have the right approach in this pull request? I have marked it a draft in case adding to the state machine isn't really the right thing to do, and because the VMware part isn't really filled out (although VMware doesn't seem to have the same problem).