### PR TITLE
VM mapping: Add dynamic nic interface

### DIFF
--- a/pkg/controller/plan/adapter/ovirt/builder.go
+++ b/pkg/controller/plan/adapter/ovirt/builder.go
@@ -298,7 +298,7 @@ func (r *Builder) mapNetworks(vm *model.Workload, object *cnv.VirtualMachineSpec
 			}
 			kInterface := cnv.Interface{
 				Name:       networkName,
-				Model:      Virtio,
+				Model:      nic.Interface,
 				MacAddress: nic.MAC,
 			}
 			switch mapped.Destination.Type {


### PR DESCRIPTION
Currently, when migrating the VM the network interface has always Virtio.
This patch uses the interface which was used in the provider.
https://kubevirt.io/user-guide/virtual_machines/interfaces_and_networks/