### PR TITLE
Add KUBEVIRT_CLIENT_GO_SCHEME_REGISTRATION_VERSION=v1 to make run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ debug: generate fmt vet
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run: generate fmt vet
 	export METRICS_PORT=8888;\
-		go run ./cmd/manager/main.go
+		KUBEVIRT_CLIENT_GO_SCHEME_REGISTRATION_VERSION=v1 go run ./cmd/manager/main.go
 
 # Install CRDs into a cluster
 install: manifests


### PR DESCRIPTION
Issue: when running the controller locally it would throw this exception
```
multiple group-version-kinds associated with type *v1.VirtualMachineList, refusing to guess at one'","stacktrace":"\ngithub.com/konveyor/forklift-controller/pkg/controller/provider/container/ocp.(*VM).Reconcile()\n\t/home/mnecas/Desktop/Projects/Redhat/forklift/forklift-controller/pkg/controller/provider/container/ocp/collection.go:351\ngithub.com/konveyor/controller/pkg/inventory/container/ocp.(*Collector).reconcileCollections()\n\t/home/mnecas/go/pkg/mod/github.com/konveyor/controller@v0.10.0/pkg/inventory/container/ocp/collector.go:231\ngithub.com/konveyor/controller/pkg/inventory/container/ocp.(*Collector).start()\n\t/home/mnecas/go/pkg/mod/github.com/konveyor/controller@v0.10.0/pkg/inventory/container/ocp/collector.go:209\ngithub.com/konveyor/controller/pkg/inventory/container/ocp.(*Collector).Start.func1()\n\t/home/mnecas/go/pkg/mod/github.com/konveyor/controller@v0.10.0/pkg/inventory/container/ocp/collector.go:160\nruntime.goexit()\n\t/usr/lib/golang/src/runtime/asm_amd64.s:1571
```
FIx: Set KUBEVIRT_CLIENT_GO_SCHEME_REGISTRATION_VERSION=v1