### PR TITLE
Support ovirt CPU Policy

### DIFF
--- a/pkg/controller/plan/adapter/ovirt/builder.go
+++ b/pkg/controller/plan/adapter/ovirt/builder.go
@@ -2,6 +2,9 @@ package ovirt
 
 import (
 	"fmt"
+	"path"
+	"strings"
+
 	liberr "github.com/konveyor/controller/pkg/error"
 	libitr "github.com/konveyor/controller/pkg/itinerary"
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/plan"
@@ -14,8 +17,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	cnv "kubevirt.io/client-go/api/v1"
 	cdi "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
-	"path"
-	"strings"
 )
 
 // BIOS types
@@ -56,6 +57,15 @@ const (
 	DefaultWindows = "win10"
 	DefaultLinux   = "rhel8.1"
 	Unknown        = "unknown"
+)
+
+// CPU Pinning Policies
+const (
+	None           = "none"
+	Manual         = "manual"
+	ResizeAndPin   = "resize_and_pin_numa"
+	Dedicated      = "dedicated"
+	IsolateThreads = "isolate_threads"
 )
 
 // Map of ovirt guest ids to osinfo ids.
@@ -358,6 +368,10 @@ func (r *Builder) mapCPU(vm *model.Workload, object *cnv.VirtualMachineSpec) {
 		Cores:   uint32(vm.CpuCores),
 		Threads: uint32(vm.CpuThreads),
 	}
+	if vm.CpuPinningPolicy == Dedicated {
+		object.Template.Spec.Domain.CPU.DedicatedCPUPlacement = true
+	}
+
 }
 
 func (r *Builder) mapFirmware(vm *model.Workload, cluster *model.Cluster, object *cnv.VirtualMachineSpec) {

--- a/pkg/controller/provider/container/ovirt/resource.go
+++ b/pkg/controller/provider/container/ovirt/resource.go
@@ -1,9 +1,10 @@
 package ovirt
 
 import (
-	model "github.com/konveyor/forklift-controller/pkg/controller/provider/model/ovirt"
 	"sort"
 	"strconv"
+
+	model "github.com/konveyor/forklift-controller/pkg/controller/provider/model/ovirt"
 )
 
 //
@@ -226,8 +227,9 @@ type VM struct {
 			Threads string `json:"threads"`
 		} `json:"topology"`
 	} `json:"cpu"`
-	CpuShares string `json:"cpu_shares"`
-	USB       struct {
+	CpuPinningPolicy string `json:"cpu_pinning_policy"`
+	CpuShares        string `json:"cpu_shares"`
+	USB              struct {
 		Enabled string `json:"enabled"`
 	} `json:"usb"`
 	Timezone struct {
@@ -352,6 +354,7 @@ func (r *VM) ApplyTo(m *model.VM) {
 	m.CpuSockets = r.int16(r.CPU.Topology.Sockets)
 	m.CpuCores = r.int16(r.CPU.Topology.Cores)
 	m.CpuThreads = r.int16(r.CPU.Topology.Threads)
+	m.CpuPinningPolicy = r.CpuPinningPolicy
 	m.CpuShares = r.int16(r.CpuShares)
 	m.Memory = r.int64(r.Memory)
 	m.BIOS = r.BIOS.Type

--- a/pkg/controller/provider/model/ovirt/model.go
+++ b/pkg/controller/provider/model/ovirt/model.go
@@ -131,6 +131,7 @@ type VM struct {
 	CpuCores                    int16            `sql:""`
 	CpuThreads                  int16            `sql:""`
 	CpuAffinity                 []CpuPinning     `sql:""`
+	CpuPinningPolicy            string           `sql:""`
 	CpuShares                   int16            `sql:""`
 	Memory                      int64            `sql:""`
 	BalloonedMemory             bool             `sql:""`

--- a/pkg/controller/provider/web/ovirt/vm.go
+++ b/pkg/controller/provider/web/ovirt/vm.go
@@ -2,13 +2,14 @@ package ovirt
 
 import (
 	"errors"
+	"net/http"
+	"strings"
+
 	"github.com/gin-gonic/gin"
 	libmodel "github.com/konveyor/controller/pkg/inventory/model"
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
 	model "github.com/konveyor/forklift-controller/pkg/controller/provider/model/ovirt"
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/web/base"
-	"net/http"
-	"strings"
 )
 
 //
@@ -228,6 +229,7 @@ type VM struct {
 	CpuThreads                  int16        `json:"cpuThreads"`
 	CpuShares                   int16        `json:"cpuShares"`
 	CpuAffinity                 []CpuPinning `json:"cpuAffinity"`
+	CpuPinningPolicy            string       `json:"cpuPinningPolicy"`
 	Memory                      int64        `json:"memory"`
 	BalloonedMemory             bool         `json:"balloonedMemory"`
 	IOThreads                   int16        `json:"ioThreads"`
@@ -276,6 +278,7 @@ func (r *VM) With(m *model.VM) {
 	r.CpuThreads = m.CpuThreads
 	r.CpuShares = m.CpuShares
 	r.CpuAffinity = m.CpuAffinity
+	r.CpuPinningPolicy = m.CpuPinningPolicy
 	r.Memory = m.Memory
 	r.BalloonedMemory = m.BalloonedMemory
 	r.IOThreads = m.IOThreads


### PR DESCRIPTION
When importing a VM from oVirt it has the property of CPU Pinning Policy.
Only having `none` or `dedicated` is supported on CNV. Therefore, only both
of them will be respected.
As for `dedicated` the user should enable the `CPU manager` on the nodes,
or else the VM won't be able to schedule and the migration will hang.
NUMA is out of the scope for this PR.
More about the feature at the [dedicated cpu resources page](https://kubevirt.io/user-guide/virtual_machines/dedicated_cpu_resources/).